### PR TITLE
Add test for player1 double deposit returning AlreadyFunded

### DIFF
--- a/contracts/escrow/src/tests.rs
+++ b/contracts/escrow/src/tests.rs
@@ -2038,3 +2038,26 @@ fn test_get_match_returns_cancelled_after_expire_match() {
     let m = client.get_match(&id);
     assert_eq!(m.state, MatchState::Cancelled);
 }
+
+#[test]
+fn test_player1_double_deposit_returns_already_funded() {
+    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let id = client.create_match(
+        &player1,
+        &player2,
+        &100,
+        &token,
+        &String::from_str(&env, "double_deposit_test"),
+        &Platform::Lichess,
+    );
+
+    // First deposit should succeed
+    client.deposit(&id, &player1);
+    assert!(!client.is_funded(&id));
+
+    // Second deposit by player1 should fail with AlreadyFunded
+    let result = client.try_deposit(&id, &player1);
+    assert_eq!(result, Err(Ok(Error::AlreadyFunded)));
+}


### PR DESCRIPTION
Issue #358: Add Test: player1 double deposit returns AlreadyFunded
Summary: Adds a test case to verify that when player1 calls deposit twice on the same match, the second call returns Error::AlreadyFunded.

Changes Made:

Added test_player1_double_deposit_returns_already_funded() test function
Test creates a match, performs initial deposit by player1 (succeeds)
Calls try_deposit for player1 again and asserts Err(Ok(Error::AlreadyFunded))
Ensures proper error handling for duplicate deposits
Test Coverage: This test addresses a missing verification in the test suite that ensures the AlreadyFunded error is correctly returned when a player attempts to deposit more than once for the same match.

Technical Details:

Uses existing setup() function for consistent test environment
Follows established test patterns in the codebase
Verifies error behavior through try_deposit method
Maintains consistency with other deposit-related tests
The test now provides coverage for the AlreadyFunded error case as specified in issue.

Closes #358 