### PR TITLE
Docs/environments toml comments

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,7 @@ CONTRACT_ESCROW=
 CONTRACT_ORACLE=
 
 LICHESS_API_TOKEN=
+# Chess.com Oracle is planned for v1.1 and not yet implemented
 CHESSDOTCOM_API_KEY=
 
 VITE_STELLAR_NETWORK=testnet

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,5 +1,16 @@
 # Deployment Sequence
 
+## Network Configuration
+
+Network environments are defined in [`environments.toml`](../environments.toml) at the project root. Each named section maps to a `--network` value used by the Stellar/Soroban CLI.
+
+Available networks: `testnet`, `mainnet`, `futurenet`, `standalone`.
+
+To target a specific network, pass `--network <name>` to any `stellar contract` command. To add a custom network, append a new `[section]` with `rpc_url` and `network_passphrase` fields — see the comments in `environments.toml` for details.
+
+---
+
+
 This document describes the required deployment order and initialization steps
 for the Checkmate Escrow smart contracts.
 

--- a/environments.toml
+++ b/environments.toml
@@ -1,3 +1,15 @@
+# Network environment configurations for Stellar CLI / Soroban CLI.
+# Each section corresponds to a named network passed via --network <name>.
+#
+# Fields:
+#   rpc_url           - Soroban RPC endpoint for the network
+#   network_passphrase - Unique string identifying the network; must match exactly
+#
+# To add a custom network, append a new section:
+#   [my_network]
+#   rpc_url = "https://my-rpc-endpoint"
+#   network_passphrase = "My Custom Network ; YYYY"
+
 [testnet]
 rpc_url = "https://soroban-testnet.stellar.org"
 network_passphrase = "Test SDF Network ; September 2015"
@@ -11,5 +23,6 @@ rpc_url = "https://rpc-futurenet.stellar.org"
 network_passphrase = "Test SDF Future Network ; October 2022"
 
 [standalone]
+# Local development node — start with `stellar network start local`
 rpc_url = "http://localhost:8000/soroban/rpc"
 network_passphrase = "Standalone Network ; February 2017"


### PR DESCRIPTION
closes #407 

Here's what changed:                                                                         
                                                                                                     
  - environments.toml — added a header comment block explaining the file purpose, each field, and how
  to add a custom network; plus an inline comment on the standalone entry.                           
  - docs/deployment.md — added a "Network Configuration" section at the top referencing              
  environments.toml, listing available networks, and pointing readers to the file for custom network 
  setup.                         