### PR TITLE
feat: implement player/active indexes, token allowlist, and game_id uniqueness guard

### DIFF
--- a/contracts/escrow/src/errors.rs
+++ b/contracts/escrow/src/errors.rs
@@ -52,4 +52,7 @@ pub enum Error {
 
     /// (15) The `game_id` is empty or invalid.
     InvalidGameId = 15,
+
+    /// (16) The token address is not on the allowlist.
+    InvalidToken = 16,
 }

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -4,7 +4,7 @@ mod errors;
 pub mod types;
 
 use errors::Error;
-use soroban_sdk::{contract, contractimpl, symbol_short, token, Address, Env, String, Symbol};
+use soroban_sdk::{contract, contractimpl, symbol_short, token, vec, Address, Env, String, Symbol, Vec};
 use types::{DataKey, Match, MatchState, Platform, Winner};
 
 /// ~30 days at 5s/ledger. Used as both the TTL threshold and the extend-to value.
@@ -141,6 +141,15 @@ impl EscrowContract {
             return Err(Error::InvalidGameId);
         }
 
+        // Reject duplicate game_id
+        if env
+            .storage()
+            .persistent()
+            .has(&DataKey::GameId(game_id.clone()))
+        {
+            return Err(Error::AlreadyExists);
+        }
+
         if env
             .storage()
             .instance()
@@ -151,6 +160,20 @@ impl EscrowContract {
         }
         if stake_amount <= 0 {
             return Err(Error::InvalidAmount);
+        }
+
+        // Token allowlist check — only enforced once at least one token has been added
+        if env
+            .storage()
+            .instance()
+            .get::<DataKey, bool>(&DataKey::AllowlistEnabled)
+            .unwrap_or(false)
+            && !env
+                .storage()
+                .persistent()
+                .has(&DataKey::AllowedToken(token.clone()))
+        {
+            return Err(Error::InvalidToken);
         }
 
         let id: u64 = env
@@ -185,13 +208,41 @@ impl EscrowContract {
             MATCH_TTL_LEDGERS,
             MATCH_TTL_LEDGERS,
         );
+        // Mark game_id as used
+        env.storage()
+            .persistent()
+            .set(&DataKey::GameId(m.game_id.clone()), &true);
         // Guard against u64 overflow in release mode where wrapping would occur silently
         let next_id = id.checked_add(1).ok_or(Error::Overflow)?;
         env.storage().instance().set(&DataKey::MatchCount, &next_id);
 
+        // Update player match indexes
+        for p in [&m.player1, &m.player2] {
+            let mut ids: Vec<u64> = env
+                .storage()
+                .persistent()
+                .get(&DataKey::PlayerMatches(p.clone()))
+                .unwrap_or_else(|| vec![&env]);
+            ids.push_back(id);
+            env.storage()
+                .persistent()
+                .set(&DataKey::PlayerMatches(p.clone()), &ids);
+        }
+
+        // Update active match index
+        let mut active: Vec<u64> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::ActiveMatches)
+            .unwrap_or_else(|| vec![&env]);
+        active.push_back(id);
+        env.storage()
+            .persistent()
+            .set(&DataKey::ActiveMatches, &active);
+
         env.events().publish(
             (Symbol::new(&env, "match"), symbol_short!("created")),
-            (id, m.player1, m.player2, stake_amount),
+            (id, m.player1.clone(), m.player2.clone(), stake_amount),
         );
 
         Ok(id)
@@ -327,6 +378,9 @@ impl EscrowContract {
             MATCH_TTL_LEDGERS,
         );
 
+        // Remove from active match index
+        Self::remove_from_active(&env, match_id);
+
         let topics = (Symbol::new(&env, "match"), symbol_short!("completed"));
         env.events().publish(topics, (match_id, winner));
 
@@ -379,6 +433,9 @@ impl EscrowContract {
             MATCH_TTL_LEDGERS,
             MATCH_TTL_LEDGERS,
         );
+
+        // Remove from active match index
+        Self::remove_from_active(&env, match_id);
 
         env.events().publish(
             (Symbol::new(&env, "match"), symbol_short!("cancelled")),
@@ -505,6 +562,9 @@ impl EscrowContract {
             MATCH_TTL_LEDGERS,
         );
 
+        // Remove from active match index
+        Self::remove_from_active(&env, match_id);
+
         env.events().publish(
             (Symbol::new(&env, "match"), symbol_short!("expired")),
             match_id,
@@ -596,6 +656,55 @@ impl EscrowContract {
             .instance()
             .get(&DataKey::MatchTimeout)
             .unwrap_or(DEFAULT_MATCH_TIMEOUT_LEDGERS))
+    }
+
+    /// Return all match IDs for a given player.
+    pub fn get_player_matches(env: Env, player: Address) -> Vec<u64> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::PlayerMatches(player))
+            .unwrap_or_else(|| vec![&env])
+    }
+
+    /// Return all currently active (non-cancelled, non-completed) match IDs.
+    pub fn get_active_matches(env: Env) -> Vec<u64> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::ActiveMatches)
+            .unwrap_or_else(|| vec![&env])
+    }
+
+    /// Add a token to the allowlist. Requires admin auth.
+    /// Once any token is added, the allowlist is enforced on `create_match`.
+    pub fn add_allowed_token(env: Env, token: Address) -> Result<(), Error> {
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(Error::Unauthorized)?;
+        admin.require_auth();
+        env.storage()
+            .persistent()
+            .set(&DataKey::AllowedToken(token), &true);
+        env.storage()
+            .instance()
+            .set(&DataKey::AllowlistEnabled, &true);
+        Ok(())
+    }
+
+    /// Internal helper: remove `match_id` from the `ActiveMatches` index.
+    fn remove_from_active(env: &Env, match_id: u64) {
+        let mut active: Vec<u64> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::ActiveMatches)
+            .unwrap_or_else(|| vec![env]);
+        if let Some(pos) = active.first_index_of(match_id) {
+            active.remove(pos);
+            env.storage()
+                .persistent()
+                .set(&DataKey::ActiveMatches, &active);
+        }
     }
 }
 

--- a/contracts/escrow/src/tests.rs
+++ b/contracts/escrow/src/tests.rs
@@ -2290,3 +2290,155 @@ fn test_submit_result_emits_completed_event_with_correct_winner() {
     assert_eq!(ev_match_id, match_id);
     assert_eq!(ev_winner, Winner::Player1);
 }
+
+// #223 — get_player_matches index is populated correctly
+#[test]
+fn test_get_player_matches_returns_all_match_ids_for_player() {
+    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let id0 = client.create_match(
+        &player1,
+        &player2,
+        &100,
+        &token,
+        &String::from_str(&env, "pm_game0"),
+        &Platform::Lichess,
+    );
+    let id1 = client.create_match(
+        &player1,
+        &player2,
+        &100,
+        &token,
+        &String::from_str(&env, "pm_game1"),
+        &Platform::Lichess,
+    );
+    let id2 = client.create_match(
+        &player1,
+        &player2,
+        &100,
+        &token,
+        &String::from_str(&env, "pm_game2"),
+        &Platform::Lichess,
+    );
+
+    let matches = client.get_player_matches(&player1);
+    assert_eq!(matches.len(), 3);
+    assert_eq!(matches.get(0).unwrap(), id0);
+    assert_eq!(matches.get(1).unwrap(), id1);
+    assert_eq!(matches.get(2).unwrap(), id2);
+}
+
+// #224 — get_active_matches index is updated correctly through lifecycle
+#[test]
+fn test_get_active_matches_updated_after_cancel_and_complete() {
+    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let id0 = client.create_match(
+        &player1,
+        &player2,
+        &100,
+        &token,
+        &String::from_str(&env, "am_game0"),
+        &Platform::Lichess,
+    );
+    let id1 = client.create_match(
+        &player1,
+        &player2,
+        &100,
+        &token,
+        &String::from_str(&env, "am_game1"),
+        &Platform::Lichess,
+    );
+    let id2 = client.create_match(
+        &player1,
+        &player2,
+        &100,
+        &token,
+        &String::from_str(&env, "am_game2"),
+        &Platform::Lichess,
+    );
+
+    // Cancel match id1
+    client.cancel_match(&id1, &player1);
+
+    // Complete match id2
+    client.deposit(&id2, &player1);
+    client.deposit(&id2, &player2);
+    client.submit_result(&id2, &Winner::Player1);
+
+    let active = client.get_active_matches();
+    assert_eq!(active.len(), 1);
+    assert_eq!(active.get(0).unwrap(), id0);
+}
+
+// #225 — token allowlist rejects disallowed tokens, accepts after add_allowed_token
+#[test]
+fn test_token_allowlist_rejects_disallowed_and_accepts_after_add() {
+    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    // Register a second token that is NOT on the allowlist
+    let admin2 = Address::generate(&env);
+    let other_token_id = env.register_stellar_asset_contract_v2(admin2.clone());
+    let other_token = other_token_id.address();
+    let other_asset = StellarAssetClient::new(&env, &other_token);
+    other_asset.mint(&player1, &1000);
+    other_asset.mint(&player2, &1000);
+
+    // Enable allowlist by adding the main token
+    client.add_allowed_token(&token);
+
+    // other_token is not on the allowlist — must be rejected
+    let result = client.try_create_match(
+        &player1,
+        &player2,
+        &100,
+        &other_token,
+        &String::from_str(&env, "allowlist_game1"),
+        &Platform::Lichess,
+    );
+    assert_eq!(result, Err(Ok(Error::InvalidToken)));
+
+    // Add other_token to allowlist
+    client.add_allowed_token(&other_token);
+
+    // Now it should succeed
+    let id = client.create_match(
+        &player1,
+        &player2,
+        &100,
+        &other_token,
+        &String::from_str(&env, "allowlist_game2"),
+        &Platform::Lichess,
+    );
+    assert_eq!(client.get_match(&id).state, MatchState::Pending);
+}
+
+// #227 — duplicate game_id guard rejects second match with same game_id
+#[test]
+fn test_duplicate_game_id_rejected() {
+    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    client.create_match(
+        &player1,
+        &player2,
+        &100,
+        &token,
+        &String::from_str(&env, "game1"),
+        &Platform::Lichess,
+    );
+
+    // Second match with the same game_id must be rejected
+    let result = client.try_create_match(
+        &player1,
+        &player2,
+        &100,
+        &token,
+        &String::from_str(&env, "game1"),
+        &Platform::Lichess,
+    );
+    assert_eq!(result, Err(Ok(Error::AlreadyExists)));
+}

--- a/contracts/escrow/src/types.rs
+++ b/contracts/escrow/src/types.rs
@@ -52,4 +52,8 @@ pub enum DataKey {
     Paused,
     GameId(String),
     MatchTimeout,
+    PlayerMatches(Address),
+    ActiveMatches,
+    AllowedToken(Address),
+    AllowlistEnabled,
 }


### PR DESCRIPTION
closes #433 
closes #434 
closes #435 
closes #437 

- Add DataKey variants: PlayerMatches(Address), ActiveMatches, AllowedToken(Address), AllowlistEnabled
- Add Error::InvalidToken (code 16)
- create_match: enforce game_id uniqueness via DataKey::GameId, populate PlayerMatches index for both players, append to ActiveMatches index, enforce token allowlist when AllowlistEnabled
- cancel_match / submit_result / expire_match: remove match from ActiveMatches index on terminal state
- New functions: get_player_matches, get_active_matches, add_allowed_token
- Tests (#223): test_get_player_matches_returns_all_match_ids_for_player
- Tests (#224): test_get_active_matches_updated_after_cancel_and_complete
- Tests (#225): test_token_allowlist_rejects_disallowed_and_accepts_after_add
- Tests (#227): test_duplicate_game_id_rejected