### PR TITLE
fix #67: document expected game_id format per platform

### DIFF
--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -11,6 +11,12 @@ use types::{DataKey, Match, MatchState, Platform, Winner};
 const MATCH_TTL_LEDGERS: u32 = 518_400;
 
 /// Maximum allowed byte length for a game_id string.
+///
+/// Platform-specific formats:
+/// - Lichess:      8 alphanumeric characters (e.g. `"abcd1234"`)
+/// - Chess.com:    numeric string, typically 7–12 digits (e.g. `"123456789"`)
+///
+/// Both formats fit well within this limit.
 const MAX_GAME_ID_LEN: u32 = 64;
 
 #[contract]
@@ -58,6 +64,21 @@ impl EscrowContract {
     }
 
     /// Create a new match. Both players must call `deposit` before the game starts.
+    ///
+    /// # Parameters
+    /// - `game_id`: The platform-specific game identifier. Must be ≤ 64 bytes.
+    ///   - **Lichess**: 8-character alphanumeric string (e.g. `"abcd1234"`).
+    ///     Taken from the game URL: `https://lichess.org/<game_id>`
+    ///   - **Chess.com**: numeric string, typically 7–12 digits (e.g. `"123456789"`).
+    ///     Taken from the game URL: `https://www.chess.com/game/live/<game_id>`
+    ///   Passing an ID from the wrong platform or a malformed ID will not be
+    ///   rejected on-chain, but the oracle will fail to verify the result.
+    /// - `platform`: Must match the platform the `game_id` was issued by.
+    ///   Use `Platform::Lichess` or `Platform::ChessDotCom` accordingly.
+    ///
+    /// # Errors
+    /// Returns `Error::InvalidGameId` if `game_id` exceeds `MAX_GAME_ID_LEN` (64 bytes).
+    /// Returns `Error::DuplicateGameId` if the same `game_id` has already been used.
     pub fn create_match(
         env: Env,
         player1: Address,

--- a/docs/oracle.md
+++ b/docs/oracle.md
@@ -1,0 +1,110 @@
+# Oracle Integration Guide
+
+This document describes how the off-chain oracle service interacts with the
+Checkmate Escrow smart contracts, with a focus on the `game_id` field.
+
+---
+
+## game_id Format
+
+The `game_id` field is a platform-specific string that uniquely identifies a
+chess game. It is supplied when creating a match and must be passed to the
+oracle when submitting a result. The oracle uses it to look up the game outcome
+via the platform's public API.
+
+### Lichess
+
+Lichess game IDs are **8-character alphanumeric strings** (case-sensitive,
+lowercase letters and digits).
+
+They appear in the game URL:
+
+```
+https://lichess.org/abcd1234
+                    ^^^^^^^^
+                    game_id = "abcd1234"
+```
+
+Example API call the oracle makes:
+
+```
+GET https://lichess.org/game/export/abcd1234
+```
+
+Valid example: `"abcd1234"`  
+Invalid examples: `"ABCD1234"` (uppercase), `"abcd123"` (7 chars), `""` (empty)
+
+### Chess.com
+
+Chess.com game IDs are **numeric strings**, typically 7–12 digits, found in
+the live game URL:
+
+```
+https://www.chess.com/game/live/123456789
+                                ^^^^^^^^^
+                                game_id = "123456789"
+```
+
+Example API call the oracle makes:
+
+```
+GET https://api.chess.com/pub/game/123456789
+```
+
+Valid example: `"123456789"`  
+Invalid examples: `"abc"` (non-numeric), `""` (empty)
+
+---
+
+## Validation Rules
+
+| Rule | Details |
+|------|---------|
+| Max length | 64 bytes (`MAX_GAME_ID_LEN`). Enforced on-chain — `create_match` returns `Error::InvalidGameId` if exceeded. |
+| Uniqueness | Each `game_id` can only be used once. A duplicate returns `Error::DuplicateGameId`. |
+| Format | Not validated on-chain. Passing a malformed ID will cause the oracle to fail result lookup off-chain. |
+| Platform match | The `platform` field must match the source of the `game_id`. Mismatches are not caught on-chain but will cause oracle verification to fail. |
+
+---
+
+## Submitting a Result
+
+Once a game is finished, the oracle calls `submit_result` on the escrow
+contract with the `match_id`, `game_id`, and `Winner` enum:
+
+```rust
+// Winner::Player1 | Winner::Player2 | Winner::Draw
+escrow_client.submit_result(&match_id, &winner, &oracle_address);
+```
+
+The oracle also records the result independently via `OracleContract::submit_result`:
+
+```rust
+oracle_client.submit_result(&match_id, &game_id, &MatchResult::Player1Wins);
+```
+
+---
+
+## Example: Full Match Lifecycle
+
+```
+1. player1 calls create_match(
+       player1, player2,
+       stake_amount = 100_000_000,
+       token = USDC_ADDRESS,
+       game_id = "abcd1234",       // Lichess game ID
+       platform = Platform::Lichess
+   )
+
+2. player1 calls deposit(match_id, player1)
+3. player2 calls deposit(match_id, player2)
+   → match state transitions to Active
+
+4. Game is played on Lichess.
+
+5. Oracle fetches result from https://lichess.org/game/export/abcd1234
+   → player1 wins
+
+6. Oracle calls escrow.submit_result(match_id, Winner::Player1, oracle_address)
+   → player1 receives 2 × stake_amount
+```


### PR DESCRIPTION

Closes #67

## What
- Added inline doc comments to `create_match` specifying the expected
  `game_id` format for Lichess (8-char alphanumeric) and Chess.com
  (numeric string), with URL extraction examples and a note on oracle
  verification behavior for malformed IDs.
- Expanded the `MAX_GAME_ID_LEN` constant comment with platform format
  examples so the limit is self-explanatory in context.
- Created `docs/oracle.md` — a full integration reference covering
  game_id formats, the on-chain validation rules (length + uniqueness),
  and an end-to-end match lifecycle example.

## Notes
The length check (`MAX_GAME_ID_LEN = 64`) was already enforced on-chain.
This PR adds the missing documentation so integrators know what to pass.
Format validation beyond length is intentionally left to the oracle
off-chain, since on-chain regex is not practical in Soroban.