### PR TITLE
chore: note Chess.com API key is for future v1.1 release

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,7 @@ CONTRACT_ESCROW=
 CONTRACT_ORACLE=
 
 LICHESS_API_TOKEN=
+# Chess.com Oracle is planned for v1.1 and not yet implemented
 CHESSDOTCOM_API_KEY=
 
 VITE_STELLAR_NETWORK=testnet


### PR DESCRIPTION
Added a comment above CHESSDOTCOM_API_KEY in .env.example

closes #392 