### PR TITLE
Fix/346 347 353 355

### DIFF
--- a/contracts/escrow/src/errors.rs
+++ b/contracts/escrow/src/errors.rs
@@ -49,4 +49,7 @@ pub enum Error {
     /// escrow contract's own address as the oracle during `initialize`.
     InvalidAddress = 13,
     InvalidPlayers = 14,
+
+    /// (15) The `game_id` is empty or invalid.
+    InvalidGameId = 15,
 }

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -132,6 +132,10 @@ impl EscrowContract {
             return Err(Error::InvalidPlayers);
         }
 
+        if game_id.len() == 0 {
+            return Err(Error::InvalidGameId);
+        }
+
         if env
             .storage()
             .instance()

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -440,6 +440,11 @@ impl EscrowContract {
             .persistent()
             .get(&DataKey::Match(match_id))
             .ok_or(Error::MatchNotFound)?;
+        env.storage().persistent().extend_ttl(
+            &DataKey::Match(match_id),
+            MATCH_TTL_LEDGERS,
+            MATCH_TTL_LEDGERS,
+        );
         if m.state == MatchState::Completed || m.state == MatchState::Cancelled {
             return Ok(0);
         }

--- a/contracts/escrow/src/tests.rs
+++ b/contracts/escrow/src/tests.rs
@@ -987,6 +987,22 @@ fn test_create_match_with_negative_stake_returns_invalid_amount() {
 }
 
 #[test]
+fn test_create_match_with_empty_game_id_returns_invalid_game_id() {
+    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let result = client.try_create_match(
+        &player1,
+        &player2,
+        &100,
+        &token,
+        &String::from_str(&env, ""),
+        &Platform::Lichess,
+    );
+    assert_eq!(result, Err(Ok(Error::InvalidGameId)));
+}
+
+#[test]
 fn test_player2_cancel_pending_match() {
     let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
     let client = EscrowContractClient::new(&env, &contract_id);

--- a/contracts/escrow/src/tests.rs
+++ b/contracts/escrow/src/tests.rs
@@ -2056,6 +2056,39 @@ fn test_get_escrow_balance_zero_after_cancel_with_player1_deposit() {
 }
 
 #[test]
+fn test_ttl_extended_on_get_escrow_balance() {
+    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let id = client.create_match(
+        &player1,
+        &player2,
+        &100,
+        &token,
+        &String::from_str(&env, "ttl_balance_game"),
+        &Platform::Lichess,
+    );
+
+    client.deposit(&id, &player1);
+
+    // Get the TTL before calling get_escrow_balance
+    let ttl_before = env.as_contract(&contract_id, || {
+        env.storage().persistent().get_ttl(&DataKey::Match(id))
+    });
+
+    // Call get_escrow_balance which should extend TTL
+    let _balance = client.get_escrow_balance(&id);
+
+    // Get the TTL after calling get_escrow_balance
+    let ttl_after = env.as_contract(&contract_id, || {
+        env.storage().persistent().get_ttl(&DataKey::Match(id))
+    });
+
+    // TTL should be extended (increased)
+    assert!(ttl_after >= ttl_before, "TTL should be extended after get_escrow_balance");
+}
+
+#[test]
 fn test_deposit_after_cancel_match_returns_invalid_state() {
     let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
     let client = EscrowContractClient::new(&env, &contract_id);

--- a/contracts/escrow/src/tests.rs
+++ b/contracts/escrow/src/tests.rs
@@ -1667,6 +1667,25 @@ fn test_cancel_match_by_player2_refunds_player1_deposit() {
     assert_eq!(token_client.balance(&player2), 1000);
 }
 
+#[test]
+fn test_cancel_match_by_unauthorized_address_returns_unauthorized() {
+    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+    let third_party = Address::generate(&env);
+
+    let id = client.create_match(
+        &player1,
+        &player2,
+        &100,
+        &token,
+        &String::from_str(&env, "unauthorized_cancel_test"),
+        &Platform::Lichess,
+    );
+
+    let result = client.try_cancel_match(&id, &third_party);
+    assert_eq!(result, Err(Ok(Error::Unauthorized)));
+}
+
 // #373 — update_oracle routes subsequent submit_result to the new oracle
 #[test]
 fn test_update_oracle_routes_submit_result() {

--- a/contracts/oracle/src/lib.rs
+++ b/contracts/oracle/src/lib.rs
@@ -304,6 +304,16 @@ mod tests {
 
     // ── has_result (public, unauthenticated) ─────────────────────────────────
 
+    /// Test that has_result returns false for match_id 0 on a fresh contract.
+    #[test]
+    fn test_has_result_returns_false_for_match_id_0_on_fresh_contract() {
+        let (env, contract_id, _escrow_id, ..) = setup();
+        let client = OracleContractClient::new(&env, &contract_id);
+
+        // On a fresh contract, has_result(0) should return false
+        assert!(!client.has_result(&0u64));
+    }
+
     /// Confirms that any caller can invoke has_result without authentication.
     /// Returns false before a result is submitted and true afterwards.
     #[test]


### PR DESCRIPTION
## Summary
  
  This PR implements four bug fixes and test coverage improvements across the escrow and oracle contracts, addressing validation gaps and TTL management issues.
  
  ## Changes
  
  ### Issue #346: Validate game_id in create_match
  - Added `InvalidGameId` error variant to escrow contract errors
  - Added validation to reject empty `game_id` strings in `create_match`
  - Added test to verify empty game_id is properly rejected
  
  ### Issue #347: Test oracle has_result on fresh contract
  - Added test `test_has_result_returns_false_for_match_id_0_on_fresh_contract`
  - Explicitly verifies `has_result(0)` returns `false` on a fresh oracle contract before any result submission
  
  ### Issue #353: Test cancel_match unauthorized
  - Added test `test_cancel_match_by_unauthorized_address_returns_unauthorized`
  - Verifies that third-party addresses cannot cancel matches and receive `Unauthorized` error
  
  ### Issue #355: Extend TTL on get_escrow_balance
  - Added `extend_ttl` call in `get_escrow_balance` to prevent match entries from expiring on repeated reads
  - Added test `test_ttl_extended_on_get_escrow_balance` to verify TTL extension behavior
  
  ## Files Modified
  
  - `contracts/escrow/src/errors.rs` - Added InvalidGameId error variant
  - `contracts/escrow/src/lib.rs` - Added game_id validation and TTL extension
  - `contracts/escrow/src/tests.rs` - Added three new tests
  - `contracts/oracle/src/lib.rs` - Added one new test
  
  ## Closes
  
  Closes #346
  Closes #347
  Closes #353
  Closes #355