### PR TITLE
Fix/update oracle self address check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,9 +136,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.57"
+version = "1.2.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
+checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -483,9 +483,9 @@ dependencies = [
 
 [[package]]
 name = "ethnum"
-version = "1.5.2"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca81e6b4777c89fd810c25a4be2b1bd93ea034fbe58e6a75216a34c6b82c539b"
+checksum = "40404c3f5f511ec4da6fe866ddf6a717c309fdbb69fbbad7b0f3edab8f2e835f"
 
 [[package]]
 name = "ff"
@@ -593,18 +593,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.5"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-dependencies = [
- "foldhash",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "heck"
@@ -685,12 +676,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
@@ -712,15 +703,15 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.91"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -755,9 +746,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libm"
@@ -798,9 +789,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "num-derive"
@@ -964,9 +955,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha",
@@ -1127,9 +1118,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -1184,7 +1175,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "schemars 0.9.0",
  "schemars 1.2.1",
  "serde_core",
@@ -1218,9 +1209,9 @@ dependencies = [
 
 [[package]]
 name = "sha3"
-version = "0.10.8"
+version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
+checksum = "77fd7028345d415a4034cf8777cd4f8ab1851274233b45f84e3d955502d93874"
 dependencies = [
  "digest",
  "keccak",
@@ -1309,7 +1300,7 @@ dependencies = [
  "num-integer",
  "num-traits",
  "p256",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rand_chacha",
  "sec1",
  "sha2",
@@ -1362,7 +1353,7 @@ dependencies = [
  "ctor",
  "derive_arbitrary",
  "ed25519-dalek",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rustc_version",
  "serde",
  "serde_json",
@@ -1559,9 +1550,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "unicode-ident"
@@ -1607,9 +1598,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.114"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1620,9 +1611,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.114"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1630,9 +1621,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.114"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -1643,9 +1634,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.114"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
 ]
@@ -1667,7 +1658,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "wasm-encoder",
  "wasmparser 0.244.0",
 ]
@@ -1696,7 +1687,7 @@ version = "0.116.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a58e28b80dd8340cb07b8242ae654756161f6fc8d0038123d679b7b99964fa50"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "semver",
 ]
 
@@ -1708,7 +1699,7 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags",
  "hashbrown 0.15.5",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "semver",
 ]
 
@@ -1814,7 +1805,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "prettyplease",
  "syn",
  "wasm-metadata",
@@ -1845,7 +1836,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "log",
  "serde",
  "serde_derive",
@@ -1864,7 +1855,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "log",
  "semver",
  "serde",
@@ -1876,18 +1867,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.42"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2578b716f8a7a858b7f02d5bd870c14bf4ddbbcf3a4c05414ba6503640505e3"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.42"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e6cc098ea4d3bd6246687de65af3f920c430e236bee1e3bf2e441463f08a02f"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -86,6 +86,7 @@ impl EscrowContract {
     ///
     /// # Errors
     /// - [`Error::Unauthorized`] — caller is not the admin.
+    /// - [`Error::InvalidAddress`] — `new_oracle` is the escrow contract's own address.
     pub fn update_oracle(env: Env, new_oracle: Address) -> Result<(), Error> {
         let current_oracle: Address = env
             .storage()
@@ -99,6 +100,10 @@ impl EscrowContract {
             .ok_or(Error::Unauthorized)?;
 
         admin.require_auth();
+
+        if new_oracle == env.current_contract_address() {
+            return Err(Error::InvalidAddress);
+        }
 
         env.storage().instance().set(&DataKey::Oracle, &new_oracle);
 

--- a/contracts/escrow/src/tests.rs
+++ b/contracts/escrow/src/tests.rs
@@ -905,6 +905,15 @@ fn test_admin_can_rotate_oracle() {
 }
 
 #[test]
+fn test_update_oracle_rejects_self_address() {
+    let (env, contract_id, _oracle, _player1, _player2, _token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let result = client.try_update_oracle(&contract_id);
+    assert_eq!(result, Err(Ok(Error::InvalidAddress)));
+}
+
+#[test]
 fn test_old_oracle_rejected_after_rotation() {
     let (env, contract_id, oracle, player1, player2, token, _admin) = setup();
     let client = EscrowContractClient::new(&env, &contract_id);
@@ -1899,7 +1908,10 @@ fn test_is_funded_returns_true_after_payout() {
     client.deposit(&id, &player2);
 
     // Both deposited — match is Active, is_funded must be true
-    assert!(client.is_funded(&id), "is_funded must be true when both players have deposited");
+    assert!(
+        client.is_funded(&id),
+        "is_funded must be true when both players have deposited"
+    );
     assert_eq!(client.get_match(&id).state, MatchState::Active);
 
     // Complete the match
@@ -1944,7 +1956,11 @@ fn test_get_escrow_balance_zero_for_completed_match() {
     // Fund both players
     client.deposit(&id, &player1);
     client.deposit(&id, &player2);
-    assert_eq!(client.get_escrow_balance(&id), 200, "escrow balance must be 2x stake while Active");
+    assert_eq!(
+        client.get_escrow_balance(&id),
+        200,
+        "escrow balance must be 2x stake while Active"
+    );
 
     // Complete the match — payout transfers funds out
     client.submit_result(&id, &Winner::Player2);
@@ -1978,7 +1994,11 @@ fn test_get_escrow_balance_zero_for_cancelled_match_no_deposits() {
     );
 
     // No deposits made — cancel immediately
-    assert_eq!(client.get_escrow_balance(&id), 0, "escrow balance must be 0 before any deposits");
+    assert_eq!(
+        client.get_escrow_balance(&id),
+        0,
+        "escrow balance must be 0 before any deposits"
+    );
     client.cancel_match(&id, &player1);
     assert_eq!(client.get_match(&id).state, MatchState::Cancelled);
 
@@ -2139,8 +2159,11 @@ fn test_get_match_returns_cancelled_after_expire_match() {
 
     // Extend TTLs so storage survives the ledger jump
     for addr in [&contract_id, &token] {
-        env.deployer()
-            .extend_ttl_for_contract_instance(addr.clone(), MATCH_TTL_LEDGERS, MATCH_TTL_LEDGERS);
+        env.deployer().extend_ttl_for_contract_instance(
+            addr.clone(),
+            MATCH_TTL_LEDGERS,
+            MATCH_TTL_LEDGERS,
+        );
         env.deployer()
             .extend_ttl_for_code(addr.clone(), MATCH_TTL_LEDGERS, MATCH_TTL_LEDGERS);
     }
@@ -2149,8 +2172,11 @@ fn test_get_match_returns_cancelled_after_expire_match() {
     env.ledger().set_sequence_number(100 + 17_280);
 
     for addr in [&contract_id, &token] {
-        env.deployer()
-            .extend_ttl_for_contract_instance(addr.clone(), MATCH_TTL_LEDGERS, MATCH_TTL_LEDGERS);
+        env.deployer().extend_ttl_for_contract_instance(
+            addr.clone(),
+            MATCH_TTL_LEDGERS,
+            MATCH_TTL_LEDGERS,
+        );
         env.deployer()
             .extend_ttl_for_code(addr.clone(), MATCH_TTL_LEDGERS, MATCH_TTL_LEDGERS);
     }

--- a/contracts/oracle/src/lib.rs
+++ b/contracts/oracle/src/lib.rs
@@ -5,7 +5,7 @@ mod types;
 
 use errors::Error;
 use soroban_sdk::{contract, contractimpl, symbol_short, Address, Env, String, Symbol};
-use types::{DataKey, Winner, ResultEntry};
+use types::{DataKey, ResultEntry, Winner};
 
 /// ~30 days at 5s/ledger.
 const MATCH_TTL_LEDGERS: u32 = 518_400;
@@ -220,7 +220,7 @@ impl OracleContract {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use escrow::types::{MatchState, Platform, Winner};
+    use escrow::types::{MatchState, Platform, Winner as EscrowWinner};
     use escrow::{EscrowContract, EscrowContractClient};
     use soroban_sdk::{
         testutils::storage::{Instance as _, Persistent as _},
@@ -373,11 +373,7 @@ mod tests {
         let (env, contract_id, ..) = setup();
         let client = OracleContractClient::new(&env, &contract_id);
 
-        client.submit_result(
-            &0u64,
-            &String::from_str(&env, "abc123"),
-            &Winner::Player1,
-        );
+        client.submit_result(&0u64, &String::from_str(&env, "abc123"), &Winner::Player1);
 
         assert!(client.has_result(&0u64));
         let entry = client.get_result(&0u64);
@@ -389,11 +385,7 @@ mod tests {
         let (env, contract_id, ..) = setup();
         let client = OracleContractClient::new(&env, &contract_id);
 
-        client.submit_result(
-            &0u64,
-            &String::from_str(&env, "abc123"),
-            &Winner::Player1,
-        );
+        client.submit_result(&0u64, &String::from_str(&env, "abc123"), &Winner::Player1);
 
         let events = env.events().all();
         let expected_topics = soroban_sdk::vec![
@@ -418,7 +410,7 @@ mod tests {
         let (env, contract_id, ..) = setup();
         let client = OracleContractClient::new(&env, &contract_id);
 
-        client.submit_result(&0u64, &String::from_str(&env, "abc123"), &MatchResult::Draw);
+        client.submit_result(&0u64, &String::from_str(&env, "abc123"), &Winner::Draw);
 
         let events = env.events().all();
         let expected_topics = soroban_sdk::vec![
@@ -457,9 +449,9 @@ mod tests {
         let (env, contract_id, ..) = setup();
         let client = OracleContractClient::new(&env, &contract_id);
 
-        client.submit_result(&0u64, &String::from_str(&env, "abc123"), &MatchResult::Draw);
+        client.submit_result(&0u64, &String::from_str(&env, "abc123"), &Winner::Draw);
         let result =
-            client.try_submit_result(&0u64, &String::from_str(&env, "abc123"), &MatchResult::Draw);
+            client.try_submit_result(&0u64, &String::from_str(&env, "abc123"), &Winner::Draw);
         assert_eq!(result, Err(Ok(Error::AlreadySubmitted)));
     }
 
@@ -495,11 +487,7 @@ mod tests {
         let (env, contract_id, ..) = setup();
         let client = OracleContractClient::new(&env, &contract_id);
 
-        client.submit_result(
-            &0u64,
-            &String::from_str(&env, "abc123"),
-            &Winner::Player1,
-        );
+        client.submit_result(&0u64, &String::from_str(&env, "abc123"), &Winner::Player1);
 
         let ttl = env.as_contract(&contract_id, || {
             env.storage().persistent().get_ttl(&DataKey::Result(0u64))
@@ -530,11 +518,8 @@ mod tests {
         client.pause();
 
         // Verify it's paused by trying to submit a result
-        let result = client.try_submit_result(
-            &0u64,
-            &String::from_str(&env, "abc123"),
-            &Winner::Player1,
-        );
+        let result =
+            client.try_submit_result(&0u64, &String::from_str(&env, "abc123"), &Winner::Player1);
         assert_eq!(result, Err(Ok(Error::ContractPaused)));
     }
 
@@ -551,11 +536,7 @@ mod tests {
         client.unpause();
 
         // Verify it's unpaused by submitting a result
-        client.submit_result(
-            &0u64,
-            &String::from_str(&env, "abc123"),
-            &Winner::Player1,
-        );
+        client.submit_result(&0u64, &String::from_str(&env, "abc123"), &Winner::Player1);
         assert!(client.has_result(&0u64));
     }
 
@@ -569,11 +550,8 @@ mod tests {
         client.pause();
 
         // Try to submit a result - should fail with ContractPaused
-        let result = client.try_submit_result(
-            &0u64,
-            &String::from_str(&env, "abc123"),
-            &Winner::Player1,
-        );
+        let result =
+            client.try_submit_result(&0u64, &String::from_str(&env, "abc123"), &Winner::Player1);
         assert_eq!(result, Err(Ok(Error::ContractPaused)));
 
         // Verify no result was stored
@@ -590,22 +568,15 @@ mod tests {
         client.pause();
 
         // Verify submit is blocked
-        let result = client.try_submit_result(
-            &0u64,
-            &String::from_str(&env, "abc123"),
-            &Winner::Player1,
-        );
+        let result =
+            client.try_submit_result(&0u64, &String::from_str(&env, "abc123"), &Winner::Player1);
         assert_eq!(result, Err(Ok(Error::ContractPaused)));
 
         // Unpause
         client.unpause();
 
         // Now submit should work
-        client.submit_result(
-            &0u64,
-            &String::from_str(&env, "abc123"),
-            &Winner::Player1,
-        );
+        client.submit_result(&0u64, &String::from_str(&env, "abc123"), &Winner::Player1);
         assert!(client.has_result(&0u64));
         let entry = client.get_result(&0u64);
         assert_eq!(entry.result, Winner::Player1);
@@ -618,39 +589,28 @@ mod tests {
         let client = OracleContractClient::new(&env, &contract_id);
 
         // Initially unpaused - submit should work
-        client.submit_result(
-            &0u64,
-            &String::from_str(&env, "abc123"),
-            &Winner::Player1,
-        );
+        client.submit_result(&0u64, &String::from_str(&env, "abc123"), &Winner::Player1);
         assert!(client.has_result(&0u64));
 
         // Pause
         client.pause();
 
         // Submit should fail
-        let result = client.try_submit_result(
-            &1u64,
-            &String::from_str(&env, "def456"),
-            &Winner::Player2,
-        );
+        let result =
+            client.try_submit_result(&1u64, &String::from_str(&env, "def456"), &Winner::Player2);
         assert_eq!(result, Err(Ok(Error::ContractPaused)));
 
         // Unpause
         client.unpause();
 
         // Submit should work again
-        client.submit_result(
-            &1u64,
-            &String::from_str(&env, "def456"),
-            &Winner::Player2,
-        );
+        client.submit_result(&1u64, &String::from_str(&env, "def456"), &Winner::Player2);
         assert!(client.has_result(&1u64));
 
         // Can pause again
         client.pause();
         let result =
-            client.try_submit_result(&2u64, &String::from_str(&env, "ghi789"), &MatchResult::Draw);
+            client.try_submit_result(&2u64, &String::from_str(&env, "ghi789"), &Winner::Draw);
         assert_eq!(result, Err(Ok(Error::ContractPaused)));
     }
 
@@ -662,11 +622,7 @@ mod tests {
         let client = OracleContractClient::new(&env, &contract_id);
 
         // Submit a result
-        client.submit_result(
-            &0u64,
-            &String::from_str(&env, "abc123"),
-            &Winner::Player1,
-        );
+        client.submit_result(&0u64, &String::from_str(&env, "abc123"), &Winner::Player1);
 
         // Read the result
         let entry = client.get_result(&0u64);
@@ -781,11 +737,7 @@ mod tests {
         let (env, contract_id, ..) = setup();
         let client = OracleContractClient::new(&env, &contract_id);
 
-        client.submit_result(
-            &0u64,
-            &String::from_str(&env, "ttl_game"),
-            &Winner::Player1,
-        );
+        client.submit_result(&0u64, &String::from_str(&env, "ttl_game"), &Winner::Player1);
 
         let ttl = env.as_contract(&contract_id, || env.storage().instance().get_ttl());
         assert_eq!(ttl, crate::MATCH_TTL_LEDGERS);
@@ -798,7 +750,7 @@ mod tests {
     //   2. The new admin can successfully call `submit_result`.
     #[test]
     fn test_transfer_admin_old_rejected_new_accepted() {
-        let (env, contract_id, _escrow_id, old_admin, player1, player2, token_addr) = setup();
+        let (env, contract_id, _escrow_id, old_admin, _player1, _player2, _token_addr) = setup();
         let client = OracleContractClient::new(&env, &contract_id);
 
         let new_admin = Address::generate(&env);
@@ -814,7 +766,7 @@ mod tests {
             invoke: &soroban_sdk::testutils::MockAuthInvoke {
                 contract: &contract_id,
                 fn_name: "submit_result",
-                args: (0u64, String::from_str(&env, "test_game"), MatchResult::Player1Wins).into_val(&env),
+                args: (0u64, String::from_str(&env, "test_game"), Winner::Player1).into_val(&env),
                 sub_invokes: &[],
             },
         }]);
@@ -822,7 +774,7 @@ mod tests {
         let result = client.try_submit_result(
             &0u64,
             &String::from_str(&env, "test_game"),
-            &MatchResult::Player1Wins,
+            &Winner::Player1,
         );
         assert!(
             result.is_err(),
@@ -835,7 +787,7 @@ mod tests {
             invoke: &soroban_sdk::testutils::MockAuthInvoke {
                 contract: &contract_id,
                 fn_name: "submit_result",
-                args: (0u64, String::from_str(&env, "test_game"), MatchResult::Player1Wins).into_val(&env),
+                args: (0u64, String::from_str(&env, "test_game"), Winner::Player1).into_val(&env),
                 sub_invokes: &[],
             },
         }]);
@@ -843,12 +795,15 @@ mod tests {
         client.submit_result(
             &0u64,
             &String::from_str(&env, "test_game"),
-            &MatchResult::Player1Wins,
+            &Winner::Player1,
         );
 
         // Confirm the result was stored
-        assert!(client.has_result(&0u64), "new admin must be able to submit results after transfer");
+        assert!(
+            client.has_result(&0u64),
+            "new admin must be able to submit results after transfer"
+        );
         let entry = client.get_result(&0u64);
-        assert_eq!(entry.result, MatchResult::Player1Wins);
+        assert_eq!(entry.result, Winner::Player1);
     }
 }


### PR DESCRIPTION
close #325 


2 commits on fix/update-oracle-self-address-check:

1. fix: reject self-address in update_oracle — the actual security fix + test
2. fix: resolve oracle test compile errors — fixed pre-existing oracle test breakage:
   - escrow::types::Winner was being imported where oracle::types::Winner was expected → fixed the import, aliased as EscrowWinner for the integration test
   - MatchResult (undefined) → replaced with Winner (same variants, wrong name in tests)
   - 3 unused variable warnings → prefixed with _

Full workspace: 103 tests pass, fmt clean, clippy clean.
