### PR TITLE
Fix/issue 445 442 444 443

### DIFF
--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -119,6 +119,11 @@ impl EscrowContract {
 
     /// Create a new match. Both players must call `deposit` before the game starts.
     ///
+    /// # Arguments
+    /// - `stake_amount` — must be greater than 0. The practical minimum depends on token
+    ///   decimal precision (e.g., 1 stroop = 0.0000001 XLM for 7-decimal tokens).
+    ///   Ensure the stake amount is at least 1 in the token's smallest unit.
+    ///
     /// # Errors
     /// - [`Error::ContractPaused`] — contract is paused.
     /// - [`Error::InvalidAmount`] — `stake_amount` is zero or negative.

--- a/contracts/escrow/src/tests.rs
+++ b/contracts/escrow/src/tests.rs
@@ -593,6 +593,40 @@ fn test_submit_result_fails_if_not_fully_funded() {
 }
 
 #[test]
+fn test_submit_result_fails_when_contract_token_balance_is_zero() {
+    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+    let token_client = TokenClient::new(&env, &token);
+
+    let id = client.create_match(
+        &player1,
+        &player2,
+        &100,
+        &token,
+        &String::from_str(&env, "zero_balance_game"),
+        &Platform::Lichess,
+    );
+
+    client.deposit(&id, &player1);
+    client.deposit(&id, &player2);
+
+    // Drain the contract's token balance by transferring out all funds
+    let contract_balance = token_client.balance(&contract_id);
+    if contract_balance > 0 {
+        env.as_contract(&contract_id, || {
+            token_client.transfer(&contract_id, &player1, &contract_balance);
+        });
+    }
+
+    // Verify balance is zero
+    assert_eq!(token_client.balance(&contract_id), 0);
+
+    // Attempt to submit result should fail due to insufficient balance
+    let result = client.try_submit_result(&id, &Winner::Player1);
+    assert!(result.is_err(), "submit_result should fail when contract has zero token balance");
+}
+
+#[test]
 fn test_initialize_accepts_valid_generated_oracle_address() {
     let env = Env::default();
     env.mock_all_auths();

--- a/contracts/escrow/src/tests.rs
+++ b/contracts/escrow/src/tests.rs
@@ -883,7 +883,7 @@ fn test_admin_pause_blocks_create_match() {
         &String::from_str(&env, "paused_game"),
         &Platform::Lichess,
     );
-    assert!(result.is_err());
+    assert_eq!(result, Err(Ok(Error::ContractPaused)));
 }
 
 #[test]


### PR DESCRIPTION
 Fix: Contract Robustness & Documentation Improvements

## Summary

This PR addresses four issues to improve contract robustness, test coverage, and documentation:

- **#442**: Add documentation on minimum viable stake amount
- **#445**: Add defensive test for submit_result with zero contract token balance
- **#444**: Improve pause test for create_match with specific error assertion
- **#443**: Verify submit_result is blocked when contract is paused (already implemented)

## Changes

### 1. Documentation: Minimum Stake Amount Guidance (#442)
**File**: `contracts/escrow/src/lib.rs`

Added comprehensive inline documentation to `create_match()` explaining:
- Stake amount must be greater than 0
- Practical minimum depends on token decimal precision
- Example: 1 stroop = 0.0000001 XLM for 7-decimal tokens
- Guidance to ensure stake is at least 1 in token's smallest unit

### 2. Test: Zero Contract Token Balance (#445)
**File**: `contracts/escrow/src/tests.rs`

Added `test_submit_result_fails_when_contract_token_balance_is_zero()`:
- Creates and funds a match
- Drains contract token balance to zero
- Verifies submit_result fails gracefully
- Defensive test for state inconsistency handling

### 3. Test: Pause Blocks Create Match (#444)
**File**: `contracts/escrow/src/tests.rs`

Improved `test_admin_pause_blocks_create_match()`:
- Changed from generic `is_err()` to specific error assertion
- Now asserts `Err(Ok(Error::ContractPaused))` for clarity
- Ensures create_match is blocked with correct error when paused

### 4. Test: Pause Blocks Submit Result (#443)
**Status**: Already implemented in `test_submit_result_blocked_when_paused()`
- Creates and funds a match
- Pauses contract
- Verifies submit_result returns `Err(Ok(Error::ContractPaused))`

## Testing

All changes follow existing test patterns and conventions:
- Use `setup()` helper for environment initialization
- Follow naming convention: `test_<function>_<scenario>`
- Assert specific error types for clarity
- Include descriptive comments

## Commits

1. `docs: add minimum stake amount guidance to create_match`
2. `test: add defensive test for submit_result with zero contract balance`
3. `test: improve pause test for create_match to assert specific error`

## Related Issues

- Closes #442
- Closes #445
- Closes #444
- Closes #443