### PR TITLE
chore: updating oracle.md

### DIFF
--- a/docs/oracle.md
+++ b/docs/oracle.md
@@ -1,7 +1,33 @@
 # Oracle Integration Guide
 
-This document describes how the off-chain oracle service interacts with the
-Checkmate Escrow smart contracts, with a focus on the `game_id` field.
+This document describes the current oracle architecture used by Checkmate
+Escrow. It explains the two distinct on-chain oracle components and how they
+work together with the off-chain oracle service.
+
+The current design has:
+- an `EscrowContract` that stores a trusted `oracle` address and authorises
+  result submissions for on-chain payout,
+- an `OracleContract` that stores an independent, auditable copy of verified
+  match results.
+
+The escrow contract uses its configured oracle address as the authoritative
+permission for submitting results to trigger payouts. The oracle contract is
+supplementary: it does not authorise escrow payouts or act as a gatekeeper for
+escrow result submission. It provides an audit log and an independent on-chain
+record of results that can be queried later.
+
+The off-chain oracle service today is the trusted operator that:
+1. verifies the platform result for `game_id` using an external chess API,
+2. calls `EscrowContract::submit_result(match_id, winner)` from the escrow-side
+   oracle address,
+3. records the same result in `OracleContract` for auditing and optional
+   verification.
+
+The two contracts are separate:
+- `EscrowContract` enforces match state, funding, and oracle address
+  authentication.
+- `OracleContract` enforces admin-only result storage and exposes public or
+  admin-gated read interfaces.
 
 ---
 
@@ -69,19 +95,28 @@ Invalid examples: `"abc"` (non-numeric), `""` (empty)
 
 ## Submitting a Result
 
-Once a game is finished, the oracle calls `submit_result` on the escrow
-contract with the `match_id`, `game_id`, and `Winner` enum:
+Once a game is finished, the off-chain oracle service verifies the result via
+an external chess platform API and then submits the verified outcome to the
+escrow contract from the configured oracle address.
 
 ```rust
 // Winner::Player1 | Winner::Player2 | Winner::Draw
-escrow_client.submit_result(&match_id, &winner, &oracle_address);
+escrow_client.submit_result(&match_id, &winner);
 ```
 
-The oracle also records the result independently via `OracleContract::submit_result`:
+That escrow submission is the authoritative payout trigger. The escrow contract
+trusts only its configured oracle address when authorising `submit_result`.
+
+Separately, the oracle service records the same result in the on-chain
+`OracleContract` for auditability and later verification.
 
 ```rust
 oracle_client.submit_result(&match_id, &game_id, &MatchResult::Player1Wins);
 ```
+
+This means the current oracle contract is supplementary: it stores an
+independent result entry and exposes read APIs, but it is not the primary
+authority used by the escrow contract to execute payouts.
 
 ---
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -101,6 +101,27 @@ if env.storage().instance().has(&DataKey::Oracle) {
 
 Prior to fix [#216], contracts had no deployer guard, allowing front-running attacks where malicious actors could initialize contracts with their own admin/oracle addresses immediately after deployment.
 
+## Panic vs Error Behavior
+
+The current contract surface uses a deliberate mix of explicit panics and typed errors:
+
+- `initialize()` in both `EscrowContract` and `OracleContract` contains an explicit `panic!("Contract already initialized")` path when initialization is attempted a second time.
+- All other public contract operations return `Result<_, Error>` and map failures to typed contract errors such as `Unauthorized`, `MatchNotFound`, `ContractPaused`, `InvalidGameId`, and `AlreadySubmitted`.
+- Authorization failures from `require_auth()` are surfaced as contract errors through the Soroban runtime, not as Rust panics.
+- `get_result()` returns `Error::ResultNotFound` for missing entries rather than panicking.
+
+For client implementations, the preferred strategy is to use generated `try_` wrappers where available. These wrappers convert contract error outcomes into host-language `Result` values and make it possible to handle failure paths explicitly.
+
+### Migration Guidance
+
+Clients and test code should prefer `try_` variants for contract invocation whenever possible:
+
+- Use `try_initialize` instead of `initialize` to safely detect duplicate initialization without triggering a hard contract panic.
+- Use `try_submit_result`, `try_create_match`, `try_deposit`, and similar wrappers so that authorization and state validation failures can be inspected programmatically.
+- When `try_` wrappers are unavailable, ensure the host-side caller explicitly handles the contract error code produced by failed invocations.
+
+This document should be revisited after issues #1 and #2 land to capture any contract or API surface changes that affect panic/error semantics and migration steps.
+
 ## Pause Mechanism
 
 Both contracts implement emergency pause functionality for rapid response to security incidents.
@@ -250,5 +271,5 @@ For security-related issues or concerns:
 ## Version History
 
 - **v1.0.0**: Initial security documentation
-- **Last Updated**: April 27, 2026</content>
+- **Last Updated**: May 28, 2026</content>
 <parameter name="filePath">/home/farouq/Desktop/Checkmate-Escrow/docs/security.md


### PR DESCRIPTION
#PR Summary

Issue #636

Updated [oracle.md](https://legendary-space-meme-9ww9jwgvvww2p56w.github.dev/)
Clarified that [EscrowContract](https://legendary-space-meme-9ww9jwgvvww2p56w.github.dev/) oracle address is authoritative for payout submission
Described [OracleContract](https://legendary-space-meme-9ww9jwgvvww2p56w.github.dev/) as a supplementary on-chain audit log
Documented current off-chain oracle flow
Issue #638

Updated [security.md](https://legendary-space-meme-9ww9jwgvvww2p56w.github.dev/)
Added Panic vs Error Behavior section
Documented duplicate-initialize panic path in both contracts
Added migration guidance to prefer try_ wrappers and revisit after issues #1/#2 land

## Closes
Closes #636 
Closes #638 