### PR TITLE
feat: Add Test: create_match with empty string game_id should be reje…

### DIFF
--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -101,7 +101,7 @@ impl EscrowContract {
         if stake_amount <= 0 {
             return Err(Error::InvalidAmount);
         }
-        if game_id.len() > MAX_GAME_ID_LEN {
+        if game_id.len() == 0 || game_id.len() > MAX_GAME_ID_LEN {
             return Err(Error::InvalidGameId);
         }
 

--- a/contracts/escrow/src/tests.rs
+++ b/contracts/escrow/src/tests.rs
@@ -1431,6 +1431,27 @@ fn test_create_match_with_oversized_game_id_fails() {
     );
 }
 
+#[test]
+fn test_create_match_with_empty_game_id_rejected() {
+    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let result = client.try_create_match(
+        &player1,
+        &player2,
+        &100,
+        &token,
+        &String::from_str(&env, ""),
+        &Platform::Lichess,
+    );
+
+    assert_eq!(
+        result,
+        Err(Ok(Error::InvalidGameId)),
+        "create_match must reject an empty game_id"
+    );
+}
+
 // ── deposit blocked when contract is paused ───────────────────────────────────
 
 #[test]


### PR DESCRIPTION
## Summary

Issue 1 — Oracle pause blocks submit_result

The oracle contract had no pause mechanism. Added pause()/unpause() admin functions, a ContractPaused error, and a pause check at the top of submit_result. Added a 
test that pauses the oracle and asserts submit_result returns Error::ContractPaused.

Issue 2 — Empty game_id rejected

create_match only validated that game_id wasn't too long, so "" slipped through silently. Added a == 0 check so empty strings are rejected with Error::InvalidGameId.
Added a test that calls create_match with "" and asserts that error.

closes #184 