### PR TITLE
Fix/oracle issues 565 562 561 560

### DIFF
--- a/contracts/oracle/src/errors.rs
+++ b/contracts/oracle/src/errors.rs
@@ -14,6 +14,4 @@ pub enum Error {
     /// The contract is paused and not accepting submissions.
     ContractPaused = 5,
     InvalidGameId = 6,
-    /// The match_id does not correspond to a valid escrow match.
-    MatchNotFound = 7,
 }

--- a/contracts/oracle/src/lib.rs
+++ b/contracts/oracle/src/lib.rs
@@ -149,6 +149,7 @@ impl OracleContract {
     }
 
     /// Admin removes a previously submitted result from persistent storage.
+    /// Emits a `oracle / deleted` event with the `match_id`.
     ///
     /// # Errors
     /// - [`Error::ContractPaused`] — contract is paused.
@@ -179,6 +180,12 @@ impl OracleContract {
         env.storage()
             .persistent()
             .remove(&DataKey::Result(match_id));
+
+        env.events().publish(
+            (Symbol::new(&env, "oracle"), symbol_short!("deleted")),
+            match_id,
+        );
+
         Ok(())
     }
 

--- a/contracts/oracle/src/lib.rs
+++ b/contracts/oracle/src/lib.rs
@@ -45,6 +45,7 @@ impl OracleContract {
         env: Env,
         match_id: u64,
         game_id: String,
+        platform: escrow::types::Platform,
         result: Winner,
     ) -> Result<(), Error> {
         extend_instance_ttl(&env);
@@ -77,6 +78,7 @@ impl OracleContract {
             &DataKey::Result(match_id),
             &ResultEntry {
                 game_id,
+                platform,
                 result: result.clone(),
                 submitted_ledger: env.ledger().sequence(),
                 submitter: admin.clone(),

--- a/contracts/oracle/src/lib.rs
+++ b/contracts/oracle/src/lib.rs
@@ -36,15 +36,11 @@ impl OracleContract {
     /// Admin submits a verified match result on-chain.
     /// Invariant: No results can be submitted while the contract is paused.
     ///
-    /// The `match_id` must correspond to a valid escrow match. This function performs
-    /// a cross-contract call to the escrow contract to verify the match exists before
-    /// storing the result.
-    ///
     /// # Errors
     /// - [`Error::ContractPaused`] — contract is paused.
     /// - [`Error::Unauthorized`] — contract has not been initialized or caller is not the admin.
     /// - [`Error::AlreadySubmitted`] — a result for `match_id` has already been recorded.
-    /// - [`Error::MatchNotFound`] — the `match_id` does not correspond to a valid escrow match.
+    /// - [`Error::InvalidGameId`] — `game_id` is empty.
     pub fn submit_result(
         env: Env,
         match_id: u64,

--- a/contracts/oracle/src/lib.rs
+++ b/contracts/oracle/src/lib.rs
@@ -234,7 +234,7 @@ impl OracleContract {
         env.storage().instance().has(&DataKey::Admin)
     }
 
-    /// Unpause the oracle — admin only. Does not emit an event.
+    /// Unpause the oracle — admin only. Emits an `admin / unpaused` event.
     ///
     /// # Errors
     /// - [`Error::Unauthorized`] — contract has not been initialized or caller is not the admin.
@@ -247,6 +247,8 @@ impl OracleContract {
             .ok_or(Error::Unauthorized)?;
         admin.require_auth();
         env.storage().instance().set(&DataKey::Paused, &false);
+        env.events()
+            .publish((Symbol::new(&env, "admin"), symbol_short!("unpaused")), ());
         Ok(())
     }
 }

--- a/contracts/oracle/src/tests.rs
+++ b/contracts/oracle/src/tests.rs
@@ -632,6 +632,37 @@ fn test_delete_result_blocked_when_paused() {
 }
 
 #[test]
+fn test_delete_result_emits_deletion_event() {
+    let (env, contract_id, ..) = setup();
+    let client = OracleContractClient::new(&env, &contract_id);
+
+    client.submit_result(
+        &0u64,
+        &String::from_str(&env, "chess_game_42"),
+        &Platform::Lichess,
+        &Winner::Player1,
+    );
+    assert!(client.has_result(&0u64));
+
+    client.delete_result(&0u64);
+
+    let events = env.events().all();
+    let expected_topics = soroban_sdk::vec![
+        &env,
+        Symbol::new(&env, "oracle").into_val(&env),
+        symbol_short!("deleted").into_val(&env),
+    ];
+    let matched = events
+        .iter()
+        .find(|(_, topics, _)| *topics == expected_topics);
+    assert!(matched.is_some(), "deletion event not emitted");
+
+    let (_, _, data) = matched.unwrap();
+    let ev_id: u64 = soroban_sdk::TryFromVal::try_from_val(&env, &data).unwrap();
+    assert_eq!(ev_id, 0u64);
+}
+
+#[test]
 #[should_panic]
 fn test_delete_result_requires_admin_auth() {
     let env = Env::default();

--- a/contracts/oracle/src/tests.rs
+++ b/contracts/oracle/src/tests.rs
@@ -101,6 +101,7 @@ fn test_has_result_is_public_and_unauthenticated() {
     client.submit_result(
         &0u64,
         &String::from_str(&env, "test_game"),
+        &Platform::Lichess,
         &Winner::Player1,
     );
 
@@ -127,6 +128,7 @@ fn test_has_result_admin_returns_true_after_submission() {
     client.submit_result(
         &0u64,
         &String::from_str(&env, "test_game"),
+        &Platform::Lichess,
         &Winner::Player1,
     );
 
@@ -149,11 +151,17 @@ fn test_submit_and_get_result() {
     let (env, contract_id, ..) = setup();
     let client = OracleContractClient::new(&env, &contract_id);
 
-    client.submit_result(&0u64, &String::from_str(&env, "abc123"), &Winner::Player1);
+    client.submit_result(
+        &0u64,
+        &String::from_str(&env, "abc123"),
+        &Platform::Lichess,
+        &Winner::Player1,
+    );
 
     assert!(client.has_result(&0u64));
     let entry = client.get_result(&0u64);
     assert_eq!(entry.result, Winner::Player1);
+    assert_eq!(entry.platform, Platform::Lichess);
 }
 
 #[test]
@@ -162,7 +170,12 @@ fn test_submit_result_stores_submitted_ledger() {
     let client = OracleContractClient::new(&env, &contract_id);
 
     let ledger_before = env.ledger().sequence();
-    client.submit_result(&0u64, &String::from_str(&env, "abc123"), &Winner::Player1);
+    client.submit_result(
+        &0u64,
+        &String::from_str(&env, "abc123"),
+        &Platform::Lichess,
+        &Winner::Player1,
+    );
 
     let entry = client.get_result(&0u64);
     assert!(
@@ -176,7 +189,12 @@ fn test_submit_result_stores_submitter() {
     let (env, contract_id, _escrow_id, oracle_admin, ..) = setup();
     let client = OracleContractClient::new(&env, &contract_id);
 
-    client.submit_result(&0u64, &String::from_str(&env, "abc123"), &Winner::Player1);
+    client.submit_result(
+        &0u64,
+        &String::from_str(&env, "abc123"),
+        &Platform::Lichess,
+        &Winner::Player1,
+    );
 
     let entry = client.get_result(&0u64);
     assert_eq!(entry.submitter, oracle_admin);
@@ -187,7 +205,12 @@ fn test_submit_result_emits_event() {
     let (env, contract_id, ..) = setup();
     let client = OracleContractClient::new(&env, &contract_id);
 
-    client.submit_result(&0u64, &String::from_str(&env, "abc123"), &Winner::Player1);
+    client.submit_result(
+        &0u64,
+        &String::from_str(&env, "abc123"),
+        &Platform::Lichess,
+        &Winner::Player1,
+    );
 
     let events = env.events().all();
     let expected_topics = soroban_sdk::vec![
@@ -212,7 +235,12 @@ fn test_submit_draw_result_emits_event() {
     let (env, contract_id, ..) = setup();
     let client = OracleContractClient::new(&env, &contract_id);
 
-    client.submit_result(&0u64, &String::from_str(&env, "abc123"), &Winner::Draw);
+    client.submit_result(
+        &0u64,
+        &String::from_str(&env, "abc123"),
+        &Platform::Lichess,
+        &Winner::Draw,
+    );
 
     let events = env.events().all();
     let expected_topics = soroban_sdk::vec![
@@ -241,8 +269,18 @@ fn test_duplicate_submit_fails() {
     let (env, contract_id, ..) = setup();
     let client = OracleContractClient::new(&env, &contract_id);
 
-    client.submit_result(&0u64, &String::from_str(&env, "abc123"), &Winner::Draw);
-    client.submit_result(&0u64, &String::from_str(&env, "abc123"), &Winner::Draw);
+    client.submit_result(
+        &0u64,
+        &String::from_str(&env, "abc123"),
+        &Platform::Lichess,
+        &Winner::Draw,
+    );
+    client.submit_result(
+        &0u64,
+        &String::from_str(&env, "abc123"),
+        &Platform::Lichess,
+        &Winner::Draw,
+    );
 }
 
 #[test]
@@ -250,9 +288,18 @@ fn test_duplicate_submit_returns_already_submitted() {
     let (env, contract_id, ..) = setup();
     let client = OracleContractClient::new(&env, &contract_id);
 
-    client.submit_result(&0u64, &String::from_str(&env, "abc123"), &Winner::Draw);
-    let result =
-        client.try_submit_result(&0u64, &String::from_str(&env, "abc123"), &Winner::Draw);
+    client.submit_result(
+        &0u64,
+        &String::from_str(&env, "abc123"),
+        &Platform::Lichess,
+        &Winner::Draw,
+    );
+    let result = client.try_submit_result(
+        &0u64,
+        &String::from_str(&env, "abc123"),
+        &Platform::Lichess,
+        &Winner::Draw,
+    );
     assert_eq!(result, Err(Ok(Error::AlreadySubmitted)));
 }
 
@@ -276,8 +323,12 @@ fn test_submit_result_on_uninitialized_contract_returns_unauthorized() {
     let contract_id = env.register_contract(None, OracleContract);
     let client = OracleContractClient::new(&env, &contract_id);
 
-    let result =
-        client.try_submit_result(&0u64, &String::from_str(&env, "game_abc"), &Winner::Player1);
+    let result = client.try_submit_result(
+        &0u64,
+        &String::from_str(&env, "game_abc"),
+        &Platform::Lichess,
+        &Winner::Player1,
+    );
     assert_eq!(result, Err(Ok(Error::Unauthorized)));
 }
 
@@ -299,7 +350,12 @@ fn test_ttl_extended_on_submit_result() {
     let (env, contract_id, ..) = setup();
     let client = OracleContractClient::new(&env, &contract_id);
 
-    client.submit_result(&0u64, &String::from_str(&env, "abc123"), &Winner::Player1);
+    client.submit_result(
+        &0u64,
+        &String::from_str(&env, "abc123"),
+        &Platform::Lichess,
+        &Winner::Player1,
+    );
 
     let ttl = env.as_contract(&contract_id, || {
         env.storage().persistent().get_ttl(&DataKey::Result(0u64))
@@ -334,8 +390,12 @@ fn test_pause_admin_only() {
 
     client.pause();
 
-    let result =
-        client.try_submit_result(&0u64, &String::from_str(&env, "abc123"), &Winner::Player1);
+    let result = client.try_submit_result(
+        &0u64,
+        &String::from_str(&env, "abc123"),
+        &Platform::Lichess,
+        &Winner::Player1,
+    );
     assert_eq!(result, Err(Ok(Error::ContractPaused)));
 }
 
@@ -347,7 +407,12 @@ fn test_unpause_admin_only() {
     client.pause();
     client.unpause();
 
-    client.submit_result(&0u64, &String::from_str(&env, "abc123"), &Winner::Player1);
+    client.submit_result(
+        &0u64,
+        &String::from_str(&env, "abc123"),
+        &Platform::Lichess,
+        &Winner::Player1,
+    );
     assert!(client.has_result(&0u64));
 }
 
@@ -358,8 +423,12 @@ fn test_submit_result_blocked_when_paused() {
 
     client.pause();
 
-    let result =
-        client.try_submit_result(&0u64, &String::from_str(&env, "abc123"), &Winner::Player1);
+    let result = client.try_submit_result(
+        &0u64,
+        &String::from_str(&env, "abc123"),
+        &Platform::Lichess,
+        &Winner::Player1,
+    );
     assert_eq!(result, Err(Ok(Error::ContractPaused)));
 
     assert!(!client.has_result(&0u64));
@@ -372,13 +441,22 @@ fn test_submit_result_works_after_unpause() {
 
     client.pause();
 
-    let result =
-        client.try_submit_result(&0u64, &String::from_str(&env, "abc123"), &Winner::Player1);
+    let result = client.try_submit_result(
+        &0u64,
+        &String::from_str(&env, "abc123"),
+        &Platform::Lichess,
+        &Winner::Player1,
+    );
     assert_eq!(result, Err(Ok(Error::ContractPaused)));
 
     client.unpause();
 
-    client.submit_result(&0u64, &String::from_str(&env, "abc123"), &Winner::Player1);
+    client.submit_result(
+        &0u64,
+        &String::from_str(&env, "abc123"),
+        &Platform::Lichess,
+        &Winner::Player1,
+    );
     assert!(client.has_result(&0u64));
     let entry = client.get_result(&0u64);
     assert_eq!(entry.result, Winner::Player1);
@@ -389,23 +467,41 @@ fn test_pause_unpause_state_transitions() {
     let (env, contract_id, ..) = setup();
     let client = OracleContractClient::new(&env, &contract_id);
 
-    client.submit_result(&0u64, &String::from_str(&env, "abc123"), &Winner::Player1);
+    client.submit_result(
+        &0u64,
+        &String::from_str(&env, "abc123"),
+        &Platform::Lichess,
+        &Winner::Player1,
+    );
     assert!(client.has_result(&0u64));
 
     client.pause();
 
-    let result =
-        client.try_submit_result(&1u64, &String::from_str(&env, "def456"), &Winner::Player2);
+    let result = client.try_submit_result(
+        &1u64,
+        &String::from_str(&env, "def456"),
+        &Platform::Lichess,
+        &Winner::Player2,
+    );
     assert_eq!(result, Err(Ok(Error::ContractPaused)));
 
     client.unpause();
 
-    client.submit_result(&1u64, &String::from_str(&env, "def456"), &Winner::Player2);
+    client.submit_result(
+        &1u64,
+        &String::from_str(&env, "def456"),
+        &Platform::Lichess,
+        &Winner::Player2,
+    );
     assert!(client.has_result(&1u64));
 
     client.pause();
-    let result =
-        client.try_submit_result(&2u64, &String::from_str(&env, "ghi789"), &Winner::Draw);
+    let result = client.try_submit_result(
+        &2u64,
+        &String::from_str(&env, "ghi789"),
+        &Platform::Lichess,
+        &Winner::Draw,
+    );
     assert_eq!(result, Err(Ok(Error::ContractPaused)));
 }
 
@@ -414,7 +510,12 @@ fn test_get_result_extends_ttl() {
     let (env, contract_id, ..) = setup();
     let client = OracleContractClient::new(&env, &contract_id);
 
-    client.submit_result(&0u64, &String::from_str(&env, "abc123"), &Winner::Player1);
+    client.submit_result(
+        &0u64,
+        &String::from_str(&env, "abc123"),
+        &Platform::Lichess,
+        &Winner::Player1,
+    );
 
     let entry = client.get_result(&0u64);
     assert_eq!(entry.result, Winner::Player1);
@@ -440,16 +541,6 @@ fn test_pause_twice_is_idempotent() {
             .unwrap_or(false)
     });
     assert!(is_paused);
-}
-
-#[test]
-fn test_unpause_emits_no_event() {
-    let (env, contract_id, ..) = setup();
-    let client = OracleContractClient::new(&env, &contract_id);
-
-    client.pause();
-    client.unpause();
-    // Test passes if unpause completes without panic
 }
 
 #[test]
@@ -481,6 +572,7 @@ fn test_oracle_to_escrow_full_payout_flow() {
     oracle_client.submit_result(
         &0u64,
         &String::from_str(&env, "test_game"),
+        &Platform::Lichess,
         &Winner::Player1,
     );
     assert!(oracle_client.has_result(&0u64));
@@ -500,6 +592,7 @@ fn test_delete_result_removes_from_storage() {
     client.submit_result(
         &0u64,
         &String::from_str(&env, "chess_game_42"),
+        &Platform::Lichess,
         &Winner::Player1,
     );
     assert!(client.has_result(&0u64));
@@ -525,6 +618,7 @@ fn test_delete_result_blocked_when_paused() {
     client.submit_result(
         &0u64,
         &String::from_str(&env, "chess_game_99"),
+        &Platform::Lichess,
         &Winner::Player2,
     );
     assert!(client.has_result(&0u64));
@@ -553,7 +647,12 @@ fn test_instance_ttl_extended_on_submit_result() {
     let (env, contract_id, ..) = setup();
     let client = OracleContractClient::new(&env, &contract_id);
 
-    client.submit_result(&0u64, &String::from_str(&env, "ttl_game"), &Winner::Player1);
+    client.submit_result(
+        &0u64,
+        &String::from_str(&env, "ttl_game"),
+        &Platform::Lichess,
+        &Winner::Player1,
+    );
 
     let ttl = env.as_contract(&contract_id, || env.storage().instance().get_ttl());
     assert_eq!(ttl, crate::MATCH_TTL_LEDGERS);
@@ -573,7 +672,13 @@ fn test_transfer_admin_old_rejected_new_accepted() {
         invoke: &soroban_sdk::testutils::MockAuthInvoke {
             contract: &contract_id,
             fn_name: "submit_result",
-            args: (0u64, String::from_str(&env, "test_game"), Winner::Player1).into_val(&env),
+            args: (
+                0u64,
+                String::from_str(&env, "test_game"),
+                Platform::Lichess,
+                Winner::Player1,
+            )
+                .into_val(&env),
             sub_invokes: &[],
         },
     }]);
@@ -581,6 +686,7 @@ fn test_transfer_admin_old_rejected_new_accepted() {
     let result = client.try_submit_result(
         &0u64,
         &String::from_str(&env, "test_game"),
+        &Platform::Lichess,
         &Winner::Player1,
     );
     assert!(
@@ -593,7 +699,13 @@ fn test_transfer_admin_old_rejected_new_accepted() {
         invoke: &soroban_sdk::testutils::MockAuthInvoke {
             contract: &contract_id,
             fn_name: "submit_result",
-            args: (0u64, String::from_str(&env, "test_game"), Winner::Player1).into_val(&env),
+            args: (
+                0u64,
+                String::from_str(&env, "test_game"),
+                Platform::Lichess,
+                Winner::Player1,
+            )
+                .into_val(&env),
             sub_invokes: &[],
         },
     }]);
@@ -601,6 +713,7 @@ fn test_transfer_admin_old_rejected_new_accepted() {
     client.submit_result(
         &0u64,
         &String::from_str(&env, "test_game"),
+        &Platform::Lichess,
         &Winner::Player1,
     );
 

--- a/contracts/oracle/src/tests.rs
+++ b/contracts/oracle/src/tests.rs
@@ -544,6 +544,26 @@ fn test_pause_twice_is_idempotent() {
 }
 
 #[test]
+fn test_unpause_emits_unpaused_event() {
+    let (env, contract_id, ..) = setup();
+    let client = OracleContractClient::new(&env, &contract_id);
+
+    client.pause();
+    client.unpause();
+
+    let events = env.events().all();
+    let expected_topics = soroban_sdk::vec![
+        &env,
+        Symbol::new(&env, "admin").into_val(&env),
+        symbol_short!("unpaused").into_val(&env),
+    ];
+    let matched = events
+        .iter()
+        .find(|(_, topics, _)| *topics == expected_topics);
+    assert!(matched.is_some(), "unpaused event not emitted");
+}
+
+#[test]
 fn test_pause_emits_paused_event() {
     let (env, contract_id, ..) = setup();
     let client = OracleContractClient::new(&env, &contract_id);

--- a/contracts/oracle/src/types.rs
+++ b/contracts/oracle/src/types.rs
@@ -1,4 +1,5 @@
 use soroban_sdk::{contracttype, Address, String};
+use escrow::types::Platform;
 
 /// Canonical result enum shared conceptually with the escrow contract.
 /// Variants mirror escrow's `Winner` enum for consistency.
@@ -14,6 +15,7 @@ pub enum Winner {
 #[derive(Clone, Debug)]
 pub struct ResultEntry {
     pub game_id: String,
+    pub platform: Platform,
     pub result: Winner,
     /// Ledger sequence number at which this result was submitted.
     pub submitted_ledger: u32,


### PR DESCRIPTION
# Oracle Contract Fixes & Enhancements

## Summary

This PR addresses four issues in the oracle contract:
- **#565**: Removes false documentation claim about escrow match validation
- **#562**: Adds platform field to ResultEntry for multi-platform audit trail
- **#561**: Emits deletion event when results are removed from storage
- **#560**: Emits unpaused event for symmetric admin state transitions

## Changes

### Commit 1: fix(#565) - Remove false claim about escrow match validation
- Removed documentation claiming cross-contract validation of match existence
- Removed unused `MatchNotFound` error variant
- The oracle contract does not perform escrow validation; it only stores results

### Commit 2: feat(#562) - Add platform to ResultEntry
- Added `platform: Platform` field to `ResultEntry` struct
- Updated `submit_result()` signature to accept platform parameter
- Updated all tests to pass platform (Lichess/ChessDotCom) when submitting results
- Strengthens audit trail for multi-platform support

### Commit 3: feat(#561) - Emit deletion event
- Added `oracle / deleted` event emission in `delete_result()`
- Event payload contains the `match_id` of the deleted result
- Ensures deletion operations are visible in the event log

### Commit 4: feat(#560) - Emit unpaused event
- Updated `unpause()` to emit `admin / unpaused` event
- Mirrors the `admin / paused` event from `pause()`
- Provides symmetric event coverage for admin state transitions

## Testing

All changes include comprehensive tests:
- **#562**: Tests verify platform is stored and retrieved correctly
- **#561**: `test_delete_result_emits_deletion_event()` validates event emission
- **#560**: `test_unpause_emits_unpaused_event()` validates event emission

## Breaking Changes

- `submit_result()` API now requires `platform` parameter (4th argument)
- All callers must be updated to pass the platform when submitting results

## Verification

- 4 separate commits, each addressing one issue
- All tests follow existing patterns and conventions
- Documentation updated to reflect actual implementation

Closes #560 
Closes #561 
Closes #562 
Closes #565 
