### PR TITLE
test: verify calling pause() twice is idempotent

### DIFF
--- a/contracts/escrow/src/tests.rs
+++ b/contracts/escrow/src/tests.rs
@@ -1574,3 +1574,18 @@ fn test_submit_result_from_non_oracle_returns_unauthorized() {
         "expected auth failure for non-oracle caller"
     );
 }
+
+#[test]
+fn test_pause_twice_is_idempotent() {
+    let (env, contract_id, ..) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    client.pause();
+    client.pause(); // second call must not error
+
+    // Contract is still paused
+    let is_paused: bool = env.as_contract(&contract_id, || {
+        env.storage().instance().get(&DataKey::Paused).unwrap_or(false)
+    });
+    assert!(is_paused);
+}

--- a/contracts/oracle/src/lib.rs
+++ b/contracts/oracle/src/lib.rs
@@ -558,6 +558,21 @@ mod tests {
     }
 
     #[test]
+    fn test_pause_twice_is_idempotent() {
+        let (env, contract_id, ..) = setup();
+        let client = OracleContractClient::new(&env, &contract_id);
+
+        client.pause();
+        client.pause(); // second call must not error
+
+        // Contract is still paused
+        let is_paused: bool = env.as_contract(&contract_id, || {
+            env.storage().instance().get(&DataKey::Paused).unwrap_or(false)
+        });
+        assert!(is_paused);
+    }
+
+    #[test]
     fn test_unpause_emits_no_event() {
         let (env, contract_id, ..) = setup();
         let client = OracleContractClient::new(&env, &contract_id);


### PR DESCRIPTION
Created and pushed test/pause-idempotent with test_pause_twice_is_idempotent added to both   
  contracts:                                                                                         
                                                                                                     
  - contracts/escrow/src/tests.rs — calls pause() twice, asserts no error and Paused storage is still
  true                                                                                               
  - contracts/oracle/src/lib.rs — same pattern for the oracle contract 
  
  closes #386 