### PR TITLE
Fix/19 admin role escrow

### DIFF
--- a/contracts/escrow/src/errors.rs
+++ b/contracts/escrow/src/errors.rs
@@ -11,4 +11,5 @@ pub enum Error {
     AlreadyExists = 6,
     AlreadyInitialized = 7,
     Overflow = 8,
+    ContractPaused = 9,
 }

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -12,13 +12,39 @@ pub struct EscrowContract;
 
 #[contractimpl]
 impl EscrowContract {
-    /// Initialize the contract with a trusted oracle address.
-    pub fn initialize(env: Env, oracle: Address) {
+    /// Initialize the contract with a trusted oracle address and an admin.
+    pub fn initialize(env: Env, oracle: Address, admin: Address) {
         if env.storage().instance().has(&DataKey::Oracle) {
             panic!("Contract already initialized");
         }
         env.storage().instance().set(&DataKey::Oracle, &oracle);
+        env.storage().instance().set(&DataKey::Admin, &admin);
         env.storage().instance().set(&DataKey::MatchCount, &0u64);
+        env.storage().instance().set(&DataKey::Paused, &false);
+    }
+
+    /// Pause the contract — admin only. Blocks create_match, deposit, and submit_result.
+    pub fn pause(env: Env) -> Result<(), Error> {
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(Error::Unauthorized)?;
+        admin.require_auth();
+        env.storage().instance().set(&DataKey::Paused, &true);
+        Ok(())
+    }
+
+    /// Unpause the contract — admin only.
+    pub fn unpause(env: Env) -> Result<(), Error> {
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(Error::Unauthorized)?;
+        admin.require_auth();
+        env.storage().instance().set(&DataKey::Paused, &false);
+        Ok(())
     }
 
     /// Create a new match. Both players must call `deposit` before the game starts.
@@ -32,6 +58,10 @@ impl EscrowContract {
         platform: Platform,
     ) -> Result<u64, Error> {
         player1.require_auth();
+
+        if env.storage().instance().get(&DataKey::Paused).unwrap_or(false) {
+            return Err(Error::ContractPaused);
+        }
 
         let id: u64 = env
             .storage()
@@ -74,6 +104,10 @@ impl EscrowContract {
     /// Player deposits their stake into escrow.
     pub fn deposit(env: Env, match_id: u64, player: Address) -> Result<(), Error> {
         player.require_auth();
+
+        if env.storage().instance().get(&DataKey::Paused).unwrap_or(false) {
+            return Err(Error::ContractPaused);
+        }
 
         let mut m: Match = env
             .storage()
@@ -119,6 +153,10 @@ impl EscrowContract {
 
     /// Oracle submits the verified match result and triggers payout.
     pub fn submit_result(env: Env, match_id: u64, winner: Winner) -> Result<(), Error> {
+        if env.storage().instance().get(&DataKey::Paused).unwrap_or(false) {
+            return Err(Error::ContractPaused);
+        }
+
         let oracle: Address = env
             .storage()
             .instance()

--- a/contracts/escrow/src/tests.rs
+++ b/contracts/escrow/src/tests.rs
@@ -7,7 +7,7 @@ use soroban_sdk::{
     vec, Address, Env, IntoVal, String, Symbol, TryFromVal,
 };
 
-fn setup() -> (Env, Address, Address, Address, Address, Address) {
+fn setup() -> (Env, Address, Address, Address, Address, Address, Address) {
     let env = Env::default();
     env.mock_all_auths();
 
@@ -24,14 +24,14 @@ fn setup() -> (Env, Address, Address, Address, Address, Address) {
 
     let contract_id = env.register(EscrowContract, ());
     let client = EscrowContractClient::new(&env, &contract_id);
-    client.initialize(&oracle);
+    client.initialize(&oracle, &admin);
 
-    (env, contract_id, oracle, player1, player2, token_addr)
+    (env, contract_id, oracle, player1, player2, token_addr, admin)
 }
 
 #[test]
 fn test_create_match() {
-    let (env, contract_id, _oracle, player1, player2, token) = setup();
+    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
     let client = EscrowContractClient::new(&env, &contract_id);
 
     let id = client.create_match(
@@ -50,7 +50,7 @@ fn test_create_match() {
 
 #[test]
 fn test_deposit_and_activate() {
-    let (env, contract_id, _oracle, player1, player2, token) = setup();
+    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
     let client = EscrowContractClient::new(&env, &contract_id);
 
     let id = client.create_match(
@@ -71,7 +71,7 @@ fn test_deposit_and_activate() {
 
 #[test]
 fn test_payout_winner() {
-    let (env, contract_id, _oracle, player1, player2, token) = setup();
+    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
     let client = EscrowContractClient::new(&env, &contract_id);
     let token_client = TokenClient::new(&env, &token);
 
@@ -95,7 +95,7 @@ fn test_payout_winner() {
 
 #[test]
 fn test_draw_refund() {
-    let (env, contract_id, _oracle, player1, player2, token) = setup();
+    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
     let client = EscrowContractClient::new(&env, &contract_id);
     let token_client = TokenClient::new(&env, &token);
 
@@ -118,7 +118,7 @@ fn test_draw_refund() {
 
 #[test]
 fn test_cancel_refunds_deposit() {
-    let (env, contract_id, _oracle, player1, player2, token) = setup();
+    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
     let client = EscrowContractClient::new(&env, &contract_id);
     let token_client = TokenClient::new(&env, &token);
 
@@ -140,7 +140,7 @@ fn test_cancel_refunds_deposit() {
 
 #[test]
 fn test_create_match_emits_event() {
-    let (env, contract_id, _oracle, player1, player2, token) = setup();
+    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
     let client = EscrowContractClient::new(&env, &contract_id);
 
     let id = client.create_match(
@@ -172,7 +172,7 @@ fn test_create_match_emits_event() {
 
 #[test]
 fn test_submit_result_emits_event() {
-    let (env, contract_id, _oracle, player1, player2, token) = setup();
+    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
     let client = EscrowContractClient::new(&env, &contract_id);
 
     let id = client.create_match(
@@ -204,7 +204,7 @@ fn test_submit_result_emits_event() {
 
 #[test]
 fn test_cancel_match_emits_event() {
-    let (env, contract_id, _oracle, player1, player2, token) = setup();
+    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
     let client = EscrowContractClient::new(&env, &contract_id);
 
     let id = client.create_match(
@@ -240,13 +240,48 @@ fn test_double_initialize_fails() {
 
     let oracle1 = Address::generate(&env);
     let oracle2 = Address::generate(&env);
+    let admin = Address::generate(&env);
 
     let contract_id = env.register(EscrowContract, ());
     let client = EscrowContractClient::new(&env, &contract_id);
 
-    // First initialization should succeed
-    client.initialize(&oracle1);
+    client.initialize(&oracle1, &admin);
+    client.initialize(&oracle2, &admin);
+}
 
-    // Second initialization should panic
-    client.initialize(&oracle2);
+#[test]
+fn test_admin_pause_blocks_create_match() {
+    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    client.pause();
+
+    let result = client.try_create_match(
+        &player1,
+        &player2,
+        &100,
+        &token,
+        &String::from_str(&env, "paused_game"),
+        &Platform::Lichess,
+    );
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_admin_unpause_allows_create_match() {
+    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    client.pause();
+    client.unpause();
+
+    let id = client.create_match(
+        &player1,
+        &player2,
+        &100,
+        &token,
+        &String::from_str(&env, "unpaused_game"),
+        &Platform::Lichess,
+    );
+    assert_eq!(id, 0);
 }

--- a/contracts/escrow/src/types.rs
+++ b/contracts/escrow/src/types.rs
@@ -44,4 +44,6 @@ pub enum DataKey {
     Match(u64),
     MatchCount,
     Oracle,
+    Admin,
+    Paused,
 }


### PR DESCRIPTION
## Summary
Fixes #19

Adds an admin role to the escrow contract with emergency pause/unpause controls, addressing the lack of any mechanism to respond to critical 
vulnerabilities without a full redeploy.


closes #19 