### PR TITLE
docs(readme): replace broken ./scripts/deploy_testnet.sh ref with inline Stellar CLI commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,9 +92,17 @@ Network configurations are defined in `environments.toml`:
 # Configure your testnet identity first
 stellar keys generate deployer --network testnet
 
-# Deploy
-./scripts/deploy_testnet.sh
+# Build the contract WASM
+./scripts/build.sh
+
+# Deploy with the Stellar CLI (replace <CONTRACT_WASM> with the built artifact)
+stellar contract deploy \
+  --source deployer \
+  --network testnet \
+  --wasm target/wasm32-unknown-unknown/release/<CONTRACT_WASM>.wasm
 ```
+
+> NOTE: A dedicated `scripts/deploy_testnet.sh` wrapper is planned (see issue #391). For now, use the inline \`stellar contract deploy\` command above.
 
 ### Run Demo
 


### PR DESCRIPTION
## Summary

Per #391, the README's *Quick Start → Deploy to Testnet* step told users to run \`./scripts/deploy_testnet.sh\`, but the \`scripts/\` directory only ships \`build.sh\` and \`test.sh\`. Copy-paste install instructions therefore fail on a fresh clone.

Replaced the dead reference with:

1. \`./scripts/build.sh\` (the existing build helper), then
2. the inline \`stellar contract deploy --source deployer --network testnet --wasm <path>\` command that a fresh user can actually run.

Also left a short note pointing back at #391 so the maintainer can drop in a dedicated wrapper script later and reduce the README back to a one-liner.

Closes #391

## Testing

Docs-only change. Verified \`scripts/build.sh\` exists and builds the WASM; the \`stellar contract deploy\` snippet follows the Soroban docs' canonical form.