### PR TITLE
fix: guard MatchCount increment against u64 overflow (#9)

### DIFF
--- a/contracts/escrow/src/errors.rs
+++ b/contracts/escrow/src/errors.rs
@@ -10,4 +10,5 @@ pub enum Error {
     InvalidState = 5,
     AlreadyExists = 6,
     AlreadyInitialized = 7,
+    Overflow = 8,
 }

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -57,9 +57,11 @@ impl EscrowContract {
         };
 
         env.storage().persistent().set(&DataKey::Match(id), &m);
+        // Guard against u64 overflow in release mode where wrapping would occur silently
+        let next_id = id.checked_add(1).ok_or(Error::Overflow)?;
         env.storage()
             .instance()
-            .set(&DataKey::MatchCount, &(id + 1));
+            .set(&DataKey::MatchCount, &next_id);
 
         env.events().publish(
             (Symbol::new(&env, "match"), symbol_short!("created")),


### PR DESCRIPTION
## Changes
- Added \`Overflow = 8\` error variant to \`errors.rs\`
- Replaced \`id + 1\` with \`id.checked_add(1).ok_or(Error::Overflow)?\` in \`create_match\`
- Added comment documenting the overflow guard

## Testing
All 12 existing tests pass." --base main

closes #9 