### PR TITLE
fix: pause() now emits (admin, paused) event in escrow and oracle

### DIFF
--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -64,6 +64,8 @@ impl EscrowContract {
             .ok_or(Error::Unauthorized)?;
         admin.require_auth();
         env.storage().instance().set(&DataKey::Paused, &true);
+        env.events()
+            .publish((Symbol::new(&env, "admin"), symbol_short!("paused")), ());
         Ok(())
     }
 
@@ -139,7 +141,7 @@ impl EscrowContract {
             return Err(Error::InvalidPlayers);
         }
 
-        if game_id.len() == 0 {
+        if game_id.is_empty() {
             return Err(Error::InvalidGameId);
         }
 

--- a/contracts/escrow/src/tests.rs
+++ b/contracts/escrow/src/tests.rs
@@ -1,5 +1,3 @@
-#![cfg(test)]
-
 extern crate std;
 
 use super::*;
@@ -675,12 +673,12 @@ fn test_cancel_match_no_deposits_emits_no_token_transfers() {
     assert_eq!(client.get_match(&id).state, MatchState::Cancelled);
 
     // No token transfers should have been emitted — neither player deposited
-    let transfer_topic = soroban_sdk::symbol_short!("transfer").into_val(&env);
+    let transfer_topic: soroban_sdk::Val = soroban_sdk::symbol_short!("transfer").into_val(&env);
     let has_transfer = env
         .events()
         .all()
         .iter()
-        .any(|(_, topics, _)| topics.contains(&transfer_topic));
+        .any(|(_, topics, _)| topics.contains(transfer_topic));
     assert!(
         !has_transfer,
         "no token transfer events should be emitted when no deposits were made"
@@ -869,6 +867,25 @@ fn test_admin_unpause_allows_create_match() {
         &Platform::Lichess,
     );
     assert_eq!(id, 0);
+}
+
+#[test]
+fn test_pause_emits_paused_event() {
+    let (env, contract_id, ..) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    client.pause();
+
+    let events = env.events().all();
+    let expected_topics = vec![
+        &env,
+        Symbol::new(&env, "admin").into_val(&env),
+        symbol_short!("paused").into_val(&env),
+    ];
+    let matched = events
+        .iter()
+        .find(|(_, topics, _)| *topics == expected_topics);
+    assert!(matched.is_some(), "paused event not emitted");
 }
 
 /// Test that deposit is rejected when the contract is paused.

--- a/contracts/oracle/src/lib.rs
+++ b/contracts/oracle/src/lib.rs
@@ -196,6 +196,8 @@ impl OracleContract {
             .ok_or(Error::Unauthorized)?;
         admin.require_auth();
         env.storage().instance().set(&DataKey::Paused, &true);
+        env.events()
+            .publish((Symbol::new(&env, "admin"), symbol_short!("paused")), ());
         Ok(())
     }
 
@@ -705,6 +707,25 @@ mod tests {
 
         // Test passes if unpause completes without panic
         // The function docstring states it does not emit events
+    }
+
+    #[test]
+    fn test_pause_emits_paused_event() {
+        let (env, contract_id, ..) = setup();
+        let client = OracleContractClient::new(&env, &contract_id);
+
+        client.pause();
+
+        let events = env.events().all();
+        let expected_topics = soroban_sdk::vec![
+            &env,
+            Symbol::new(&env, "admin").into_val(&env),
+            symbol_short!("paused").into_val(&env),
+        ];
+        let matched = events
+            .iter()
+            .find(|(_, topics, _)| *topics == expected_topics);
+        assert!(matched.is_some(), "paused event not emitted");
     }
 
     /// Full integration: oracle stores result, escrow oracle address submits


### PR DESCRIPTION
close #332 

## Summary
pause() was silently updating contract state with no event emitted, making it impossible for off-chain monitors to detect a pause without polling. unpause() already emitted an ("admin", "unpaused") event — this brings pause()
into parity.

## Changes
- Added env.events().publish(("admin", "paused"), ()) to pause() in both the escrow and oracle contracts
- Added test_pause_emits_paused_event in both contracts asserting the event is present after calling pause()
- Fixed 3 pre-existing clippy warnings (duplicated_attributes, len_zero, needless_borrows_for_generic_args)

## Testing
All CI checks pass:
- ✅ cargo test --workspace — 89 escrow + 32 oracle tests
- ✅ cargo clippy -- -D warnings — clean
- ✅ cargo build --workspace — clean
- ✅ cargo fmt -- --check — clean
