### PR TITLE
feat: fix intgration

### DIFF
--- a/contracts/oracle/src/lib.rs
+++ b/contracts/oracle/src/lib.rs
@@ -160,7 +160,7 @@ mod tests {
         Address, Env, IntoVal, String, Symbol,
     };
     use escrow::{EscrowContract, EscrowContractClient};
-    use escrow::types::Platform;
+    use escrow::types::{MatchState, Platform, Winner};
 
     fn setup() -> (Env, Address, Address, Address, Address, Address, Address) {
         let env = Env::default();
@@ -569,5 +569,33 @@ mod tests {
         
         // Test passes if unpause completes without panic
         // The function docstring states it does not emit events
+    }
+
+    /// Full integration: oracle stores result, escrow oracle address submits
+    /// result to escrow, payout executes, match is Completed.
+    #[test]
+    fn test_oracle_to_escrow_full_payout_flow() {
+        let (env, oracle_id, escrow_id, oracle_admin, player1, _player2, token_addr) = setup();
+        let oracle_client = OracleContractClient::new(&env, &oracle_id);
+        let escrow_client = EscrowContractClient::new(&env, &escrow_id);
+        let token_client = soroban_sdk::token::Client::new(&env, &token_addr);
+
+        // Step 1: oracle admin submits verified result to the oracle contract
+        oracle_client.submit_result(
+            &0u64,
+            &String::from_str(&env, "test_game"),
+            &MatchResult::Player1Wins,
+        );
+        assert!(oracle_client.has_result(&0u64));
+
+        // Step 2: the escrow's trusted oracle address (oracle_admin) calls
+        // submit_result on the escrow contract, triggering the payout
+        escrow_client.submit_result(&0u64, &Winner::Player1);
+
+        // Step 3: assert match is Completed and player1 received the full pot
+        let m = escrow_client.get_match(&0u64);
+        assert_eq!(m.state, MatchState::Completed);
+        // player1 staked 100, pot = 200; started with 1000, deposited 100 → balance = 1100
+        assert_eq!(token_client.balance(&player1), 1100);
     }
 }


### PR DESCRIPTION
## Here's a summary of the two changes made to contracts/oracle/src/lib.rs:                                                                                    
                                                                                                                                                                    
  Import addition — added MatchState and Winner from escrow::types alongside the existing Platform import, needed for the assertions and the escrow submit_result   
   call.                                                                                                                                                            
                                                                                                                                                                    
  `test_oracle_to_escrow_full_payout_flow` — exercises the complete cross-contract flow:                                                                            
                                                                                                                                                                    
  1. Oracle admin submits MatchResult::Player1Wins to the oracle contract for match 0 — verifies the oracle stored it                                               
  2. The same oracle_admin address (which was registered as the escrow's trusted oracle in setup()) calls escrow.submit_result(0, Winner::Player1) — this is the    
  bridge step the issue identified as untested                                                                                                                      
  3. Asserts match.state == Completed and player1's balance is 1100 (started at 1000, deposited 100, received the 200 pot back)                                     
                                                                                                                                                                    
  The existing setup() already wires oracle_admin as both the oracle contract's admin and the escrow's trusted oracle address, so no new setup was needed.          

closes #366 