### PR TITLE
docs: add doc comments to oracle error variants

### DIFF
--- a/contracts/oracle/src/errors.rs
+++ b/contracts/oracle/src/errors.rs
@@ -3,9 +3,14 @@ use soroban_sdk::contracterror;
 #[contracterror]
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum Error {
+    /// Caller is not the authorized oracle submitter.
     Unauthorized = 1,
+    /// A result has already been submitted for this match.
     AlreadySubmitted = 2,
+    /// No result has been submitted for the requested match.
     ResultNotFound = 3,
+    /// The contract has already been initialized.
     AlreadyInitialized = 4,
+    /// The contract is paused and not accepting submissions.
     ContractPaused = 5,
 }

--- a/contracts/oracle/src/lib.rs
+++ b/contracts/oracle/src/lib.rs
@@ -339,6 +339,35 @@ mod tests {
     }
 
     #[test]
+    fn test_submit_draw_result_emits_event() {
+        let (env, contract_id, ..) = setup();
+        let client = OracleContractClient::new(&env, &contract_id);
+
+        client.submit_result(
+            &0u64,
+            &String::from_str(&env, "abc123"),
+            &MatchResult::Draw,
+        );
+
+        let events = env.events().all();
+        let expected_topics = soroban_sdk::vec![
+            &env,
+            Symbol::new(&env, "oracle").into_val(&env),
+            symbol_short!("result").into_val(&env),
+        ];
+        let matched = events
+            .iter()
+            .find(|(_, topics, _)| *topics == expected_topics);
+        assert!(matched.is_some(), "oracle result event not emitted for Draw");
+
+        let (_, _, data) = matched.unwrap();
+        let (ev_id, ev_result): (u64, MatchResult) =
+            soroban_sdk::TryFromVal::try_from_val(&env, &data).unwrap();
+        assert_eq!(ev_id, 0u64);
+        assert_eq!(ev_result, MatchResult::Draw);
+    }
+
+    #[test]
     #[should_panic]
     fn test_duplicate_submit_fails() {
         let (env, contract_id, ..) = setup();


### PR DESCRIPTION
Added a /// doc comment to each of the 5 error variants in contracts/oracle/src/errors.rs:   
                                                                                                     
  - Unauthorized — caller isn't the authorized oracle submitter                                      
  - AlreadySubmitted — result already exists for that match                                          
  - ResultNotFound — no result submitted yet for the match                                           
  - AlreadyInitialized — contract init called more than once                                         
  - ContractPaused — submissions blocked while contract is paused
  
  closes #375 