### PR TITLE
feat(escrow): implement two-step admin transfer (propose/accept)

### DIFF
--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -449,6 +449,32 @@ impl EscrowContract {
         Ok(())
     }
 
+    /// Propose a new admin. Current admin must authorize. Transfer is not
+    /// complete until the nominee calls `accept_admin`.
+    pub fn propose_admin(env: Env, new_admin: Address) -> Result<(), Error> {
+        let current_admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(Error::Unauthorized)?;
+        current_admin.require_auth();
+        env.storage().instance().set(&DataKey::PendingAdmin, &new_admin);
+        Ok(())
+    }
+
+    /// Accept a pending admin proposal. Must be called by the proposed address.
+    pub fn accept_admin(env: Env) -> Result<(), Error> {
+        let pending: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::PendingAdmin)
+            .ok_or(Error::Unauthorized)?;
+        pending.require_auth();
+        env.storage().instance().set(&DataKey::Admin, &pending);
+        env.storage().instance().remove(&DataKey::PendingAdmin);
+        Ok(())
+    }
+
     /// Return the admin address set at initialization.
     pub fn get_admin(env: Env) -> Result<Address, Error> {
         env.storage()

--- a/contracts/escrow/src/tests.rs
+++ b/contracts/escrow/src/tests.rs
@@ -7,7 +7,7 @@ use soroban_sdk::{
     vec, Address, Env, IntoVal, String, Symbol, TryFromVal,
 };
 
-fn setup() -> (Env, Addreshttps://github.com/StellarCheckMate/Checkmate-Escrow/pull/470/conflict?name=contracts%252Fescrow%252Fsrc%252Ftests.rs&ancestor_oid=b5690b23824639cbb4551d781cfa3c403880c19a&base_oid=4c2e0c6879a5f69510d06e9adb08d1e31af26aae&head_oid=c8364e1ffa359f4bb02fbb9297940c84171057bas, Address, Address, Address, Address, Address) {
+fn setup() -> (Env, Address, Address, Address, Address, Address, Address) {
     let env = Env::default();
     env.mock_all_auths();
 
@@ -1779,4 +1779,25 @@ fn test_transfer_admin_success_and_old_admin_rejected() {
         matches!(result, Err(Err(_)) | Err(Ok(Error::Unauthorized))),
         "old admin should be rejected after transfer"
     );
+}
+
+#[test]
+fn test_two_step_admin_transfer() {
+    let (env, contract_id, _oracle, _p1, _p2, _token, admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let new_admin = Address::generate(&env);
+
+    // Step 1: propose — old admin is still active
+    client.propose_admin(&new_admin);
+    assert_eq!(client.get_admin(), admin);
+
+    // Step 2: accept — new admin takes over
+    client.accept_admin();
+    assert_eq!(client.get_admin(), new_admin);
+
+    // Old admin is now rejected — clear mocks so auth is enforced
+    env.set_auths(&[]);
+    let result = client.try_propose_admin(&admin);
+    assert!(result.is_err());
 }

--- a/contracts/escrow/src/types.rs
+++ b/contracts/escrow/src/types.rs
@@ -47,6 +47,7 @@ pub enum DataKey {
     MatchCount,
     Oracle,
     Admin,
+    PendingAdmin,
     Paused,
     GameId(String),
     MatchTimeout,


### PR DESCRIPTION
closes #438
- Body: Two-step pattern — propose_admin stores a PendingAdmin, accept_admin atomically promotes it and clears the pending slot. Includes test covering the full flow and 
verifying the old admin is rejected post-transfer.