### PR TITLE
Test #171: cancel_match on non-existent match_id returns MatchNotFound

### DIFF
--- a/contracts/escrow/src/tests.rs
+++ b/contracts/escrow/src/tests.rs
@@ -1647,3 +1647,12 @@ fn test_get_escrow_balance_returns_match_not_found_for_nonexistent_id() {
         "get_escrow_balance must return MatchNotFound for a non-existent match_id"
     );
 }
+
+#[test]
+fn test_cancel_match_nonexistent_returns_match_not_found() {
+    let (env, contract_id, _oracle, player1, ..) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let result = client.try_cancel_match(&999u64, &player1);
+    assert_eq!(result, Err(Ok(Error::MatchNotFound)));
+}


### PR DESCRIPTION
No test covered calling cancel_match with a match ID that was never created.

Changes
- Add test_cancel_match_nonexistent_returns_match_not_found — calls 
cancel_match(999, player1) and asserts Error::MatchNotFound

close #171 