### PR TITLE
test(escrow): add cancel_match on Completed match returns InvalidState

### DIFF
--- a/contracts/escrow/src/tests.rs
+++ b/contracts/escrow/src/tests.rs
@@ -836,6 +836,49 @@ fn test_cancel_only_player2_deposited_refunds_player2() {
     assert_eq!(client.get_match(&id).state, MatchState::Cancelled);
 }
 
+// ── cancel_match on a Completed match ────────────────────────────────────────
+
+/// Complete a match (create → deposit × 2 → submit_result), then attempt to
+/// cancel it. cancel_match checks `m.state != MatchState::Pending` and must
+/// return `InvalidState`. The match state and token balances must be unchanged.
+#[test]
+fn test_cancel_completed_match_returns_invalid_state() {
+    let (env, contract_id, oracle, player1, player2, token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+    let token_client = TokenClient::new(&env, &token);
+
+    let id = client.create_match(
+        &player1,
+        &player2,
+        &100,
+        &token,
+        &String::from_str(&env, "completed_cancel_game"),
+        &Platform::Lichess,
+    );
+
+    client.deposit(&id, &player1);
+    client.deposit(&id, &player2);
+    client.submit_result(&id, &Winner::Player1, &oracle);
+
+    // Sanity-check: match is now Completed and payout has happened
+    assert_eq!(client.get_match(&id).state, MatchState::Completed);
+    assert_eq!(token_client.balance(&player1), 1100);
+    assert_eq!(token_client.balance(&player2), 900);
+
+    // Attempting to cancel a Completed match must be rejected
+    let result = client.try_cancel_match(&id, &player1);
+    assert_eq!(
+        result,
+        Err(Ok(Error::InvalidState)),
+        "cancel_match on a Completed match must return InvalidState"
+    );
+
+    // State and balances must be untouched after the failed cancel
+    assert_eq!(client.get_match(&id).state, MatchState::Completed);
+    assert_eq!(token_client.balance(&player1), 1100);
+    assert_eq!(token_client.balance(&player2), 900);
+}
+
 // ── From main: pause / unpause emit events ───────────────────────────────────
 
 #[test]


### PR DESCRIPTION
closes #61 

cancel_match guards against non-Pending states but had no test covering
the Completed case specifically. This adds explicit coverage for that path.

- Complete a match via the full flow (create → deposit × 2 → submit_result)
- Assert state is Completed and payout balances are correct
- Call try_cancel_match and assert Err(InvalidState)
- Assert state and balances are unchanged after the failed cancel
