### PR TITLE
test: assert game_id field in test_submit_and_get_result (#149)

### DIFF
--- a/contracts/oracle/src/lib.rs
+++ b/contracts/oracle/src/lib.rs
@@ -286,6 +286,7 @@ mod tests {
         assert!(client.has_result(&0u64));
         let entry = client.get_result(&0u64);
         assert_eq!(entry.result, MatchResult::Player1Wins);
+        assert_eq!(entry.game_id, String::from_str(&env, "test_game"));
     }
 
     #[test]


### PR DESCRIPTION
### Problem

test_submit_and_get_result verified entry.result but never asserted entry.game_id, leaving 
the field untested despite being part of ResultEntry.

### Change

contracts/oracle/src/lib.rs
- Added one assertion to the existing test_submit_and_get_result test:
 rust
  assert_eq!(entry.game_id, String::from_str(&env, "test_game"));
  
 The game_id was already being submitted in the test — it just wasn't being verified on 
retrieval.

Closes #149