### PR TITLE
fix(#191): guard cancel_match against contract address as caller

### DIFF
--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -395,6 +395,11 @@ impl EscrowContract {
             return Err(Error::InvalidState);
         }
 
+        // Defensive: the contract itself must never be accepted as a valid caller.
+        if caller == env.current_contract_address() {
+            return Err(Error::Unauthorized);
+        }
+
         // Either player1 or player2 can cancel a pending match
         let is_p1 = caller == m.player1;
         let is_p2 = caller == m.player2;

--- a/contracts/escrow/src/tests.rs
+++ b/contracts/escrow/src/tests.rs
@@ -2053,3 +2053,32 @@ fn test_create_match_with_invalid_token_returns_invalid_token() {
         "create_match must return InvalidToken for a non-token address"
     );
 }
+
+// ── #191: cancel_match rejects the contract address as caller ─────────────────
+
+/// Passing env.current_contract_address() as the caller to cancel_match must
+/// return Unauthorized — the contract itself is never a valid canceller.
+#[test]
+fn test_cancel_match_rejects_contract_as_caller() {
+    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let id = client.create_match(
+        &player1,
+        &player2,
+        &100,
+        &token,
+        &String::from_str(&env, "contract_caller_cancel"),
+        &Platform::Lichess,
+    );
+
+    let result = client.try_cancel_match(&id, &contract_id);
+    assert_eq!(
+        result,
+        Err(Ok(Error::Unauthorized)),
+        "cancel_match must reject the contract address as caller"
+    );
+
+    // Match must remain Pending — no state change from the rejected call
+    assert_eq!(client.get_match(&id).state, MatchState::Pending);
+}


### PR DESCRIPTION
 Closes #191 — adds an early Unauthorized check in cancel_match that rejects env.current_contract_address() before the player identity check, plus a test asserting the match stays Pending after the rejected call