### PR TITLE
feat: introduce Winner::None as the default unresolved match state

### DIFF
--- a/contracts/escrow/src/errors.rs
+++ b/contracts/escrow/src/errors.rs
@@ -62,4 +62,8 @@ pub enum Error {
     /// (18) `set_match_timeout` was called with a value exceeding the maximum
     /// allowed timeout (~30 days / `MATCH_TTL_LEDGERS`).
     TimeoutTooLarge = 18,
+
+    /// (19) `submit_result` was called with `Winner::None`, which is reserved
+    /// as the initial unresolved state and is not a valid submitted outcome.
+    InvalidWinner = 19,
 }

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -213,7 +213,7 @@ impl EscrowContract {
             player2_deposited: false,
             created_ledger: env.ledger().sequence(),
             completed_ledger: None,
-            winner: Winner::Draw,
+            winner: Winner::None,
         };
 
         env.storage().persistent().set(&DataKey::Match(id), &m);
@@ -394,6 +394,7 @@ impl EscrowContract {
                 client.transfer(&env.current_contract_address(), &m.player1, &m.stake_amount);
                 client.transfer(&env.current_contract_address(), &m.player2, &m.stake_amount);
             }
+            Winner::None => return Err(Error::InvalidWinner),
         }
 
         m.state = MatchState::Completed;

--- a/contracts/escrow/src/types.rs
+++ b/contracts/escrow/src/types.rs
@@ -22,6 +22,9 @@ pub enum Winner {
     Player1,
     Player2,
     Draw,
+    /// Match has not yet been resolved. Used as the initial value on new matches
+    /// so that unresolved and drawn matches are distinguishable.
+    None,
 }
 
 /// Represents a single wagered chess match held in escrow.
@@ -63,7 +66,8 @@ pub struct Match {
     pub created_ledger: u32,
     /// Ledger sequence number at which the match was completed or cancelled, if applicable.
     pub completed_ledger: Option<u32>,
-    /// Outcome of the match. Defaults to `Winner::Draw` until a result is submitted.
+    /// Outcome of the match. `Winner::None` until a result is submitted; set to
+    /// `Player1`, `Player2`, or `Draw` by `submit_result`.
     pub winner: Winner,
 }
 


### PR DESCRIPTION
Winner::Draw is no longer used as the initial value for new matches. Winner::None is set at creation and replaced by the actual outcome when submit_result is called. This makes unresolved and drawn matches distinguishable by inspecting the winner field alone.

submit_result now rejects Winner::None with InvalidWinner (error 19) to prevent the sentinel value from being submitted as a real result.

Closes #547

