### PR TITLE
feat: implement view function

### DIFF
--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -70,7 +70,7 @@ impl EscrowContract {
     /// Must be called by the deployer immediately after deployment.
     /// The deployer address is passed as `deployer` and must authorize this call,
     /// preventing any third party from front-running initialization.
-pub fn initialize(env: Env, oracle: Address, admin: Address, deployer: Address) {
+    pub fn initialize(env: Env, oracle: Address, admin: Address, deployer: Address) {
         deployer.require_auth();
         if env.storage().instance().has(&DataKey::Oracle) {
             panic!("Contract already initialized");
@@ -301,7 +301,12 @@ pub fn initialize(env: Env, oracle: Address, admin: Address, deployer: Address) 
         env.storage().instance().set(&DataKey::MatchCount, &next_id);
         env.storage()
             .persistent()
-            .set(&DataKey::GameId(m.game_id.clone()), &true);
+            .set(&DataKey::GameId(m.game_id.clone()), &id);
+        env.storage().persistent().extend_ttl(
+            &DataKey::GameId(m.game_id.clone()),
+            MATCH_TTL_LEDGERS,
+            MATCH_TTL_LEDGERS,
+        );
 
         // Update player matches index
         for player in [m.player1.clone(), m.player2.clone()] {
@@ -657,6 +662,38 @@ pub fn initialize(env: Env, oracle: Address, admin: Address, deployer: Address) 
     ///   existed on-chain but is no longer accessible.
     pub fn get_match(env: Env, match_id: u64) -> Result<Match, Error> {
         let m = load_match(&env, match_id)?;
+        env.storage().persistent().extend_ttl(
+            &DataKey::Match(match_id),
+            MATCH_TTL_LEDGERS,
+            MATCH_TTL_LEDGERS,
+        );
+        Ok(m)
+    }
+
+    /// Read a match by its platform game ID.
+    ///
+    /// # Errors
+    /// - `Error::InvalidGameId` — the provided `game_id` is empty or exceeds
+    ///   `MAX_GAME_ID_LEN`.
+    /// - `Error::MatchNotFound` — no match has been indexed for this `game_id`.
+    /// - `Error::MatchStorageExpired` — the `game_id` still resolves to a
+    ///   previously allocated `match_id`, but that match entry has been evicted.
+    pub fn get_match_by_game_id(env: Env, game_id: String) -> Result<Match, Error> {
+        if game_id.is_empty() || game_id.len() > MAX_GAME_ID_LEN {
+            return Err(Error::InvalidGameId);
+        }
+
+        let match_id: u64 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::GameId(game_id.clone()))
+            .ok_or(Error::MatchNotFound)?;
+        let m = load_match(&env, match_id)?;
+        env.storage().persistent().extend_ttl(
+            &DataKey::GameId(game_id),
+            MATCH_TTL_LEDGERS,
+            MATCH_TTL_LEDGERS,
+        );
         env.storage().persistent().extend_ttl(
             &DataKey::Match(match_id),
             MATCH_TTL_LEDGERS,

--- a/contracts/escrow/src/tests.rs
+++ b/contracts/escrow/src/tests.rs
@@ -183,6 +183,61 @@ fn test_get_match_returns_correct_platform() {
 }
 
 #[test]
+fn test_create_match_indexes_game_id_to_match_id() {
+    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let game_id = String::from_str(&env, "indexed_game_id");
+    let id = client.create_match(
+        &player1,
+        &player2,
+        &100,
+        &token,
+        &game_id,
+        &Platform::Lichess,
+    );
+
+    let indexed_id: u64 = env.as_contract(&contract_id, || {
+        env.storage()
+            .persistent()
+            .get(&DataKey::GameId(game_id))
+            .expect("game_id index should be stored")
+    });
+    assert_eq!(indexed_id, id);
+}
+
+#[test]
+fn test_get_match_by_game_id_returns_match() {
+    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let game_id = String::from_str(&env, "lookup_game_id");
+    let id = client.create_match(
+        &player1,
+        &player2,
+        &100,
+        &token,
+        &game_id,
+        &Platform::Lichess,
+    );
+
+    let m = client.get_match_by_game_id(&game_id);
+    assert_eq!(m.id, id);
+    assert_eq!(m.game_id, game_id);
+    assert_eq!(m.state, MatchState::Pending);
+}
+
+#[test]
+fn test_get_match_by_game_id_returns_match_not_found_for_unknown_game_id() {
+    let (env, contract_id, _oracle, _player1, _player2, _token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let result = client.try_get_match_by_game_id(&String::from_str(&env, "missing_game_id"));
+
+    assert!(matches!(result, Err(Ok(Error::MatchNotFound))));
+}
+
+#[test]
 fn test_deposit_and_activate() {
     let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
     let client = EscrowContractClient::new(&env, &contract_id);
@@ -686,7 +741,7 @@ fn test_create_match_with_same_player_fails() {
         &Platform::Lichess,
     );
 
-    assert_eq!(result, Err(Ok(Error::SamePlayer)));
+    assert_eq!(result, Err(Ok(Error::InvalidPlayers)));
 }
 
 #[test]

--- a/contracts/escrow/test_snapshots/tests/test_admin_unpause_allows_create_match.1.json
+++ b/contracts/escrow/test_snapshots/tests/test_admin_unpause_allows_create_match.1.json
@@ -627,13 +627,13 @@
                 },
                 "durability": "persistent",
                 "val": {
-                  "bool": true
+                  "u64": 0
                 }
               }
             },
             "ext": "v0"
           },
-          4095
+          518400
         ]
       ],
       [

--- a/contracts/escrow/test_snapshots/tests/test_cancel_active_match_fails_with_invalid_state.1.json
+++ b/contracts/escrow/test_snapshots/tests/test_cancel_active_match_fails_with_invalid_state.1.json
@@ -694,13 +694,13 @@
                 },
                 "durability": "persistent",
                 "val": {
-                  "bool": true
+                  "u64": 0
                 }
               }
             },
             "ext": "v0"
           },
-          4095
+          518400
         ]
       ],
       [

--- a/contracts/escrow/test_snapshots/tests/test_cancel_both_deposited_active_returns_invalid_state.1.json
+++ b/contracts/escrow/test_snapshots/tests/test_cancel_both_deposited_active_returns_invalid_state.1.json
@@ -693,13 +693,13 @@
                 },
                 "durability": "persistent",
                 "val": {
-                  "bool": true
+                  "u64": 0
                 }
               }
             },
             "ext": "v0"
           },
-          4095
+          518400
         ]
       ],
       [

--- a/contracts/escrow/test_snapshots/tests/test_cancel_completed_match_returns_invalid_state.1.json
+++ b/contracts/escrow/test_snapshots/tests/test_cancel_completed_match_returns_invalid_state.1.json
@@ -779,13 +779,13 @@
                 },
                 "durability": "persistent",
                 "val": {
-                  "bool": true
+                  "u64": 0
                 }
               }
             },
             "ext": "v0"
           },
-          4095
+          518400
         ]
       ],
       [

--- a/contracts/escrow/test_snapshots/tests/test_cancel_match_emits_event.1.json
+++ b/contracts/escrow/test_snapshots/tests/test_cancel_match_emits_event.1.json
@@ -582,13 +582,13 @@
                 },
                 "durability": "persistent",
                 "val": {
-                  "bool": true
+                  "u64": 0
                 }
               }
             },
             "ext": "v0"
           },
-          4095
+          518400
         ]
       ],
       [

--- a/contracts/escrow/test_snapshots/tests/test_cancel_only_player1_deposited_refunds_player1.1.json
+++ b/contracts/escrow/test_snapshots/tests/test_cancel_only_player1_deposited_refunds_player1.1.json
@@ -666,13 +666,13 @@
                 },
                 "durability": "persistent",
                 "val": {
-                  "bool": true
+                  "u64": 0
                 }
               }
             },
             "ext": "v0"
           },
-          4095
+          518400
         ]
       ],
       [

--- a/contracts/escrow/test_snapshots/tests/test_cancel_only_player2_deposited_refunds_player2.1.json
+++ b/contracts/escrow/test_snapshots/tests/test_cancel_only_player2_deposited_refunds_player2.1.json
@@ -666,13 +666,13 @@
                 },
                 "durability": "persistent",
                 "val": {
-                  "bool": true
+                  "u64": 0
                 }
               }
             },
             "ext": "v0"
           },
-          4095
+          518400
         ]
       ],
       [

--- a/contracts/escrow/test_snapshots/tests/test_cancel_refunds_deposit.1.json
+++ b/contracts/escrow/test_snapshots/tests/test_cancel_refunds_deposit.1.json
@@ -663,13 +663,13 @@
                 },
                 "durability": "persistent",
                 "val": {
-                  "bool": true
+                  "u64": 0
                 }
               }
             },
             "ext": "v0"
           },
-          4095
+          518400
         ]
       ],
       [

--- a/contracts/escrow/test_snapshots/tests/test_create_match_emits_event.1.json
+++ b/contracts/escrow/test_snapshots/tests/test_create_match_emits_event.1.json
@@ -531,13 +531,13 @@
                 },
                 "durability": "persistent",
                 "val": {
-                  "bool": true
+                  "u64": 0
                 }
               }
             },
             "ext": "v0"
           },
-          4095
+          518400
         ]
       ],
       [

--- a/contracts/escrow/test_snapshots/tests/test_create_match_sets_created_ledger.1.json
+++ b/contracts/escrow/test_snapshots/tests/test_create_match_sets_created_ledger.1.json
@@ -532,13 +532,13 @@
                 },
                 "durability": "persistent",
                 "val": {
-                  "bool": true
+                  "u64": 0
                 }
               }
             },
             "ext": "v0"
           },
-          4095
+          518400
         ]
       ],
       [

--- a/contracts/escrow/test_snapshots/tests/test_deposit_and_activate.1.json
+++ b/contracts/escrow/test_snapshots/tests/test_deposit_and_activate.1.json
@@ -693,13 +693,13 @@
                 },
                 "durability": "persistent",
                 "val": {
-                  "bool": true
+                  "u64": 0
                 }
               }
             },
             "ext": "v0"
           },
-          4095
+          518400
         ]
       ],
       [

--- a/contracts/escrow/test_snapshots/tests/test_deposit_emits_activated_event.1.json
+++ b/contracts/escrow/test_snapshots/tests/test_deposit_emits_activated_event.1.json
@@ -689,13 +689,13 @@
                 },
                 "durability": "persistent",
                 "val": {
-                  "bool": true
+                  "u64": 0
                 }
               }
             },
             "ext": "v0"
           },
-          4095
+          518400
         ]
       ],
       [

--- a/contracts/escrow/test_snapshots/tests/test_deposit_into_cancelled_match_returns_match_cancelled.1.json
+++ b/contracts/escrow/test_snapshots/tests/test_deposit_into_cancelled_match_returns_match_cancelled.1.json
@@ -583,13 +583,13 @@
                 },
                 "durability": "persistent",
                 "val": {
-                  "bool": true
+                  "u64": 0
                 }
               }
             },
             "ext": "v0"
           },
-          4095
+          518400
         ]
       ],
       [

--- a/contracts/escrow/test_snapshots/tests/test_deposit_into_completed_match_returns_invalid_state.1.json
+++ b/contracts/escrow/test_snapshots/tests/test_deposit_into_completed_match_returns_invalid_state.1.json
@@ -778,13 +778,13 @@
                 },
                 "durability": "persistent",
                 "val": {
-                  "bool": true
+                  "u64": 0
                 }
               }
             },
             "ext": "v0"
           },
-          4095
+          518400
         ]
       ],
       [

--- a/contracts/escrow/test_snapshots/tests/test_deposit_into_completed_match_returns_match_completed.1.json
+++ b/contracts/escrow/test_snapshots/tests/test_deposit_into_completed_match_returns_match_completed.1.json
@@ -773,13 +773,13 @@
                 },
                 "durability": "persistent",
                 "val": {
-                  "bool": true
+                  "u64": 0
                 }
               }
             },
             "ext": "v0"
           },
-          4095
+          518400
         ]
       ],
       [

--- a/contracts/escrow/test_snapshots/tests/test_draw_refund.1.json
+++ b/contracts/escrow/test_snapshots/tests/test_draw_refund.1.json
@@ -775,13 +775,13 @@
                 },
                 "durability": "persistent",
                 "val": {
-                  "bool": true
+                  "u64": 0
                 }
               }
             },
             "ext": "v0"
           },
-          4095
+          518400
         ]
       ],
       [

--- a/contracts/escrow/test_snapshots/tests/test_duplicate_game_id_rejected.1.json
+++ b/contracts/escrow/test_snapshots/tests/test_duplicate_game_id_rejected.1.json
@@ -532,13 +532,13 @@
                 },
                 "durability": "persistent",
                 "val": {
-                  "bool": true
+                  "u64": 0
                 }
               }
             },
             "ext": "v0"
           },
-          4095
+          518400
         ]
       ],
       [

--- a/contracts/escrow/test_snapshots/tests/test_non_oracle_cannot_submit_result.1.json
+++ b/contracts/escrow/test_snapshots/tests/test_non_oracle_cannot_submit_result.1.json
@@ -693,13 +693,13 @@
                 },
                 "durability": "persistent",
                 "val": {
-                  "bool": true
+                  "u64": 0
                 }
               }
             },
             "ext": "v0"
           },
-          4095
+          518400
         ]
       ],
       [

--- a/contracts/escrow/test_snapshots/tests/test_player1_cannot_deposit_twice.1.json
+++ b/contracts/escrow/test_snapshots/tests/test_player1_cannot_deposit_twice.1.json
@@ -611,13 +611,13 @@
                 },
                 "durability": "persistent",
                 "val": {
-                  "bool": true
+                  "u64": 0
                 }
               }
             },
             "ext": "v0"
           },
-          4095
+          518400
         ]
       ],
       [

--- a/contracts/escrow/test_snapshots/tests/test_player2_cancel_only_player2_deposited.1.json
+++ b/contracts/escrow/test_snapshots/tests/test_player2_cancel_only_player2_deposited.1.json
@@ -663,13 +663,13 @@
                 },
                 "durability": "persistent",
                 "val": {
-                  "bool": true
+                  "u64": 0
                 }
               }
             },
             "ext": "v0"
           },
-          4095
+          518400
         ]
       ],
       [

--- a/contracts/escrow/test_snapshots/tests/test_player2_cancel_pending_match.1.json
+++ b/contracts/escrow/test_snapshots/tests/test_player2_cancel_pending_match.1.json
@@ -583,13 +583,13 @@
                 },
                 "durability": "persistent",
                 "val": {
-                  "bool": true
+                  "u64": 0
                 }
               }
             },
             "ext": "v0"
           },
-          4095
+          518400
         ]
       ],
       [

--- a/contracts/escrow/test_snapshots/tests/test_player2_cancel_refunds_both_players.1.json
+++ b/contracts/escrow/test_snapshots/tests/test_player2_cancel_refunds_both_players.1.json
@@ -690,13 +690,13 @@
                 },
                 "durability": "persistent",
                 "val": {
-                  "bool": true
+                  "u64": 0
                 }
               }
             },
             "ext": "v0"
           },
-          4095
+          518400
         ]
       ],
       [

--- a/contracts/escrow/test_snapshots/tests/test_player2_cannot_deposit_twice.1.json
+++ b/contracts/escrow/test_snapshots/tests/test_player2_cannot_deposit_twice.1.json
@@ -611,13 +611,13 @@
                 },
                 "durability": "persistent",
                 "val": {
-                  "bool": true
+                  "u64": 0
                 }
               }
             },
             "ext": "v0"
           },
-          4095
+          518400
         ]
       ],
       [

--- a/contracts/escrow/test_snapshots/tests/test_submit_result_emits_event.1.json
+++ b/contracts/escrow/test_snapshots/tests/test_submit_result_emits_event.1.json
@@ -772,13 +772,13 @@
                 },
                 "durability": "persistent",
                 "val": {
-                  "bool": true
+                  "u64": 0
                 }
               }
             },
             "ext": "v0"
           },
-          4095
+          518400
         ]
       ],
       [

--- a/contracts/escrow/test_snapshots/tests/test_submit_result_on_cancelled_match_returns_invalid_state.1.json
+++ b/contracts/escrow/test_snapshots/tests/test_submit_result_on_cancelled_match_returns_invalid_state.1.json
@@ -584,13 +584,13 @@
                 },
                 "durability": "persistent",
                 "val": {
-                  "bool": true
+                  "u64": 0
                 }
               }
             },
             "ext": "v0"
           },
-          4095
+          518400
         ]
       ],
       [

--- a/contracts/escrow/test_snapshots/tests/test_ttl_extended_on_cancel.1.json
+++ b/contracts/escrow/test_snapshots/tests/test_ttl_extended_on_cancel.1.json
@@ -583,13 +583,13 @@
                 },
                 "durability": "persistent",
                 "val": {
-                  "bool": true
+                  "u64": 0
                 }
               }
             },
             "ext": "v0"
           },
-          4095
+          518400
         ]
       ],
       [

--- a/contracts/escrow/test_snapshots/tests/test_ttl_extended_on_create_match.1.json
+++ b/contracts/escrow/test_snapshots/tests/test_ttl_extended_on_create_match.1.json
@@ -532,13 +532,13 @@
                 },
                 "durability": "persistent",
                 "val": {
-                  "bool": true
+                  "u64": 0
                 }
               }
             },
             "ext": "v0"
           },
-          4095
+          518400
         ]
       ],
       [

--- a/contracts/escrow/test_snapshots/tests/test_ttl_extended_on_deposit.1.json
+++ b/contracts/escrow/test_snapshots/tests/test_ttl_extended_on_deposit.1.json
@@ -611,13 +611,13 @@
                 },
                 "durability": "persistent",
                 "val": {
-                  "bool": true
+                  "u64": 0
                 }
               }
             },
             "ext": "v0"
           },
-          4095
+          518400
         ]
       ],
       [

--- a/contracts/escrow/test_snapshots/tests/test_ttl_extended_on_submit_result.1.json
+++ b/contracts/escrow/test_snapshots/tests/test_ttl_extended_on_submit_result.1.json
@@ -773,13 +773,13 @@
                 },
                 "durability": "persistent",
                 "val": {
-                  "bool": true
+                  "u64": 0
                 }
               }
             },
             "ext": "v0"
           },
-          4095
+          518400
         ]
       ],
       [

--- a/contracts/escrow/test_snapshots/tests/test_unauthorized_player_cannot_cancel.1.json
+++ b/contracts/escrow/test_snapshots/tests/test_unauthorized_player_cannot_cancel.1.json
@@ -532,13 +532,13 @@
                 },
                 "durability": "persistent",
                 "val": {
-                  "bool": true
+                  "u64": 0
                 }
               }
             },
             "ext": "v0"
           },
-          4095
+          518400
         ]
       ],
       [

--- a/contracts/oracle/Cargo.toml
+++ b/contracts/oracle/Cargo.toml
@@ -8,7 +8,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 soroban-sdk = { workspace = true }
+escrow = { path = "../escrow" }
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }
-escrow = { path = "../escrow" }

--- a/contracts/oracle/src/errors.rs
+++ b/contracts/oracle/src/errors.rs
@@ -20,4 +20,5 @@ pub enum Error {
     /// Code 5 — The match ID referenced does not exist in the escrow contract.
     MatchNotFound = 5,
     ContractPaused = 6,
+    GameIdMismatch = 7,
 }

--- a/contracts/oracle/src/lib.rs
+++ b/contracts/oracle/src/lib.rs
@@ -5,9 +5,9 @@ mod types;
 pub use types::MatchResult;
 
 use errors::Error;
+use escrow::types::Match;
 use soroban_sdk::{contract, contractimpl, symbol_short, Address, Env, String, Symbol, TryFromVal};
 use types::{DataKey, ResultEntry};
-use escrow::types::Match;
 
 /// ~30 days at 5s/ledger.
 const MATCH_TTL_LEDGERS: u32 = 518_400;
@@ -456,8 +456,7 @@ mod tests {
                 &token_addr,
                 &String::from_str(&env, "test_game_b"),
                 &escrow::types::Platform::Lichess,
-            )
-            .unwrap();
+            );
         let match_id_3 = escrow_client
             .create_match(
                 &player1,
@@ -466,19 +465,32 @@ mod tests {
                 &token_addr,
                 &String::from_str(&env, "test_game_c"),
                 &escrow::types::Platform::Lichess,
-            )
-            .unwrap();
+            );
 
         let cases = [
-            (match_id_1, MatchResult::Player1Wins, String::from_str(&env, "test_game")),
-            (match_id_2, MatchResult::Player2Wins, String::from_str(&env, "test_game_b")),
-            (match_id_3, MatchResult::Draw, String::from_str(&env, "test_game_c")),
+            (
+                match_id_1,
+                MatchResult::Player1Wins,
+                String::from_str(&env, "test_game"),
+            ),
+            (
+                match_id_2,
+                MatchResult::Player2Wins,
+                String::from_str(&env, "test_game_b"),
+            ),
+            (
+                match_id_3,
+                MatchResult::Draw,
+                String::from_str(&env, "test_game_c"),
+            ),
         ];
 
         for (match_id, result, game_id) in cases {
             client.submit_result(&match_id, &game_id, &result, &escrow_id);
             let ttl = env.as_contract(&contract_id, || {
-                env.storage().persistent().get_ttl(&DataKey::Result(match_id))
+                env.storage()
+                    .persistent()
+                    .get_ttl(&DataKey::Result(match_id))
             });
             assert_eq!(ttl, crate::MATCH_TTL_LEDGERS);
         }


### PR DESCRIPTION
## Summary

Add direct match lookup by `game_id` so frontends that only have a platform game ID, such as one parsed from a Lichess URL, can fetch a match without scanning numeric `match_id`s.

## What Changed

- Store `DataKey::GameId(String) -> u64` during `create_match`
- Add `get_match_by_game_id(game_id: String) -> Result<Match, Error>` to the escrow contract
- Refresh TTL for both the `game_id` index entry and resolved match on lookup
- Add tests covering:
  - `game_id -> match_id` index creation
  - successful lookup by `game_id`
  - `MatchNotFound` for unknown `game_id`

## Additional Fixes

- Fixed existing oracle workspace issues that were blocking `cargo test`
- Added the missing oracle `GameIdMismatch` error
- Moved `escrow` into oracle runtime dependencies
- Cleaned up a few stale test assertions/imports so the full workspace test suite passes again

## Why

Previously, matches could only be retrieved by numeric `match_id`. This made integrations awkward for clients that only know the external chess platform’s `game_id`. This change adds a direct on-chain index for that use case.

## Testing

- `cargo test`

Closes #231 