### PR TITLE
Fix #1: Prevent double initialization of escrow contract

### DIFF
--- a/contracts/escrow/src/errors.rs
+++ b/contracts/escrow/src/errors.rs
@@ -9,4 +9,5 @@ pub enum Error {
     Unauthorized = 4,
     InvalidState = 5,
     AlreadyExists = 6,
+    AlreadyInitialized = 7,
 }

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -14,6 +14,9 @@ pub struct EscrowContract;
 impl EscrowContract {
     /// Initialize the contract with a trusted oracle address.
     pub fn initialize(env: Env, oracle: Address) {
+        if env.storage().instance().has(&DataKey::Oracle) {
+            panic!("Contract already initialized");
+        }
         env.storage().instance().set(&DataKey::Oracle, &oracle);
         env.storage().instance().set(&DataKey::MatchCount, &0u64);
     }
@@ -101,7 +104,9 @@ impl EscrowContract {
             m.state = MatchState::Active;
         }
 
-        env.storage().persistent().set(&DataKey::Match(match_id), &m);
+        env.storage()
+            .persistent()
+            .set(&DataKey::Match(match_id), &m);
         Ok(())
     }
 
@@ -131,21 +136,15 @@ impl EscrowContract {
             Winner::Player1 => client.transfer(&env.current_contract_address(), &m.player1, &pot),
             Winner::Player2 => client.transfer(&env.current_contract_address(), &m.player2, &pot),
             Winner::Draw => {
-                client.transfer(
-                    &env.current_contract_address(),
-                    &m.player1,
-                    &m.stake_amount,
-                );
-                client.transfer(
-                    &env.current_contract_address(),
-                    &m.player2,
-                    &m.stake_amount,
-                );
+                client.transfer(&env.current_contract_address(), &m.player1, &m.stake_amount);
+                client.transfer(&env.current_contract_address(), &m.player2, &m.stake_amount);
             }
         }
 
         m.state = MatchState::Completed;
-        env.storage().persistent().set(&DataKey::Match(match_id), &m);
+        env.storage()
+            .persistent()
+            .set(&DataKey::Match(match_id), &m);
         Ok(())
     }
 
@@ -167,22 +166,16 @@ impl EscrowContract {
         let client = token::Client::new(&env, &m.token);
 
         if m.player1_deposited {
-            client.transfer(
-                &env.current_contract_address(),
-                &m.player1,
-                &m.stake_amount,
-            );
+            client.transfer(&env.current_contract_address(), &m.player1, &m.stake_amount);
         }
         if m.player2_deposited {
-            client.transfer(
-                &env.current_contract_address(),
-                &m.player2,
-                &m.stake_amount,
-            );
+            client.transfer(&env.current_contract_address(), &m.player2, &m.stake_amount);
         }
 
         m.state = MatchState::Cancelled;
-        env.storage().persistent().set(&DataKey::Match(match_id), &m);
+        env.storage()
+            .persistent()
+            .set(&DataKey::Match(match_id), &m);
         Ok(())
     }
 

--- a/contracts/escrow/src/tests.rs
+++ b/contracts/escrow/src/tests.rs
@@ -137,3 +137,22 @@ fn test_cancel_refunds_deposit() {
     assert_eq!(token_client.balance(&player1), 1000);
     assert_eq!(client.get_match(&id).state, MatchState::Cancelled);
 }
+
+#[test]
+#[should_panic(expected = "Contract already initialized")]
+fn test_double_initialize_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let oracle1 = Address::generate(&env);
+    let oracle2 = Address::generate(&env);
+
+    let contract_id = env.register(EscrowContract, ());
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    // First initialization should succeed
+    client.initialize(&oracle1);
+
+    // Second initialization should panic
+    client.initialize(&oracle2);
+}

--- a/contracts/escrow/test_snapshots/tests/test_double_initialize_fails.1.json
+++ b/contracts/escrow/test_snapshots/tests/test_double_initialize_fails.1.json
@@ -1,0 +1,102 @@
+{
+  "generators": {
+    "address": 3,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "MatchCount"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u64": 0
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Oracle"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/contracts/oracle/src/lib.rs
+++ b/contracts/oracle/src/lib.rs
@@ -52,9 +52,7 @@ impl OracleContract {
 
     /// Check whether a result has been submitted for a match.
     pub fn has_result(env: Env, match_id: u64) -> bool {
-        env.storage()
-            .persistent()
-            .has(&DataKey::Result(match_id))
+        env.storage().persistent().has(&DataKey::Result(match_id))
     }
 }
 
@@ -95,16 +93,8 @@ mod tests {
         let (env, contract_id) = setup();
         let client = OracleContractClient::new(&env, &contract_id);
 
-        client.submit_result(
-            &0u64,
-            &String::from_str(&env, "abc123"),
-            &MatchResult::Draw,
-        );
+        client.submit_result(&0u64, &String::from_str(&env, "abc123"), &MatchResult::Draw);
         // second submit should panic
-        client.submit_result(
-            &0u64,
-            &String::from_str(&env, "abc123"),
-            &MatchResult::Draw,
-        );
+        client.submit_result(&0u64, &String::from_str(&env, "abc123"), &MatchResult::Draw);
     }
 }


### PR DESCRIPTION
## Description
This PR fixes issue #1 by adding a guard to prevent the `initialize()` function from being called multiple times, which would allow an attacker to overwrite the trusted oracle address.

## Changes
- Added initialization guard in `initialize()` to check if Oracle already exists
- Function now panics with clear error message if already initialized
- Added `test_double_initialize_fails` test to verify the protection
- Applied cargo fmt for consistent code formatting

## Testing
✅ All 6 escrow tests pass (including new double-initialize test)
✅ All 2 oracle tests pass
✅ Cargo clippy: no warnings
✅ Cargo fmt: properly formatted
✅ Release build for wasm32-unknown-unknown: successful

## Security Impact
This prevents a critical vulnerability where an attacker could call `initialize()` multiple times to substitute a malicious oracle address, potentially allowing them to manipulate match results and steal funds.

Closes #1