### PR TITLE
feat: oracle contract

### DIFF
--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -428,6 +428,26 @@ impl EscrowContract {
         Ok(())
     }
 
+    /// Transfer admin rights to a new address. Requires current admin auth.
+    pub fn transfer_admin(env: Env, new_admin: Address) -> Result<(), Error> {
+        let current_admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(Error::Unauthorized)?;
+
+        current_admin.require_auth();
+
+        env.storage().instance().set(&DataKey::Admin, &new_admin);
+
+        env.events().publish(
+            (Symbol::new(&env, "admin"), symbol_short!("transferred")),
+            (current_admin, new_admin),
+        );
+
+        Ok(())
+    }
+
     /// Return the admin address set at initialization.
     pub fn get_admin(env: Env) -> Result<Address, Error> {
         env.storage()

--- a/contracts/escrow/src/tests.rs
+++ b/contracts/escrow/src/tests.rs
@@ -1531,3 +1531,32 @@ fn test_cancel_match_by_player2_refunds_player1_deposit() {
     assert_eq!(player1_balance_after_cancel, 1000);
     assert_eq!(token_client.balance(&player2), 1000);
 }
+
+#[test]
+fn test_transfer_admin_updates_admin_and_emits_event() {
+    let (env, contract_id, _oracle, _player1, _player2, _token, admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let new_admin = Address::generate(&env);
+    env.mock_all_auths();
+
+    client.transfer_admin(&new_admin);
+
+    assert_eq!(client.get_admin(), new_admin);
+
+    let events = env.events().all();
+    let expected_topics = vec![
+        &env,
+        Symbol::new(&env, "admin").into_val(&env),
+        soroban_sdk::symbol_short!("transferred").into_val(&env),
+    ];
+    let matched = events
+        .iter()
+        .find(|(_, topics, _)| *topics == expected_topics);
+    assert!(matched.is_some(), "transferred event not emitted");
+
+    let (_, _, data) = matched.unwrap();
+    let (ev_old, ev_new): (Address, Address) = TryFromVal::try_from_val(&env, &data).unwrap();
+    assert_eq!(ev_old, admin);
+    assert_eq!(ev_new, new_admin);
+}


### PR DESCRIPTION
## What was implemented

`contracts/escrow/src/lib.rs` — added transfer_admin before get_admin:                                                                                            
                                                                                                                                                                    
  - Reads current admin from DataKey::Admin, requires its auth                                                                                                      
  - Writes new_admin to DataKey::Admin                                                                                                                              
  - Emits ("admin", "transferred") event with (old_admin, new_admin) as data                                                                                        
                                                                                                                                                                    
  `contracts/escrow/src/tests.rs` — added test_transfer_admin_updates_admin_and_emits_event:                                                                        
                                                                                                                                                                    
  - Calls transfer_admin with a freshly generated address                                                                                                           
  - Asserts get_admin() returns the new address                                                                                                                     
  - Asserts the ("admin", "transferred") event was emitted with correct old/new addresses       
closes #351 