### PR TITLE
Feat/self match guard

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,7 @@ CONTRACT_ESCROW=
 CONTRACT_ORACLE=
 
 LICHESS_API_TOKEN=
+# Chess.com Oracle is planned for v1.1 and not yet implemented
 CHESSDOTCOM_API_KEY=
 
 VITE_STELLAR_NETWORK=testnet

--- a/contracts/escrow/src/errors.rs
+++ b/contracts/escrow/src/errors.rs
@@ -16,4 +16,5 @@ pub enum Error {
     MatchAlreadyActive = 11,
     MatchNotExpired = 12,
     InvalidAddress = 13,
+    InvalidPlayers = 14,
 }

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -103,6 +103,10 @@ impl EscrowContract {
     ) -> Result<u64, Error> {
         player1.require_auth();
 
+        if player1 == player2 {
+            return Err(Error::InvalidPlayers);
+        }
+
         if env
             .storage()
             .instance()

--- a/contracts/escrow/src/tests.rs
+++ b/contracts/escrow/src/tests.rs
@@ -1780,3 +1780,19 @@ fn test_transfer_admin_success_and_old_admin_rejected() {
         "old admin should be rejected after transfer"
     );
 }
+
+#[test]
+fn test_create_match_rejects_same_player_as_both_sides() {
+    let (env, contract_id, _oracle, player1, _player2, token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let result = client.try_create_match(
+        &player1,
+        &player1,
+        &100,
+        &token,
+        &String::from_str(&env, "self_match"),
+        &Platform::Lichess,
+    );
+    assert_eq!(result, Err(Ok(Error::InvalidPlayers)));
+}

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,5 +1,16 @@
 # Deployment Sequence
 
+## Network Configuration
+
+Network environments are defined in [`environments.toml`](../environments.toml) at the project root. Each named section maps to a `--network` value used by the Stellar/Soroban CLI.
+
+Available networks: `testnet`, `mainnet`, `futurenet`, `standalone`.
+
+To target a specific network, pass `--network <name>` to any `stellar contract` command. To add a custom network, append a new `[section]` with `rpc_url` and `network_passphrase` fields — see the comments in `environments.toml` for details.
+
+---
+
+
 This document describes the required deployment order and initialization steps
 for the Checkmate Escrow smart contracts.
 

--- a/environments.toml
+++ b/environments.toml
@@ -1,3 +1,15 @@
+# Network environment configurations for Stellar CLI / Soroban CLI.
+# Each section corresponds to a named network passed via --network <name>.
+#
+# Fields:
+#   rpc_url           - Soroban RPC endpoint for the network
+#   network_passphrase - Unique string identifying the network; must match exactly
+#
+# To add a custom network, append a new section:
+#   [my_network]
+#   rpc_url = "https://my-rpc-endpoint"
+#   network_passphrase = "My Custom Network ; YYYY"
+
 [testnet]
 rpc_url = "https://soroban-testnet.stellar.org"
 network_passphrase = "Test SDF Network ; September 2015"
@@ -11,5 +23,6 @@ rpc_url = "https://rpc-futurenet.stellar.org"
 network_passphrase = "Test SDF Future Network ; October 2022"
 
 [standalone]
+# Local development node — start with `stellar network start local`
 rpc_url = "http://localhost:8000/soroban/rpc"
 network_passphrase = "Standalone Network ; February 2017"


### PR DESCRIPTION
All three changes are in place:                                                                    
                                                                                                     
  - errors.rs — added InvalidPlayers = 14                                                            
  - lib.rs — guard added at the top of create_match, before any storage reads:                       
                                                                                                     
    if player1 == player2 {                                                                          
        return Err(Error::InvalidPlayers);                                                           
    }                                                                                                
                                                                                                     
  - tests.rs — test_create_match_rejects_same_player_as_both_sides calls try_create_match with       
  player1 as both arguments and asserts Err(Ok(Error::InvalidPlayers))

closes #436 