### PR TITLE
feat:fix: add get_oracle public getter to escrow contract

### DIFF
--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -648,6 +648,17 @@ impl EscrowContract {
             .ok_or(Error::Unauthorized)
     }
 
+    /// Return the trusted oracle address stored at initialization.
+    ///
+    /// # Errors
+    /// - `Error::Unauthorized` — the contract has not been initialized yet.
+    pub fn get_oracle(env: Env) -> Result<Address, Error> {
+        env.storage()
+            .instance()
+            .get(&DataKey::Oracle)
+            .ok_or(Error::Unauthorized)
+    }
+
     /// Read a match by ID.
     ///
     /// # Errors

--- a/contracts/escrow/src/tests.rs
+++ b/contracts/escrow/src/tests.rs
@@ -2257,3 +2257,17 @@ fn test_cancel_match_rejects_contract_as_caller() {
     // Match must remain Pending — no state change from the rejected call
     assert_eq!(client.get_match(&id).state, MatchState::Pending);
 }
+
+// ── get_oracle returns the address set at initialize ─────────────────────────
+
+#[test]
+fn test_get_oracle_returns_address_set_at_initialize() {
+    let (env, contract_id, oracle_contract_id, _player1, _player2, _token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    assert_eq!(
+        client.get_oracle(),
+        oracle_contract_id,
+        "get_oracle must return the oracle address passed to initialize"
+    );
+}


### PR DESCRIPTION
Labels: enhancement
Priority: Low
Estimated Time: 15 minutes

Description:
There is no public getter for the oracle address stored in the escrow contract. Frontends and integrators cannot verify which oracle is trusted without reading raw storage.

Tasks:

Add get_oracle(env: Env) -> Address read function
Add test asserting it returns the address set at initialize
closes #68 