### PR TITLE
Fix/ci clippy lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           targets: wasm32-unknown-unknown
+          components: clippy
 
       - name: Cache cargo
         uses: actions/cache@v4
@@ -31,6 +32,9 @@ jobs:
             target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: ${{ runner.os }}-cargo-
+
+      - name: Lint
+        run: cargo clippy -- -D warnings
 
       - name: Run tests
         run: cargo test

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -441,7 +441,7 @@ impl EscrowContract {
         env.storage().instance().set(&DataKey::Admin, &new_admin);
 
         env.events().publish(
-            (Symbol::new(&env, "admin"), symbol_short!("transferred")),
+            (Symbol::new(&env, "admin"), symbol_short!("xfer")),
             (current_admin, new_admin),
         );
 

--- a/contracts/escrow/src/tests.rs
+++ b/contracts/escrow/src/tests.rs
@@ -1574,3 +1574,23 @@ fn test_submit_result_from_non_oracle_returns_unauthorized() {
         "expected auth failure for non-oracle caller"
     );
 }
+
+#[test]
+fn test_cancel_match_state_is_cancelled() {
+    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let id = client.create_match(
+        &player1,
+        &player2,
+        &100,
+        &token,
+        &String::from_str(&env, "game_cancel_state"),
+        &Platform::Lichess,
+    );
+
+    client.cancel_match(&id, &player1);
+
+    let m = client.get_match(&id);
+    assert_eq!(m.state, MatchState::Cancelled);
+}


### PR DESCRIPTION
closes #377 

ci.yml
- Added components: clippy to the dtolnay/rust-toolchain step
- Added a Lint step running cargo clippy -- -D warnings before tests — any future lint warning will fail the pipeline

contracts/escrow/src/lib.rs
- Fixed symbol_short!("transferred") → symbol_short!("xfer") — symbol_short! enforces a 9-character max, "transferred" is 11 chars and was causing a compile error that would
have immediately failed the new clippy step

