### PR TITLE
fix(#388): add doc comments to Match struct fields and define stable API surface

### DIFF
--- a/contracts/escrow/src/tests.rs
+++ b/contracts/escrow/src/tests.rs
@@ -621,7 +621,10 @@ fn test_submit_result_fails_when_contract_token_balance_is_zero() {
 
     // Attempt to submit result should fail due to insufficient balance
     let result = client.try_submit_result(&id, &Winner::Player1);
-    assert!(result.is_err(), "submit_result should fail when contract has zero token balance");
+    assert!(
+        result.is_err(),
+        "submit_result should fail when contract has zero token balance"
+    );
 }
 
 #[test]

--- a/contracts/escrow/src/types.rs
+++ b/contracts/escrow/src/types.rs
@@ -24,21 +24,46 @@ pub enum Winner {
     Draw,
 }
 
+/// Represents a single wagered chess match held in escrow.
+///
+/// # Stable API
+/// The following fields are part of the stable public API and safe to read
+/// by external callers and integrations:
+/// `id`, `player1`, `player2`, `stake_amount`, `token`, `game_id`,
+/// `platform`, `state`, `winner`, `created_ledger`, `completed_ledger`.
+///
+/// # Internal State
+/// `player1_deposited` and `player2_deposited` are internal bookkeeping
+/// fields used by the contract to track deposit progress. Callers should
+/// prefer `is_funded()` to check whether a match is fully funded.
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Match {
+    /// Unique auto-incrementing match identifier assigned at creation.
     pub id: u64,
+    /// Stellar address of the first player (match creator).
     pub player1: Address,
+    /// Stellar address of the second player (invited opponent).
     pub player2: Address,
+    /// Amount each player must stake, in the smallest unit of `token`.
     pub stake_amount: i128,
+    /// Contract address of the token used for staking (XLM or USDC).
     pub token: Address,
+    /// External game identifier from the chess platform (e.g. Lichess game ID).
     pub game_id: String,
+    /// Chess platform where the game is being played.
     pub platform: Platform,
+    /// Current lifecycle state of the match.
     pub state: MatchState,
+    /// Internal: whether player1 has deposited their stake. Use `is_funded()` externally.
     pub player1_deposited: bool,
+    /// Internal: whether player2 has deposited their stake. Use `is_funded()` externally.
     pub player2_deposited: bool,
+    /// Ledger sequence number at which the match was created.
     pub created_ledger: u32,
+    /// Ledger sequence number at which the match was completed or cancelled, if applicable.
     pub completed_ledger: Option<u32>,
+    /// Outcome of the match. Defaults to `Winner::Draw` until a result is submitted.
     pub winner: Winner,
 }
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,99 @@
+# Architecture Overview
+
+Checkmate-Escrow is a trustless chess wagering platform built on Stellar Soroban smart contracts. This document describes the high-level architecture and the stable public API surface.
+
+## Components
+
+```
+┌─────────────┐     create/deposit/cancel     ┌──────────────────┐
+│   Players   │ ─────────────────────────────▶│  Escrow Contract │
+└─────────────┘                               └────────┬─────────┘
+                                                       │ submit_result / execute_payout
+┌─────────────┐     verify game result                 │
+│   Oracle    │ ─────────────────────────────▶─────────┘
+└─────────────┘
+      │
+      │ polls
+      ▼
+┌──────────────────────┐
+│  Lichess / Chess.com │
+└──────────────────────┘
+```
+
+- **Escrow Contract** (`contracts/escrow`): Holds player stakes, enforces match lifecycle, and executes payouts.
+- **Oracle Contract** (`contracts/oracle`): Bridges external chess platform APIs to the escrow contract, submitting verified match results on-chain.
+
+## Match Lifecycle
+
+```
+Pending ──(both deposit)──▶ Active ──(oracle submits result)──▶ Completed
+   │                           │
+   └──(cancel)──▶ Cancelled ◀──┘
+```
+
+## Stable Public API
+
+The following types and contract functions are considered stable. External integrations and tooling should rely only on these.
+
+### `Match` Struct
+
+Returned by `get_match(match_id)`. All fields below are stable and safe to read.
+
+| Field              | Type            | Description |
+|--------------------|-----------------|-------------|
+| `id`               | `u64`           | Unique match identifier. |
+| `player1`          | `Address`       | Match creator (first player). |
+| `player2`          | `Address`       | Invited opponent (second player). |
+| `stake_amount`     | `i128`          | Amount each player stakes, in the token's smallest unit. |
+| `token`            | `Address`       | Token contract address used for staking (XLM or USDC). |
+| `game_id`          | `String`        | External game ID from the chess platform. |
+| `platform`         | `Platform`      | Chess platform: `Lichess` or `ChessDotCom`. |
+| `state`            | `MatchState`    | Current lifecycle state (see below). |
+| `winner`           | `Winner`        | Match outcome once completed; defaults to `Draw` until set. |
+| `created_ledger`   | `u32`           | Ledger sequence at match creation. |
+| `completed_ledger` | `Option<u32>`   | Ledger sequence at completion or cancellation, if applicable. |
+
+> **Internal fields** — `player1_deposited` and `player2_deposited` are internal bookkeeping. Use `is_funded(match_id)` to check whether a match is fully funded.
+
+### `MatchState` Enum
+
+| Variant     | Meaning |
+|-------------|---------|
+| `Pending`   | Match created; awaiting both deposits. |
+| `Active`    | Both players deposited; game in progress. |
+| `Completed` | Result submitted and payout executed. |
+| `Cancelled` | Cancelled before activation; stakes refunded. |
+
+### `Winner` Enum
+
+| Variant   | Meaning |
+|-----------|---------|
+| `Player1` | Player 1 won. |
+| `Player2` | Player 2 won. |
+| `Draw`    | Game ended in a draw; stakes returned to both players. |
+
+### Contract Functions
+
+#### Match Management
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `create_match` | `(stake_amount: i128, token: Address, game_id: String, platform: Platform) -> u64` | Creates a new match and returns its ID. |
+| `get_match` | `(match_id: u64) -> Match` | Returns the current state of a match. |
+| `cancel_match` | `(match_id: u64)` | Cancels a match and refunds any deposits. |
+
+#### Escrow
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `deposit` | `(match_id: u64)` | Deposits the caller's stake into escrow. |
+| `get_escrow_balance` | `(match_id: u64) -> i128` | Returns the total escrowed balance for a match. |
+| `is_funded` | `(match_id: u64) -> bool` | Returns `true` when both players have deposited. |
+
+#### Oracle & Payouts
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `submit_result` | `(match_id: u64, winner: Winner)` | Oracle submits the verified match result. |
+| `verify_result` | `(match_id: u64) -> bool` | Returns `true` if a result has been submitted. |
+| `execute_payout` | `(match_id: u64)` | Transfers escrowed funds to the winner (or refunds on draw). |


### PR DESCRIPTION
## Summary

Closes #388.

All fields of the `Match` struct were `pub` with no documentation, making it unclear which fields are part of the stable API vs. internal bookkeeping.

## Changes

### `contracts/escrow/src/types.rs`
- Added `///` doc comments to every field of the `Match` struct
- Added a struct-level doc comment distinguishing **stable API fields** from **internal state** (`player1_deposited`, `player2_deposited`)
- Directs external callers to use `is_funded()` instead of reading deposit flags directly

### `docs/architecture.md` (new file)
- Created architecture overview with component diagram and match lifecycle diagram
- Documents the stable public API surface: `Match` fields, `MatchState`, `Winner`, and all contract functions

## Testing
No logic changes — documentation only. Existing test suite passes.