### PR TITLE
Fix/oracle instance ttl

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,7 @@ CONTRACT_ESCROW=
 CONTRACT_ORACLE=
 
 LICHESS_API_TOKEN=
+# Chess.com Oracle is planned for v1.1 and not yet implemented
 CHESSDOTCOM_API_KEY=
 
 VITE_STELLAR_NETWORK=testnet

--- a/contracts/escrow/src/errors.rs
+++ b/contracts/escrow/src/errors.rs
@@ -16,4 +16,5 @@ pub enum Error {
     MatchAlreadyActive = 11,
     MatchNotExpired = 12,
     InvalidAddress = 13,
+    InvalidPlayers = 14,
 }

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -103,6 +103,10 @@ impl EscrowContract {
     ) -> Result<u64, Error> {
         player1.require_auth();
 
+        if player1 == player2 {
+            return Err(Error::InvalidPlayers);
+        }
+
         if env
             .storage()
             .instance()

--- a/contracts/escrow/src/tests.rs
+++ b/contracts/escrow/src/tests.rs
@@ -1780,3 +1780,19 @@ fn test_transfer_admin_success_and_old_admin_rejected() {
         "old admin should be rejected after transfer"
     );
 }
+
+#[test]
+fn test_create_match_rejects_same_player_as_both_sides() {
+    let (env, contract_id, _oracle, player1, _player2, token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let result = client.try_create_match(
+        &player1,
+        &player1,
+        &100,
+        &token,
+        &String::from_str(&env, "self_match"),
+        &Platform::Lichess,
+    );
+    assert_eq!(result, Err(Ok(Error::InvalidPlayers)));
+}

--- a/contracts/oracle/src/lib.rs
+++ b/contracts/oracle/src/lib.rs
@@ -10,6 +10,13 @@ use types::{DataKey, MatchResult, ResultEntry};
 /// ~30 days at 5s/ledger.
 const MATCH_TTL_LEDGERS: u32 = 518_400;
 
+/// Extend instance storage TTL on every invocation so Admin and Paused never expire.
+fn extend_instance_ttl(env: &Env) {
+    env.storage()
+        .instance()
+        .extend_ttl(MATCH_TTL_LEDGERS / 2, MATCH_TTL_LEDGERS);
+}
+
 #[contract]
 pub struct OracleContract;
 
@@ -17,6 +24,7 @@ pub struct OracleContract;
 impl OracleContract {
     /// Initialize with a trusted admin (the off-chain oracle service).
     pub fn initialize(env: Env, admin: Address) {
+        extend_instance_ttl(&env);
         if env.storage().instance().has(&DataKey::Admin) {
             panic!("Contract already initialized");
         }
@@ -33,6 +41,7 @@ impl OracleContract {
         game_id: String,
         result: MatchResult,
     ) -> Result<(), Error> {
+        extend_instance_ttl(&env);
         // Check if contract is paused first
         if env.storage().instance().get(&DataKey::Paused).unwrap_or(false) {
             return Err(Error::ContractPaused);
@@ -78,6 +87,7 @@ impl OracleContract {
     /// TTL is extended on every read to prevent active results from expiring.
     /// Without this, frequently-accessed results could expire and return ResultNotFound.
     pub fn get_result(env: Env, match_id: u64) -> Result<ResultEntry, Error> {
+        extend_instance_ttl(&env);
         let result = env
             .storage()
             .persistent()
@@ -96,6 +106,7 @@ impl OracleContract {
 
     /// Check whether a result has been submitted for a match.
     pub fn has_result(env: Env, match_id: u64) -> bool {
+        extend_instance_ttl(&env);
         env.storage().persistent().has(&DataKey::Result(match_id))
     }
 
@@ -109,6 +120,7 @@ impl OracleContract {
     /// Returns [`Error::Unauthorized`] if the contract has not been initialised
     /// or if the caller is not the current admin.
     pub fn has_result_admin(env: Env, match_id: u64) -> Result<bool, Error> {
+        extend_instance_ttl(&env);
         let admin: Address = env
             .storage()
             .instance()
@@ -120,6 +132,7 @@ impl OracleContract {
 
     /// Rotate the admin to a new address. Requires current admin auth.
     pub fn update_admin(env: Env, new_admin: Address) -> Result<(), Error> {
+        extend_instance_ttl(&env);
         let current_admin: Address = env
             .storage()
             .instance()
@@ -132,6 +145,7 @@ impl OracleContract {
 
     /// Pause the oracle — admin only. Blocks submit_result while paused.
     pub fn pause(env: Env) -> Result<(), Error> {
+        extend_instance_ttl(&env);
         let admin: Address = env
             .storage()
             .instance()
@@ -144,11 +158,13 @@ impl OracleContract {
 
     /// Returns true if the contract has been initialized.
     pub fn is_initialized(env: Env) -> bool {
+        extend_instance_ttl(&env);
         env.storage().instance().has(&DataKey::Admin)
     }
 
     /// Unpause the oracle — admin only. Does not emit an event.
     pub fn unpause(env: Env) -> Result<(), Error> {
+        extend_instance_ttl(&env);
         let admin: Address = env
             .storage()
             .instance()
@@ -663,5 +679,22 @@ mod tests {
 
         let entry = client.get_result(&0u64);
         assert_eq!(entry.game_id, String::from_str(&env, "chess_game_42"));
+    }
+
+    #[test]
+    fn test_instance_ttl_extended_on_submit_result() {
+        let (env, contract_id, ..) = setup();
+        let client = OracleContractClient::new(&env, &contract_id);
+
+        client.submit_result(
+            &0u64,
+            &String::from_str(&env, "ttl_game"),
+            &MatchResult::Player1Wins,
+        );
+
+        let ttl = env.as_contract(&contract_id, || {
+            env.storage().instance().get_ttl()
+        });
+        assert_eq!(ttl, crate::MATCH_TTL_LEDGERS);
     }
 }

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,5 +1,16 @@
 # Deployment Sequence
 
+## Network Configuration
+
+Network environments are defined in [`environments.toml`](../environments.toml) at the project root. Each named section maps to a `--network` value used by the Stellar/Soroban CLI.
+
+Available networks: `testnet`, `mainnet`, `futurenet`, `standalone`.
+
+To target a specific network, pass `--network <name>` to any `stellar contract` command. To add a custom network, append a new `[section]` with `rpc_url` and `network_passphrase` fields — see the comments in `environments.toml` for details.
+
+---
+
+
 This document describes the required deployment order and initialization steps
 for the Checkmate Escrow smart contracts.
 

--- a/environments.toml
+++ b/environments.toml
@@ -1,3 +1,15 @@
+# Network environment configurations for Stellar CLI / Soroban CLI.
+# Each section corresponds to a named network passed via --network <name>.
+#
+# Fields:
+#   rpc_url           - Soroban RPC endpoint for the network
+#   network_passphrase - Unique string identifying the network; must match exactly
+#
+# To add a custom network, append a new section:
+#   [my_network]
+#   rpc_url = "https://my-rpc-endpoint"
+#   network_passphrase = "My Custom Network ; YYYY"
+
 [testnet]
 rpc_url = "https://soroban-testnet.stellar.org"
 network_passphrase = "Test SDF Network ; September 2015"
@@ -11,5 +23,6 @@ rpc_url = "https://rpc-futurenet.stellar.org"
 network_passphrase = "Test SDF Future Network ; October 2022"
 
 [standalone]
+# Local development node — start with `stellar network start local`
 rpc_url = "http://localhost:8000/soroban/rpc"
 network_passphrase = "Standalone Network ; February 2017"


### PR DESCRIPTION
Fix:                                                                                               
                                                                                                     
  - Added a private extend_instance_ttl helper (threshold: 15 days, extend-to: 30 days — same        
  MATCH_TTL_LEDGERS constant already in use)                                                         
  - Called it at the top of all 8 public functions: initialize, submit_result, get_result,           
  has_result, has_result_admin, update_admin, pause, is_initialized, unpause                         
                                                                                                     
  Test: test_instance_ttl_extended_on_submit_result — calls submit_result then reads                 
  instance().get_ttl() and asserts it equals MATCH_TTL_LEDGERS

closes #412 