### PR TITLE
fix(escrow): emit events on pause and unpause (#84)

### DIFF
--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -35,6 +35,10 @@ impl EscrowContract {
             .ok_or(Error::Unauthorized)?;
         admin.require_auth();
         env.storage().instance().set(&DataKey::Paused, &true);
+        env.events().publish(
+            (Symbol::new(&env, "admin"), symbol_short!("paused")),
+            (),
+        );
         Ok(())
     }
 
@@ -47,6 +51,10 @@ impl EscrowContract {
             .ok_or(Error::Unauthorized)?;
         admin.require_auth();
         env.storage().instance().set(&DataKey::Paused, &false);
+        env.events().publish(
+            (Symbol::new(&env, "admin"), symbol_short!("unpaused")),
+            (),
+        );
         Ok(())
     }
 

--- a/contracts/escrow/src/tests.rs
+++ b/contracts/escrow/src/tests.rs
@@ -594,3 +594,42 @@ fn test_ttl_extended_on_cancel() {
     });
     assert_eq!(ttl, crate::MATCH_TTL_LEDGERS);
 }
+
+#[test]
+fn test_pause_emits_event() {
+    let (env, contract_id, _oracle, _player1, _player2, _token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    client.pause();
+
+    let events = env.events().all();
+    let expected_topics = vec![
+        &env,
+        Symbol::new(&env, "admin").into_val(&env),
+        soroban_sdk::symbol_short!("paused").into_val(&env),
+    ];
+    assert!(
+        events.iter().any(|(_, topics, _)| topics == expected_topics),
+        "paused event not emitted"
+    );
+}
+
+#[test]
+fn test_unpause_emits_event() {
+    let (env, contract_id, _oracle, _player1, _player2, _token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    client.pause();
+    client.unpause();
+
+    let events = env.events().all();
+    let expected_topics = vec![
+        &env,
+        Symbol::new(&env, "admin").into_val(&env),
+        soroban_sdk::symbol_short!("unpaused").into_val(&env),
+    ];
+    assert!(
+        events.iter().any(|(_, topics, _)| topics == expected_topics),
+        "unpaused event not emitted"
+    );
+}


### PR DESCRIPTION
## Problem
pause() and unpause() updated contract state silently — off-chain monitors had no way to detect pause state changes without polling storage.

## Changes
- pause() now emits ("admin", "paused") event
- unpause() now emits ("admin", "unpaused") event
- Added test_pause_emits_event and test_unpause_emits_event to assert both events fire correctly

## Testing
All 26 tests pass.

Closes #84
