### PR TITLE
feat: fix view function

### DIFF
--- a/contracts/oracle/src/lib.rs
+++ b/contracts/oracle/src/lib.rs
@@ -138,6 +138,11 @@ impl OracleContract {
         Ok(())
     }
 
+    /// Returns true if the contract has been initialized.
+    pub fn is_initialized(env: Env) -> bool {
+        env.storage().instance().has(&DataKey::Admin)
+    }
+
     /// Unpause the oracle — admin only. Does not emit an event.
     pub fn unpause(env: Env) -> Result<(), Error> {
         let admin: Address = env
@@ -361,6 +366,19 @@ mod tests {
         client.initialize(&admin);
         // second initialize should panic
         client.initialize(&admin);
+    }
+
+    #[test]
+    fn test_is_initialized() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let contract_id = env.register(OracleContract, ());
+        let client = OracleContractClient::new(&env, &contract_id);
+
+        assert!(!client.is_initialized());
+        client.initialize(&admin);
+        assert!(client.is_initialized());
     }
 
     #[test]


### PR DESCRIPTION
## What was implemented

1. Added is_initialized to OracleContract:                                                                                                                    
                                                                                                                                                                
  /// Returns true if the contract has been initialized.                                                                                                        
  pub fn is_initialized(env: Env) -> bool {                                                                                                                     
      env.storage().instance().has(&DataKey::Admin)                                                                                                             
  }                                                                                                                                                             
                                                                                                                                                                
  2. Added test_is_initialized in the test module:                                                                                                              
                                                                                                                                                                
  #[test]                                                                                                                                                       
  fn test_is_initialized() {                                                                                                                                    
      let env = Env::default();                                                                                                                                 
      env.mock_all_auths();                                                                                                                                     
      let admin = Address::generate(&env);                                                                                                                      
      let contract_id = env.register(OracleContract, ());                                                                                                       
      let client = OracleContractClient::new(&env, &contract_id);                                                                                               
                                                                                                                                                                
      assert!(!client.is_initialized());                                                                                                                        
      client.initialize(&admin);                                                                                                                                
      assert!(client.is_initialized());                                                                                                                         
  }                                                                                                                                                             
                                                                                                                                                                
  The function reuses the same DataKey::Admin presence check that initialize already uses as its guard, so there's no new storage key or logic — it's just      
  exposing that check publicly.        

closes #362 