### PR TITLE
feat: fix match struct

### DIFF
--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -138,6 +138,7 @@ impl EscrowContract {
             player2_deposited: false,
             created_ledger: env.ledger().sequence(),
             completed_ledger: None,
+            winner: None,
         };
 
         env.storage().persistent().set(&DataKey::Match(id), &m);
@@ -264,6 +265,7 @@ impl EscrowContract {
 
         m.state = MatchState::Completed;
         m.completed_ledger = Some(env.ledger().sequence());
+        m.winner = Some(winner.clone());
         env.storage()
             .persistent()
             .set(&DataKey::Match(match_id), &m);

--- a/contracts/escrow/src/tests.rs
+++ b/contracts/escrow/src/tests.rs
@@ -1574,3 +1574,24 @@ fn test_submit_result_from_non_oracle_returns_unauthorized() {
         "expected auth failure for non-oracle caller"
     );
 }
+
+#[test]
+fn test_get_match_returns_winner_after_payout() {
+    let (env, contract_id, oracle, player1, player2, token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let id = client.create_match(
+        &player1,
+        &player2,
+        &100,
+        &token,
+        &String::from_str(&env, "winner_test"),
+        &Platform::Lichess,
+    );
+    client.deposit(&id, &player1);
+    client.deposit(&id, &player2);
+    client.submit_result(&id, &Winner::Player2);
+
+    let m = client.get_match(&id);
+    assert_eq!(m.winner, Some(Winner::Player2));
+}

--- a/contracts/escrow/src/types.rs
+++ b/contracts/escrow/src/types.rs
@@ -39,6 +39,7 @@ pub struct Match {
     pub player2_deposited: bool,
     pub created_ledger: u32,
     pub completed_ledger: Option<u32>,
+    pub winner: Option<Winner>,
 }
 
 #[contracttype]


### PR DESCRIPTION
## What was implemented                                                                                                                          
  `types.rs` — added winner: Option<Winner> to Match                                                                                                                
                                                                                                                                                                    
  `lib.rs` — two spots:                                                                                                                                             
                                                                                                                                                                    
  - create_match: initializes winner: None                                                                                                                          
  - submit_result: sets m.winner = Some(winner.clone()) before writing back to storage (.clone() needed because winner is already moved into the match payout       
  expression above it)                                                                                                                                              
                                                                                                                                                                    
  `tests.rs` — test_get_match_returns_winner_after_payout: creates a match, both players deposit, oracle submits Winner::Player2, then asserts get_match returns    
  winner == Some(Winner::Player2)           

closes #367 