### PR TITLE
feat: oracle.get_result on non-existent match_id should return Result…

### DIFF
--- a/contracts/oracle/src/lib.rs
+++ b/contracts/oracle/src/lib.rs
@@ -175,6 +175,15 @@ mod tests {
     }
 
     #[test]
+    fn test_get_result_non_existent_match_returns_not_found() {
+        let (env, contract_id) = setup();
+        let client = OracleContractClient::new(&env, &contract_id);
+
+        let result = client.try_get_result(&999u64);
+        assert!(matches!(result, Err(Ok(Error::ResultNotFound))));
+    }
+
+    #[test]
     fn test_ttl_extended_on_submit_result() {
         let (env, contract_id) = setup();
         let client = OracleContractClient::new(&env, &contract_id);


### PR DESCRIPTION
This PR introduces a new test case to validate the behavior of the oracle.get_result function when queried with a non-existent match_id. closes #28 