### PR TITLE
fix: add MIT LICENSE file and license field to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "contracts/oracle",
 ]
 resolver = "2"
+license = "MIT"
 
 [workspace.dependencies]
 soroban-sdk = "21.7.5"

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,35 @@
+
+MIT License
+
+Copyright (c) 2026 StellarCheckMate Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+
+of this software and associated documentation files (the "Software"), to deal
+
+in the Software without restriction, including without limitation the rights
+
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+
+copies of the Software, and to permit persons to whom the Software is
+
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+
+SOFTWARE.
+


### PR DESCRIPTION
Closes #647

## Summary
The README and CONTRIBUTING.md both state the project is MIT licensed, but no `LICENSE` file existed in the repository and `Cargo.toml` had no `license` field.

## Changes
- Added standard MIT `LICENSE` file to the repo root
- Added `license = "MIT"` to `[workspace]` in `Cargo.toml`

All three references (README, CONTRIBUTING.md, Cargo.toml) now consistently declare MIT.