### PR TITLE
docs: add doc comments to error variants and # Errors sections to functions

### DIFF
--- a/contracts/escrow/src/errors.rs
+++ b/contracts/escrow/src/errors.rs
@@ -3,17 +3,49 @@ use soroban_sdk::contracterror;
 #[contracterror]
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum Error {
+    /// (1) No match exists for the given `match_id`.
     MatchNotFound = 1,
+
+    /// (2) The calling player has already deposited their stake for this match.
     AlreadyFunded = 2,
+
+    /// (3) `submit_result` was called before both players have deposited.
     NotFunded = 3,
+
+    /// (4) The caller is not authorised to perform this action (not a player,
+    /// not the admin, or not the oracle).
     Unauthorized = 4,
+
+    /// (5) The match is not in the required state for this operation
+    /// (e.g. trying to deposit into an Active match, or expire a Completed one).
     InvalidState = 5,
+
+    /// (6) A match with this ID already exists in storage.
     AlreadyExists = 6,
+
+    /// (7) `initialize` has already been called; the contract cannot be
+    /// re-initialized.
     AlreadyInitialized = 7,
+
+    /// (8) An arithmetic operation would overflow. Currently guards the
+    /// internal match-ID counter.
     Overflow = 8,
+
+    /// (9) The contract is paused. `create_match`, `deposit`, and
+    /// `submit_result` are blocked until an admin calls `unpause`.
     ContractPaused = 9,
+
+    /// (10) `stake_amount` is zero or negative.
     InvalidAmount = 10,
+
+    /// (11) `cancel_match` was called on a match that is no longer Pending
+    /// (i.e. it is Active, Completed, or already Cancelled).
     MatchAlreadyActive = 11,
+
+    /// (12) `expire_match` was called before the match timeout has elapsed.
     MatchNotExpired = 12,
+
+    /// (13) The supplied address is invalid for the context — e.g. passing the
+    /// escrow contract's own address as the oracle during `initialize`.
     InvalidAddress = 13,
 }

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -24,6 +24,9 @@ impl EscrowContract {
     /// address. It must not be the escrow contract's own address — passing the
     /// contract's own address would allow anyone to satisfy `oracle.require_auth()`
     /// trivially, permanently compromising result submission.
+    ///
+    /// # Errors
+    /// - [`Error::InvalidAddress`] — `oracle` is the escrow contract's own address.
     pub fn initialize(env: Env, oracle: Address, admin: Address) -> Result<(), Error> {
         if env.storage().instance().has(&DataKey::Oracle) {
             panic!("Contract already initialized");
@@ -41,6 +44,9 @@ impl EscrowContract {
     }
 
     /// Pause the contract — admin only. Blocks create_match, deposit, and submit_result.
+    ///
+    /// # Errors
+    /// - [`Error::Unauthorized`] — caller is not the admin.
     pub fn pause(env: Env) -> Result<(), Error> {
         let admin: Address = env
             .storage()
@@ -53,6 +59,9 @@ impl EscrowContract {
     }
 
     /// Unpause the contract — admin only.
+    ///
+    /// # Errors
+    /// - [`Error::Unauthorized`] — caller is not the admin.
     pub fn unpause(env: Env) -> Result<(), Error> {
         let admin: Address = env
             .storage()
@@ -67,6 +76,9 @@ impl EscrowContract {
     }
 
     /// Rotate the oracle address. Requires authorization from the admin.
+    ///
+    /// # Errors
+    /// - [`Error::Unauthorized`] — caller is not the admin.
     pub fn update_oracle(env: Env, new_oracle: Address) -> Result<(), Error> {
         let current_oracle: Address = env
             .storage()
@@ -92,6 +104,12 @@ impl EscrowContract {
     }
 
     /// Create a new match. Both players must call `deposit` before the game starts.
+    ///
+    /// # Errors
+    /// - [`Error::ContractPaused`] — contract is paused.
+    /// - [`Error::InvalidAmount`] — `stake_amount` is zero or negative.
+    /// - [`Error::AlreadyExists`] — a match with the derived ID already exists.
+    /// - [`Error::Overflow`] — the internal match-ID counter would overflow.
     pub fn create_match(
         env: Env,
         player1: Address,
@@ -159,6 +177,13 @@ impl EscrowContract {
     }
 
     /// Player deposits their stake into escrow.
+    ///
+    /// # Errors
+    /// - [`Error::ContractPaused`] — contract is paused.
+    /// - [`Error::MatchNotFound`] — no match exists for `match_id`.
+    /// - [`Error::InvalidState`] — match is not in `Pending` state.
+    /// - [`Error::Unauthorized`] — `player` is not player1 or player2.
+    /// - [`Error::AlreadyFunded`] — `player` has already deposited.
     pub fn deposit(env: Env, match_id: u64, player: Address) -> Result<(), Error> {
         player.require_auth();
 
@@ -219,6 +244,13 @@ impl EscrowContract {
     }
 
     /// Oracle submits the verified match result and triggers payout.
+    ///
+    /// # Errors
+    /// - [`Error::Unauthorized`] — caller is not the oracle.
+    /// - [`Error::ContractPaused`] — contract is paused.
+    /// - [`Error::MatchNotFound`] — no match exists for `match_id`.
+    /// - [`Error::NotFunded`] — one or both players have not deposited.
+    /// - [`Error::InvalidState`] — match is not in `Active` state.
     pub fn submit_result(env: Env, match_id: u64, winner: Winner) -> Result<(), Error> {
         let oracle: Address = env
             .storage()
@@ -281,6 +313,11 @@ impl EscrowContract {
 
     /// Cancel a pending match and refund any deposits.
     /// Either player can cancel a pending match.
+    ///
+    /// # Errors
+    /// - [`Error::MatchNotFound`] — no match exists for `match_id`.
+    /// - [`Error::MatchAlreadyActive`] — match is no longer in `Pending` state.
+    /// - [`Error::Unauthorized`] — `caller` is not player1 or player2.
     pub fn cancel_match(env: Env, match_id: u64, caller: Address) -> Result<(), Error> {
         let mut m: Match = env
             .storage()
@@ -330,6 +367,9 @@ impl EscrowContract {
     }
 
     /// Read a match by ID.
+    ///
+    /// # Errors
+    /// - [`Error::MatchNotFound`] — no match exists for `match_id`.
     pub fn get_match(env: Env, match_id: u64) -> Result<Match, Error> {
         env.storage()
             .persistent()
@@ -338,6 +378,9 @@ impl EscrowContract {
     }
 
     /// Check whether both players have deposited.
+    ///
+    /// # Errors
+    /// - [`Error::MatchNotFound`] — no match exists for `match_id`.
     pub fn is_funded(env: Env, match_id: u64) -> Result<bool, Error> {
         let m: Match = env
             .storage()
@@ -353,6 +396,9 @@ impl EscrowContract {
     }
 
     /// Return the oracle address set at initialization.
+    ///
+    /// # Errors
+    /// - [`Error::Unauthorized`] — contract has not been initialized.
     pub fn get_oracle(env: Env) -> Result<Address, Error> {
         env.storage()
             .instance()
@@ -361,6 +407,9 @@ impl EscrowContract {
     }
 
     /// Return the total escrowed balance for a match (0, 1x, or 2x stake).
+    ///
+    /// # Errors
+    /// - [`Error::MatchNotFound`] — no match exists for `match_id`.
     pub fn get_escrow_balance(env: Env, match_id: u64) -> Result<i128, Error> {
         let m: Match = env
             .storage()
@@ -376,6 +425,11 @@ impl EscrowContract {
 
     /// Cancel a Pending match that has exceeded the configurable ledger timeout,
     /// refunding any deposited stakes. Anyone may call this once the timeout elapses.
+    ///
+    /// # Errors
+    /// - [`Error::MatchNotFound`] — no match exists for `match_id`.
+    /// - [`Error::InvalidState`] — match is not in `Pending` state.
+    /// - [`Error::MatchNotExpired`] — the timeout period has not yet elapsed.
     pub fn expire_match(env: Env, match_id: u64) -> Result<(), Error> {
         let mut m: Match = env
             .storage()
@@ -429,6 +483,9 @@ impl EscrowContract {
     }
 
     /// Transfer admin rights to a new address. Requires current admin auth.
+    ///
+    /// # Errors
+    /// - [`Error::Unauthorized`] — caller is not the current admin.
     pub fn transfer_admin(env: Env, new_admin: Address) -> Result<(), Error> {
         let current_admin: Address = env
             .storage()
@@ -449,6 +506,9 @@ impl EscrowContract {
     }
 
     /// Return the admin address set at initialization.
+    ///
+    /// # Errors
+    /// - [`Error::Unauthorized`] — contract has not been initialized.
     pub fn get_admin(env: Env) -> Result<Address, Error> {
         env.storage()
             .instance()

--- a/contracts/oracle/src/errors.rs
+++ b/contracts/oracle/src/errors.rs
@@ -3,9 +3,24 @@ use soroban_sdk::contracterror;
 #[contracterror]
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum Error {
+    /// (1) The contract has not been initialized, or the caller is not the
+    /// stored admin.
     Unauthorized = 1,
+
+    /// (2) A result for this `match_id` has already been submitted.
+    /// Each match may only have one result recorded.
     AlreadySubmitted = 2,
+
+    /// (3) No result has been stored for the given `match_id`.
+    /// Returned by `get_result` when the match ID is unknown or the entry
+    /// has expired.
     ResultNotFound = 3,
+
+    /// (4) `initialize` has already been called; the contract cannot be
+    /// re-initialized.
     AlreadyInitialized = 4,
+
+    /// (5) The contract is paused. `submit_result` is blocked until an admin
+    /// calls `unpause`.
     ContractPaused = 5,
 }

--- a/contracts/oracle/src/lib.rs
+++ b/contracts/oracle/src/lib.rs
@@ -27,6 +27,11 @@ impl OracleContract {
 
     /// Admin submits a verified match result on-chain.
     /// Invariant: No results can be submitted while the contract is paused.
+    ///
+    /// # Errors
+    /// - [`Error::ContractPaused`] — contract is paused.
+    /// - [`Error::Unauthorized`] — contract has not been initialized or caller is not the admin.
+    /// - [`Error::AlreadySubmitted`] — a result for `match_id` has already been recorded.
     pub fn submit_result(
         env: Env,
         match_id: u64,
@@ -73,6 +78,9 @@ impl OracleContract {
     /// Retrieve the stored result for a match.
     /// TTL is extended on every read to prevent active results from expiring.
     /// Without this, frequently-accessed results could expire and return ResultNotFound.
+    ///
+    /// # Errors
+    /// - [`Error::ResultNotFound`] — no result has been submitted for `match_id`, or the entry has expired.
     pub fn get_result(env: Env, match_id: u64) -> Result<ResultEntry, Error> {
         let result = env
             .storage()
@@ -115,6 +123,9 @@ impl OracleContract {
     }
 
     /// Rotate the admin to a new address. Requires current admin auth.
+    ///
+    /// # Errors
+    /// - [`Error::Unauthorized`] — contract has not been initialized or caller is not the current admin.
     pub fn update_admin(env: Env, new_admin: Address) -> Result<(), Error> {
         let current_admin: Address = env
             .storage()
@@ -127,6 +138,9 @@ impl OracleContract {
     }
 
     /// Pause the oracle — admin only. Blocks submit_result while paused.
+    ///
+    /// # Errors
+    /// - [`Error::Unauthorized`] — contract has not been initialized or caller is not the admin.
     pub fn pause(env: Env) -> Result<(), Error> {
         let admin: Address = env
             .storage()
@@ -139,6 +153,9 @@ impl OracleContract {
     }
 
     /// Unpause the oracle — admin only. Does not emit an event.
+    ///
+    /// # Errors
+    /// - [`Error::Unauthorized`] — contract has not been initialized or caller is not the admin.
     pub fn unpause(env: Env) -> Result<(), Error> {
         let admin: Address = env
             .storage()


### PR DESCRIPTION
Closes #374

---

## Summary

Addresses the missing documentation for error codes in both contracts.

### Changes

**`contracts/escrow/src/errors.rs`**
- Added doc comments to all 13 error variants explaining the error code, meaning, and when it is returned

**`contracts/oracle/src/errors.rs`**
- Added doc comments to all 5 error variants explaining the error code, meaning, and when it is returned

**`contracts/escrow/src/lib.rs`**
- Added `# Errors` sections to all public functions that return `Result<_, Error>`

**`contracts/oracle/src/lib.rs`**
- Added `# Errors` sections to `submit_result`, `get_result`, `update_admin`, `pause`, and `unpause`