### PR TITLE
fix: set completed_ledger when expire_match transitions to terminal s…

### DIFF
--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -619,6 +619,7 @@ impl EscrowContract {
         }
 
         m.state = MatchState::Cancelled;
+        m.completed_ledger = Some(env.ledger().sequence());
         env.storage()
             .persistent()
             .set(&DataKey::Match(match_id), &m);


### PR DESCRIPTION
…tate

Expired matches now record the ledger sequence at which they were finalised, consistent with cancel_match and submit_result. This preserves the metadata needed for historical queries.

Closes #543


