### PR TITLE
fix: add checked_mul guard in submit_result to prevent overflow

### DIFF
--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -251,7 +251,7 @@ impl EscrowContract {
         }
 
         let client = token::Client::new(&env, &m.token);
-        let pot = m.stake_amount * 2;
+        let pot = m.stake_amount.checked_mul(2).ok_or(Error::Overflow)?;
 
         match winner {
             Winner::Player1 => client.transfer(&env.current_contract_address(), &m.player1, &pot),

--- a/contracts/escrow/src/tests.rs
+++ b/contracts/escrow/src/tests.rs
@@ -1810,3 +1810,15 @@ fn test_submit_result_overflow_on_extreme_stake() {
     let result = client.try_submit_result(&id, &Winner::Player1);
     assert_eq!(result, Err(Ok(Error::Overflow)));
 }
+
+#[test]
+fn test_submit_result_uninitialized_returns_unauthorized() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(EscrowContract, ());
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let result = client.try_submit_result(&0, &Winner::Player1);
+    assert_eq!(result, Err(Ok(Error::Unauthorized)));
+}

--- a/contracts/escrow/src/tests.rs
+++ b/contracts/escrow/src/tests.rs
@@ -7,7 +7,7 @@ use soroban_sdk::{
     vec, Address, Env, IntoVal, String, Symbol, TryFromVal,
 };
 
-fn setup() -> (Env, Addreshttps://github.com/StellarCheckMate/Checkmate-Escrow/pull/470/conflict?name=contracts%252Fescrow%252Fsrc%252Ftests.rs&ancestor_oid=b5690b23824639cbb4551d781cfa3c403880c19a&base_oid=4c2e0c6879a5f69510d06e9adb08d1e31af26aae&head_oid=c8364e1ffa359f4bb02fbb9297940c84171057bas, Address, Address, Address, Address, Address) {
+fn setup() -> (Env, Address, Address, Address, Address, Address, Address) {
     let env = Env::default();
     env.mock_all_auths();
 
@@ -1779,4 +1779,34 @@ fn test_transfer_admin_success_and_old_admin_rejected() {
         matches!(result, Err(Err(_)) | Err(Ok(Error::Unauthorized))),
         "old admin should be rejected after transfer"
     );
+}
+
+#[test]
+fn test_submit_result_overflow_on_extreme_stake() {
+    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    // Create a match with a normal stake, then directly overwrite the stake_amount
+    // in storage to i128::MAX so that stake_amount * 2 overflows — bypassing the
+    // token layer which would also overflow on deposit.
+    let id = client.create_match(
+        &player1,
+        &player2,
+        &100,
+        &token,
+        &String::from_str(&env, "overflow_game"),
+        &Platform::Lichess,
+    );
+
+    env.as_contract(&contract_id, || {
+        let mut m: Match = env.storage().persistent().get(&DataKey::Match(id)).unwrap();
+        m.stake_amount = i128::MAX;
+        m.state = MatchState::Active;
+        m.player1_deposited = true;
+        m.player2_deposited = true;
+        env.storage().persistent().set(&DataKey::Match(id), &m);
+    });
+
+    let result = client.try_submit_result(&id, &Winner::Player1);
+    assert_eq!(result, Err(Ok(Error::Overflow)));
 }


### PR DESCRIPTION
closes #404
- Replace stake_amount * 2 with checked_mul(2).ok_or(Error::Overflow)?
- Also fix pre-existing corrupted line in tests.rs (GitHub URL in fn signature)
- Add test_submit_result_overflow_on_extreme_stake: injects i128::MAX stake directly into storage and asserts Error::Overflow is returned