### PR TITLE
worked on api consistency check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,22 @@ env:
   RUST_BACKTRACE: 1
 
 jobs:
+  check-links:
+    name: Check Markdown Links
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Validate local Markdown links
+        run: bash scripts/check_links.sh
+
+  check-api-refs:
+    name: Check API References
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Validate contract API names in docs
+        run: bash scripts/check_api_refs.sh
+
   test:
     name: Test
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -133,6 +133,54 @@ cargo test -p oracle
 - Mock external dependencies
 - Verify events are emitted correctly
 
+### Testing Conventions: Prefer `try_` Over `#[should_panic]`
+
+When testing that a contract function returns a specific error, prefer the typed
+`try_` variant over `#[should_panic]`. The `try_` approach asserts the *exact*
+error variant, making failures easier to diagnose and preventing tests from
+accidentally passing due to an unrelated panic.
+
+**Avoid** — `#[should_panic]` only checks that *something* panicked:
+
+```rust
+#[test]
+#[should_panic(expected = "Error(Contract, #10)")]
+fn test_create_match_with_zero_stake_fails() {
+    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    client.create_match(&player1, &player2, &0, &token,
+        &String::from_str(&env, "game"), &Platform::Lichess);
+}
+```
+
+**Prefer** — `try_` asserts the exact error variant:
+
+```rust
+#[test]
+fn test_create_match_with_zero_stake_returns_invalid_amount() {
+    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let result = client.try_create_match(&player1, &player2, &0, &token,
+        &String::from_str(&env, "game"), &Platform::Lichess);
+    assert_eq!(result, Err(Ok(Error::InvalidAmount)));
+}
+```
+
+Use `#[should_panic]` only for cases where the contract panics with a plain
+string message rather than a typed error (e.g. double-initialization):
+
+```rust
+#[test]
+#[should_panic(expected = "Contract already initialized")]
+fn test_double_initialize_fails() {
+    // ...
+    client.initialize(&oracle, &admin);
+    client.initialize(&oracle, &admin); // panics with a string, not a typed Error
+}
+```
+
 ## Drips Wave Contributions
 
 Checkmate-Escrow participates in Drips Wave contributor funding. Issues labeled `wave-ready` are eligible for funding:

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 StellarCheckMate
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -129,8 +129,8 @@ is_funded(match_id) -> bool
 
 ```
 submit_result(match_id, winner)
-verify_result(match_id) -> bool
-execute_payout(match_id)
+has_result(match_id) -> bool
+get_result(match_id) -> ResultEntry
 ```
 
 ## 🧪 Testing

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -4,19 +4,33 @@ This document outlines the planned development phases for Checkmate-Escrow, expa
 
 ---
 
-## v1.0 — Core Escrow & Lichess Integration (Current)
+## v1.0 — Core Escrow & Lichess Integration (Complete)
 
 The foundation of trustless chess wagering on Stellar.
 
 ### Features
 
-- **XLM-only escrow**: Players stake native XLM tokens in a Soroban smart contract
-- **Match lifecycle management**: Create, deposit, activate, and complete matches
+- **Multi-token escrow**: Players stake any Stellar token (XLM, USDC, or custom assets) via a generic token interface
+- **Match lifecycle management**: Create, deposit, activate, complete, cancel, and expire matches
 - **Lichess Oracle integration**: Automated result verification via Lichess public API
+- **Chess.com platform support**: `Platform::ChessDotCom` variant supported in match creation
 - **Winner payouts**: Automatic distribution of the full pot to the winner
 - **Draw handling**: Stakes returned to both players when games end in a draw
 - **Cancellation logic**: Players can cancel unfunded matches before both deposits are made
+- **Match expiry**: Pending matches that exceed a configurable ledger timeout can be expired by anyone, refunding any deposits
+- **Token allowlist**: Admin can restrict which tokens are accepted via `add_allowed_token`
+- **Contract pause/unpause**: Admin can halt `create_match`, `deposit`, and `submit_result` in an emergency
+- **Admin management**: Two-step admin transfer (`propose_admin` / `accept_admin`) and direct `transfer_admin`
+- **Match indexing**: `get_player_matches` and `get_active_matches` for efficient on-chain lookups
 - **Basic security**: Admin-gated oracle submission, duplicate game ID prevention
+
+### Oracle Features
+
+- **Result submission**: Admin submits verified match results on-chain
+- **Result queries**: Public `has_result` and admin-gated `has_result_admin`
+- **Result deletion**: Admin can remove a previously submitted result via `delete_result`
+- **Oracle pause/unpause**: Admin can halt result submission independently of the escrow contract
+- **Admin rotation**: `update_admin` rotates the oracle admin address
 
 ### Status
 
@@ -24,24 +38,21 @@ The foundation of trustless chess wagering on Stellar.
 
 ---
 
-## v1.1 — Multi-Token Support & Chess.com
+## v1.1 — Chess.com Oracle & Token Interface Standardization
 
-Expand token support and add a second platform integration.
+Expand the off-chain oracle service to cover Chess.com and standardize the token integration.
 
 ### Features
 
-- **USDC support**: Allow players to stake USDC instead of XLM
-- **Custom token support**: Enable any Stellar asset as stake currency
-- **Chess.com Oracle**: Verify results from Chess.com games via their public API
-- **Platform validation**: Ensure game IDs match the declared platform
-- **Token interface standardization**: Abstract token operations for easier extension
+- **Chess.com Oracle**: Implement the off-chain API client for Chess.com result verification
+- **Platform validation**: Validate that game IDs match the declared platform format (numeric strings for Chess.com)
+- **Token interface documentation**: Document the generic token transfer pattern for integrators
 
 ### Technical Changes
 
-- Add `token_address` parameter to `create_match`
-- Implement generic token transfer logic using Stellar token interface
-- Add Chess.com API client to oracle service
-- Update validation to handle Chess.com game ID format (numeric strings)
+- Add Chess.com API client to the oracle off-chain service
+- Update validation to handle Chess.com game ID format
+- Document token integration patterns
 
 ### Timeline
 

--- a/scripts/check_api_refs.sh
+++ b/scripts/check_api_refs.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Checks that every contract function name referenced in docs exists in the codebase.
+# Only flags names that appear in function-call style: name( in code blocks.
+# Exits non-zero if any stale API names are found.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+# Build allowlist from actual public contract functions
+ALLOWLIST=$(grep -rh "pub fn " \
+  "$REPO_ROOT/contracts/escrow/src/lib.rs" \
+  "$REPO_ROOT/contracts/oracle/src/lib.rs" \
+  | grep -oP 'pub fn \K[a-z_]+' | sort -u)
+
+# SDK / CLI / Rust stdlib calls that are not contract functions — skip these
+EXCLUDE="require_auth|from_str|to_string|cost_estimate|invoke_contract|call_contract"
+
+# Docs to scan
+DOCS=$(find "$REPO_ROOT/docs" "$REPO_ROOT/demo" -name "*.md"; echo "$REPO_ROOT/README.md")
+
+errors=0
+
+while IFS= read -r file; do
+  while IFS= read -r name; do
+    if ! echo "$ALLOWLIST" | grep -qx "$name"; then
+      echo "STALE API: '$name' in $file"
+      errors=$((errors + 1))
+    fi
+  done < <(grep -oP '`?\K[a-z][a-z_]+(?=\()' "$file" \
+           | grep '_' \
+           | grep -vE "^($EXCLUDE)$" \
+           | sort -u)
+done <<< "$DOCS"
+
+if [[ $errors -gt 0 ]]; then
+  echo "$errors stale API reference(s) found."
+  exit 1
+fi
+
+echo "All API references OK."

--- a/scripts/check_links.sh
+++ b/scripts/check_links.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Validates local Markdown links in README.md, docs/, and demo/.
+# Exits non-zero if any broken links are found.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+FILES=$(find "$REPO_ROOT/docs" "$REPO_ROOT/demo" -name "*.md"; echo "$REPO_ROOT/README.md")
+
+errors=0
+
+while IFS= read -r file; do
+  # Extract local links: [text](path) where path does not start with http/https/#
+  while IFS= read -r link; do
+    # Resolve relative to the file's directory
+    target="$(dirname "$file")/$link"
+    # Normalize path (remove ../ etc.)
+    target="$(realpath -m "$target")"
+    if [[ ! -e "$target" ]]; then
+      echo "BROKEN: $file -> $link"
+      errors=$((errors + 1))
+    fi
+  done < <(grep -oP '\]\(\K[^)]+' "$file" | grep -v '^https\?://' | grep -v '^#' | grep -v '^mailto:')
+done <<< "$FILES"
+
+if [[ $errors -gt 0 ]]; then
+  echo "$errors broken link(s) found."
+  exit 1
+fi
+
+echo "All local Markdown links OK."


### PR DESCRIPTION
Closes #654 . Adds a lightweight CI check and an API allowlist to ensure Markdown docs don't reference nonexistent or removed function names. Prevents docs drift!

Closes #653

Closes #644
Closes #642