### PR TITLE
feat(escrow): add get_matches batch getter and duplicate-ID tests 

### DIFF
--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -472,6 +472,29 @@ impl EscrowContract {
         Ok(m)
     }
 
+    /// Read multiple matches by ID in one call. Each ID in `ids` that exists
+    /// produces one entry in the returned `Vec`; missing IDs are silently
+    /// skipped. Duplicate IDs each produce their own entry, so the output
+    /// length may be less than or equal to `ids.len()`.
+    pub fn get_matches(env: Env, ids: Vec<u64>) -> Vec<Match> {
+        let mut out: Vec<Match> = Vec::new(&env);
+        for id in ids.iter() {
+            if let Some(m) = env
+                .storage()
+                .persistent()
+                .get::<DataKey, Match>(&DataKey::Match(id))
+            {
+                env.storage().persistent().extend_ttl(
+                    &DataKey::Match(id),
+                    MATCH_TTL_LEDGERS,
+                    MATCH_TTL_LEDGERS,
+                );
+                out.push_back(m);
+            }
+        }
+        out
+    }
+
     /// Return whether the contract is currently paused.
     pub fn is_paused(env: Env) -> bool {
         env.storage()

--- a/contracts/escrow/src/tests.rs
+++ b/contracts/escrow/src/tests.rs
@@ -2681,3 +2681,48 @@ fn test_expire_match_refunds_both_players_when_both_deposited_but_still_pending(
     assert_eq!(token_client.balance(&player1) - p1_balance_before, 100);
     assert_eq!(token_client.balance(&player2) - p2_balance_before, 100);
 }
+
+#[test]
+fn test_get_matches_duplicate_ids_returns_one_entry_per_occurrence() {
+    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let id = client.create_match(
+        &player1,
+        &player2,
+        &100,
+        &token,
+        &String::from_str(&env, "dup_test_game"),
+        &Platform::Lichess,
+    );
+
+    // Query the same ID twice; expect two entries with identical data.
+    let ids = vec![&env, id, id];
+    let results = client.get_matches(&ids);
+
+    assert_eq!(results.len(), 2);
+    assert_eq!(results.get(0).unwrap(), results.get(1).unwrap());
+    assert_eq!(results.get(0).unwrap().id, id);
+}
+
+#[test]
+fn test_get_matches_missing_ids_are_skipped() {
+    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let id = client.create_match(
+        &player1,
+        &player2,
+        &100,
+        &token,
+        &String::from_str(&env, "skip_test_game"),
+        &Platform::Lichess,
+    );
+
+    // id exists, 999 does not — only the existing match is returned.
+    let ids = vec![&env, id, 999u64];
+    let results = client.get_matches(&ids);
+
+    assert_eq!(results.len(), 1);
+    assert_eq!(results.get(0).unwrap().id, id);
+}


### PR DESCRIPTION
closes #624 

- Add  to EscrowContract: each ID in the input that exists produces one entry in the output; missing IDs are silently skipped; duplicate IDs each produce their own entry (output length ≤ input length).
- Add test_get_matches_duplicate_ids_returns_one_entry_per_occurrence: queries the same ID twice and asserts two identical entries are returned.
- Add test_get_matches_missing_ids_are_skipped: queries one valid and one nonexistent ID and asserts only the existing match is returned.