### PR TITLE
feat: add oracle pause tests and escrow is_paused view

### DIFF
--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -145,6 +145,14 @@ pub fn initialize(env: Env, oracle: Address, admin: Address, deployer: Address) 
         Ok(())
     }
 
+    /// Returns true if the contract is currently paused.
+    pub fn is_paused(env: Env) -> bool {
+        env.storage()
+            .instance()
+            .get(&DataKey::Paused)
+            .unwrap_or(false)
+    }
+
     /// Unpause the contract — admin only.
     pub fn unpause(env: Env) -> Result<(), Error> {
         let admin: Address = env

--- a/contracts/escrow/src/tests.rs
+++ b/contracts/escrow/src/tests.rs
@@ -1427,6 +1427,18 @@ fn test_unpause_emits_event() {
     );
 }
 
+#[test]
+fn test_is_paused_reflects_state() {
+    let (env, contract_id, ..) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    assert!(!client.is_paused());
+    client.pause();
+    assert!(client.is_paused());
+    client.unpause();
+    assert!(!client.is_paused());
+}
+
 // ── Issue #65: player cannot deposit twice for the same match ─────────────────
 
 #[test]

--- a/contracts/oracle/src/lib.rs
+++ b/contracts/oracle/src/lib.rs
@@ -656,4 +656,63 @@ mod tests {
             "oracle initialize must reject a non-deployer caller"
         );
     }
+
+    // ── pause / unpause ───────────────────────────────────────────────────────
+
+    #[test]
+    fn test_pause_blocks_submit_result() {
+        let (env, contract_id, escrow_id, ..) = setup();
+        let client = OracleContractClient::new(&env, &contract_id);
+
+        client.pause();
+
+        let result = client.try_submit_result(
+            &0u64,
+            &String::from_str(&env, "test_game"),
+            &MatchResult::Player1Wins,
+            &escrow_id,
+        );
+        assert_eq!(result, Err(Ok(Error::ContractPaused)));
+    }
+
+    #[test]
+    fn test_unpause_allows_submit_result() {
+        let (env, contract_id, escrow_id, ..) = setup();
+        let client = OracleContractClient::new(&env, &contract_id);
+
+        client.pause();
+        client.unpause();
+
+        client.submit_result(
+            &0u64,
+            &String::from_str(&env, "test_game"),
+            &MatchResult::Player1Wins,
+            &escrow_id,
+        );
+        assert!(client.has_result(&0u64));
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_non_admin_cannot_pause() {
+        let env = Env::default();
+        let admin = Address::generate(&env);
+        let non_admin = Address::generate(&env);
+        let contract_id = env.register(OracleContract, ());
+        let client = OracleContractClient::new(&env, &contract_id);
+
+        env.mock_all_auths();
+        client.initialize(&admin, &admin);
+
+        env.mock_auths(&[soroban_sdk::testutils::MockAuth {
+            address: &non_admin,
+            invoke: &soroban_sdk::testutils::MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "pause",
+                args: ().into_val(&env),
+                sub_invokes: &[],
+            },
+        }]);
+        client.pause();
+    }
 }


### PR DESCRIPTION
closes #227 
closes #233 


## feat: oracle pause tests & escrow is_paused view

### Summary

Closes two open tickets:

Oracle pause/unpause tests (Medium priority)
The oracle contract already had pause(), unpause(), and a paused guard in submit_result, but had 
zero test coverage for that behaviour. This adds:

- test_pause_blocks_submit_result — verifies that calling submit_result while paused returns 
Error::ContractPaused
- test_unpause_allows_submit_result — verifies that pausing then unpausing restores normal 
operation
- test_non_admin_cannot_pause — verifies that a non-admin caller cannot pause the oracle

Escrow is_paused() view function (Low priority)
Frontends had no way to check pause state without attempting a transaction. This adds:

- is_paused() -> bool public view on the escrow contract — reads the Paused storage key, returns 
false if unset
- test_is_paused_reflects_state — asserts the return value transitions correctly across pause() 
and unpause() calls

### Changes

| File | Change |
|---|---|
| contracts/oracle/src/lib.rs | +3 tests for pause/unpause behaviour |
| contracts/escrow/src/lib.rs | +is_paused() view function |
| contracts/escrow/src/tests.rs | +test_is_paused_reflects_state |

### Notes

No logic changes were made to either contract — the oracle pause guard and escrow pause/unpause 
were already correctly implemented. This PR is purely additive (new view function + missing test 
coverage).
