### PR TITLE
feat: oracle-duplicate-submit_result

### DIFF
--- a/contracts/oracle/src/lib.rs
+++ b/contracts/oracle/src/lib.rs
@@ -350,6 +350,16 @@ mod tests {
     }
 
     #[test]
+    fn test_duplicate_submit_returns_already_submitted() {
+        let (env, contract_id, ..) = setup();
+        let client = OracleContractClient::new(&env, &contract_id);
+
+        client.submit_result(&0u64, &String::from_str(&env, "abc123"), &MatchResult::Draw);
+        let result = client.try_submit_result(&0u64, &String::from_str(&env, "abc123"), &MatchResult::Draw);
+        assert_eq!(result, Err(Ok(Error::AlreadySubmitted)));
+    }
+
+    #[test]
     #[should_panic]
     fn test_double_initialize_fails() {
         let env = Env::default();


### PR DESCRIPTION
## The new test_duplicate_submit_returns_already_submitted test:                                                                                               
                                                                                                                                                                    
  - Submits a result for match 0                                                                                                                                    
  - Calls try_submit_result for match 0 again                                                                                                                       
  - Asserts Err(Ok(Error::AlreadySubmitted)) — pinning the exact error code rather than just expecting a panic   
closes #365 