### PR TITLE
feat: added the get_match_count function to the Escrow contract

### DIFF
--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -434,6 +434,14 @@ impl EscrowContract {
             + if m.player2_deposited { 1 } else { 0 };
         Ok(depositors * m.stake_amount)
     }
+
+    /// Return the total number of matches created.
+    pub fn get_match_count(env: Env) -> u64 {
+        env.storage()
+            .instance()
+            .get(&DataKey::MatchCount)
+            .unwrap_or(0)
+    }
 }
 
 #[cfg(test)]

--- a/contracts/escrow/src/tests.rs
+++ b/contracts/escrow/src/tests.rs
@@ -55,6 +55,34 @@ fn test_create_match() {
 }
 
 #[test]
+fn test_get_match_count() {
+    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    assert_eq!(client.get_match_count(), 0);
+
+    client.create_match(
+        &player1,
+        &player2,
+        &100,
+        &token,
+        &String::from_str(&env, "game1"),
+        &Platform::Lichess,
+    );
+    assert_eq!(client.get_match_count(), 1);
+
+    client.create_match(
+        &player1,
+        &player2,
+        &200,
+        &token,
+        &String::from_str(&env, "game2"),
+        &Platform::ChessDotCom,
+    );
+    assert_eq!(client.get_match_count(), 2);
+}
+
+#[test]
 fn test_create_match_sets_created_ledger() {
     let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
     let client = EscrowContractClient::new(&env, &contract_id);


### PR DESCRIPTION
I have added the get_match_count function to the Escrow contract and added a corresponding test case in tests.rs. You can find the details in the walkthrough artifact.

Note: I encountered some issues running cargo test in the background environment, but the changes have been visually verified to follow the existing patterns in the codebase.
closes #150 