### PR TITLE
test: verify old admin rejected and new admin accepted on pause() after transfer_admin

### DIFF
--- a/contracts/escrow/src/tests.rs
+++ b/contracts/escrow/src/tests.rs
@@ -1780,3 +1780,40 @@ fn test_transfer_admin_success_and_old_admin_rejected() {
         "old admin should be rejected after transfer"
     );
 }
+
+#[test]
+fn test_transfer_admin_pause_auth() {
+    let (env, contract_id, _oracle, _player1, _player2, _token, admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let new_admin = Address::generate(&env);
+
+    // Transfer admin to new_admin (mock_all_auths is active from setup)
+    client.transfer_admin(&new_admin);
+    assert_eq!(client.get_admin(), new_admin);
+
+    // Old admin tries to pause — must fail
+    env.mock_auths(&[MockAuth {
+        address: &admin,
+        invoke: &MockAuthInvoke {
+            contract: &contract_id,
+            fn_name: "pause",
+            args: ().into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+    let result = client.try_pause();
+    assert!(result.is_err(), "old admin should be rejected from pause after transfer");
+
+    // New admin pauses — must succeed
+    env.mock_auths(&[MockAuth {
+        address: &new_admin,
+        invoke: &MockAuthInvoke {
+            contract: &contract_id,
+            fn_name: "pause",
+            args: ().into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+    client.pause();
+}


### PR DESCRIPTION
Closes #432

---

## Summary

Adds `test_transfer_admin_pause_auth` to the escrow contract test suite.

## What this test does

1. Transfers admin rights to `new_admin` via `transfer_admin`
2. Attempts to call `pause()` from the **old admin** — asserts auth failure
3. Calls `pause()` from the **new admin** — asserts success

## Why

The existing `test_transfer_admin_success_and_old_admin_rejected` test only verifies that the old admin can no longer call `transfer_admin` itself. This test closes the gap by confirming that admin-gated functions (specifically `pause()`) correctly enforce the updated admin after a transfer — ensuring no privilege escalation or stale-auth bypass is possible.

## Related

Closes the issue: _If transfer_admin is implemented on the escrow contract, verify old admin is rejected and new admin is accepted._