### PR TITLE
Add missing tests

### DIFF
--- a/contracts/escrow/src/tests.rs
+++ b/contracts/escrow/src/tests.rs
@@ -1863,3 +1863,25 @@ fn test_update_oracle_emits_oracle_up_event_with_addresses() {
     assert_eq!(ev_old, old_oracle);
     assert_eq!(ev_new, new_oracle);
 }
+
+
+#[test]
+fn test_is_funded_returns_false_when_only_player1_deposited() {
+    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let id = client.create_match(
+        &player1,
+        &player2,
+        &100,
+        &token,
+        &String::from_str(&env, "funded_test"),
+        &Platform::Lichess,
+    );
+
+    client.deposit(&id, &player1);
+    assert!(!client.is_funded(&id));
+
+    client.deposit(&id, &player2);
+    assert!(client.is_funded(&id));
+}

--- a/contracts/escrow/src/tests.rs
+++ b/contracts/escrow/src/tests.rs
@@ -1831,3 +1831,35 @@ fn test_get_escrow_balance_returns_match_not_found_for_nonexistent_id() {
         "get_escrow_balance must return MatchNotFound for a non-existent match_id"
     );
 }
+
+
+#[test]
+fn test_update_oracle_emits_oracle_up_event_with_addresses() {
+    let (env, contract_id, _oracle, _player1, _player2, _token, admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let new_oracle = Address::generate(&env);
+    let old_oracle: Address = env
+        .storage()
+        .instance()
+        .get(&DataKey::Oracle)
+        .unwrap();
+
+    client.update_oracle(&new_oracle, &admin);
+
+    let events = env.events().all();
+    let expected_topics = vec![
+        &env,
+        Symbol::new(&env, "admin").into_val(&env),
+        soroban_sdk::symbol_short!("oracle_up").into_val(&env),
+    ];
+    let matched = events
+        .iter()
+        .find(|(_, topics, _)| *topics == expected_topics);
+    assert!(matched.is_some(), "oracle_up event not emitted");
+
+    let (_, _, data) = matched.unwrap();
+    let (ev_old, ev_new): (Address, Address) = TryFromVal::try_from_val(&env, &data).unwrap();
+    assert_eq!(ev_old, old_oracle);
+    assert_eq!(ev_new, new_oracle);
+}

--- a/contracts/escrow/src/tests.rs
+++ b/contracts/escrow/src/tests.rs
@@ -1895,3 +1895,30 @@ fn test_submit_result_on_nonexistent_match_id_returns_match_not_found() {
     let result = client.try_submit_result(&9999u64, &Address::generate(&env));
     assert_eq!(result, Err(Ok(Error::MatchNotFound)));
 }
+
+
+#[test]
+fn test_cancel_match_by_player2_refunds_player1_deposit() {
+    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+    let token_client = TokenClient::new(&env, &token);
+
+    let id = client.create_match(
+        &player1,
+        &player2,
+        &100,
+        &token,
+        &String::from_str(&env, "cancel_test"),
+        &Platform::Lichess,
+    );
+
+    client.deposit(&id, &player1);
+    let player1_balance_after_deposit = token_client.balance(&player1);
+    assert_eq!(player1_balance_after_deposit, 900);
+
+    client.cancel_match(&id, &player2);
+
+    let player1_balance_after_cancel = token_client.balance(&player1);
+    assert_eq!(player1_balance_after_cancel, 1000);
+    assert_eq!(token_client.balance(&player2), 1000);
+}

--- a/contracts/escrow/src/tests.rs
+++ b/contracts/escrow/src/tests.rs
@@ -1885,3 +1885,13 @@ fn test_is_funded_returns_false_when_only_player1_deposited() {
     client.deposit(&id, &player2);
     assert!(client.is_funded(&id));
 }
+
+
+#[test]
+fn test_submit_result_on_nonexistent_match_id_returns_match_not_found() {
+    let (env, contract_id, _oracle, _player1, _player2, _token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let result = client.try_submit_result(&9999u64, &Address::generate(&env));
+    assert_eq!(result, Err(Ok(Error::MatchNotFound)));
+}


### PR DESCRIPTION
Overview
This PR adds four critical test cases to improve test coverage for the Escrow contract, addressing gaps in event verification and edge case handling.

## Changes

### Test 1: Update Oracle Event Verification (#327)
Verifies that the `update_oracle` function correctly emits the `oracle_up` event with both the old and new oracle addresses in the event data.

### Test 2: Is Funded State Verification (#330)
Ensures that `is_funded` correctly returns `false` when only one player has deposited, and `true` when both have deposited.

### Test 3: Submit Result Error Handling (#334)
Validates that `submit_result` properly returns `Error::MatchNotFound` when called with an unknown match ID.

### Test 4: Cancel Match Refund Logic (#331)
Verifies that player2 can cancel a pending match and that player1 receives their deposit back.

## Testing
All tests follow the existing test patterns in the codebase:
- Use the `setup()` helper function for environment initialization
- Mock all authentications
- Verify both state changes and event emissions
- Use minimal, focused assertions

## Related Issues
Closes #327
Closes #330
Closes #334
Closes #331