### PR TITLE
test(escrow): add test for remove_allowed_token last-token edge case

### DIFF
--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -700,12 +700,63 @@ impl EscrowContract {
             .get(&DataKey::Admin)
             .ok_or(Error::Unauthorized)?;
         admin.require_auth();
+        let already = env
+            .storage()
+            .persistent()
+            .get::<DataKey, bool>(&DataKey::AllowedToken(token.clone()))
+            .unwrap_or(false);
         env.storage()
             .persistent()
             .set(&DataKey::AllowedToken(token), &true);
+        if !already {
+            let count: u32 = env
+                .storage()
+                .instance()
+                .get(&DataKey::AllowedTokenCount)
+                .unwrap_or(0);
+            env.storage()
+                .instance()
+                .set(&DataKey::AllowedTokenCount, &(count + 1));
+        }
         env.storage()
             .instance()
             .set(&DataKey::AllowlistEnabled, &true);
+        Ok(())
+    }
+
+    /// Remove a token from the allowlist. Requires admin auth.
+    /// When the last token is removed, the allowlist is disabled.
+    pub fn remove_allowed_token(env: Env, token: Address) -> Result<(), Error> {
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(Error::Unauthorized)?;
+        admin.require_auth();
+        let present = env
+            .storage()
+            .persistent()
+            .get::<DataKey, bool>(&DataKey::AllowedToken(token.clone()))
+            .unwrap_or(false);
+        if present {
+            env.storage()
+                .persistent()
+                .remove(&DataKey::AllowedToken(token));
+            let count: u32 = env
+                .storage()
+                .instance()
+                .get(&DataKey::AllowedTokenCount)
+                .unwrap_or(1);
+            let new_count = count.saturating_sub(1);
+            env.storage()
+                .instance()
+                .set(&DataKey::AllowedTokenCount, &new_count);
+            if new_count == 0 {
+                env.storage()
+                    .instance()
+                    .set(&DataKey::AllowlistEnabled, &false);
+            }
+        }
         Ok(())
     }
 

--- a/contracts/escrow/src/tests.rs
+++ b/contracts/escrow/src/tests.rs
@@ -2681,3 +2681,37 @@ fn test_expire_match_refunds_both_players_when_both_deposited_but_still_pending(
     assert_eq!(token_client.balance(&player1) - p1_balance_before, 100);
     assert_eq!(token_client.balance(&player2) - p2_balance_before, 100);
 }
+
+#[test]
+fn test_remove_allowed_token_last_token_disables_allowlist() {
+    let (env, contract_id, _oracle, _player1, _player2, token_addr, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    // Add the single token — allowlist becomes enabled
+    client.add_allowed_token(&token_addr);
+
+    // Remove it — allowlist must be disabled
+    client.remove_allowed_token(&token_addr);
+
+    // AllowedToken entry must be gone
+    env.as_contract(&contract_id, || {
+        assert!(!env
+            .storage()
+            .persistent()
+            .has(&DataKey::AllowedToken(token_addr.clone())));
+        // AllowlistEnabled must be false
+        assert!(!env
+            .storage()
+            .instance()
+            .get::<DataKey, bool>(&DataKey::AllowlistEnabled)
+            .unwrap_or(false));
+        // Count must be zero
+        assert_eq!(
+            env.storage()
+                .instance()
+                .get::<DataKey, u32>(&DataKey::AllowedTokenCount)
+                .unwrap_or(0),
+            0
+        );
+    });
+}

--- a/contracts/escrow/src/types.rs
+++ b/contracts/escrow/src/types.rs
@@ -81,4 +81,5 @@ pub enum DataKey {
     ActiveMatches,
     AllowedToken(Address),
     AllowlistEnabled,
+    AllowedTokenCount,
 }


### PR DESCRIPTION
closes #623 


- Add  to  to track the number of allowlisted tokens
- Update  to increment the count (idempotent on re-add)
- Implement  (admin-only): removes the token from persistent storage, decrements the count, and sets to false when the last token is removed
- Add test : adds one token, removes it, then asserts the AllowedToken entry is gone, AllowlistEnabled is false, and AllowedTokenCount is 0