### PR TITLE
Feat/token allowlist tests

### DIFF
--- a/contracts/escrow/src/errors.rs
+++ b/contracts/escrow/src/errors.rs
@@ -19,4 +19,5 @@ pub enum Error {
     MatchNotExpired = 14,
     InvalidGameId = 15,
     InvalidPlayers = 16,
+    TokenNotAllowed = 17,
 }

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -63,6 +63,58 @@ impl EscrowContract {
         Ok(())
     }
 
+    /// Add a token to the allowlist — admin only.
+    pub fn add_allowed_token(env: Env, token: Address) -> Result<(), Error> {
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(Error::Unauthorized)?;
+        admin.require_auth();
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::AllowedToken(token.clone()), &true);
+        env.storage()
+            .persistent()
+            .extend_ttl(&DataKey::AllowedToken(token.clone()), MATCH_TTL_LEDGERS, MATCH_TTL_LEDGERS);
+        env.storage().instance().set(&DataKey::AllowlistEnforced, &true);
+
+        env.events().publish(
+            (Symbol::new(&env, "admin"), symbol_short!("token_add")),
+            token,
+        );
+        Ok(())
+    }
+
+    /// Remove a token from the allowlist — admin only.
+    pub fn remove_allowed_token(env: Env, token: Address) -> Result<(), Error> {
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(Error::Unauthorized)?;
+        admin.require_auth();
+
+        env.storage()
+            .persistent()
+            .remove(&DataKey::AllowedToken(token.clone()));
+
+        env.events().publish(
+            (Symbol::new(&env, "admin"), symbol_short!("token_remove")),
+            token,
+        );
+        Ok(())
+    }
+
+    /// Check if a token is allowed.
+    pub fn is_token_allowed(env: Env, token: Address) -> bool {
+        env.storage()
+            .persistent()
+            .get(&DataKey::AllowedToken(token))
+            .unwrap_or(false)
+    }
+
     /// Create a new match. Both players must call `deposit` before the game starts.
     ///
     /// # Parameters
@@ -98,6 +150,17 @@ impl EscrowContract {
         {
             return Err(Error::ContractPaused);
         }
+
+        // Check allowlist enforcement
+        let allowlist_enforced: bool = env
+            .storage()
+            .instance()
+            .get(&DataKey::AllowlistEnforced)
+            .unwrap_or(false);
+        if allowlist_enforced && !Self::is_token_allowed(env.clone(), token.clone()) {
+            return Err(Error::TokenNotAllowed);
+        }
+
         if stake_amount <= 0 {
             return Err(Error::InvalidAmount);
         }

--- a/contracts/escrow/src/tests/mod.rs
+++ b/contracts/escrow/src/tests/mod.rs
@@ -12,6 +12,7 @@ mod events;
 mod index;
 mod lifecycle;
 mod ttl;
+mod token_allowlist;
 
 pub fn setup() -> (Env, Address, Address, Address, Address, Address, Address) {
     let env = Env::default();

--- a/contracts/escrow/src/tests/token_allowlist.rs
+++ b/contracts/escrow/src/tests/token_allowlist.rs
@@ -54,3 +54,52 @@ fn test_removed_tokens_can_no_longer_be_used_for_new_matches() {
         "create_match should reject removed token"
     );
 }
+
+#[test]
+fn test_multiple_approved_tokens_can_coexist_after_allowlist_enforcement_is_enabled() {
+    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let token2_id = env.register_stellar_asset_contract_v2(Address::generate(&env));
+    let token2_addr = token2_id.address();
+    let asset_client2 = StellarAssetClient::new(&env, &token2_addr);
+    asset_client2.mint(&player1, &1000);
+    asset_client2.mint(&player2, &1000);
+
+    client.add_allowed_token(&token);
+    client.add_allowed_token(&token2_addr);
+
+    let id1 = client.create_match(
+        &player1,
+        &player2,
+        &100,
+        &token,
+        &String::from_str(&env, "game_token1"),
+        &Platform::Lichess,
+    );
+    assert_eq!(id1, 0, "first match with token1 should succeed");
+
+    let id2 = client.create_match(
+        &player1,
+        &player2,
+        &100,
+        &token2_addr,
+        &String::from_str(&env, "game_token2"),
+        &Platform::Lichess,
+    );
+    assert_eq!(id2, 1, "second match with token2 should succeed");
+
+    let unknown_token = Address::generate(&env);
+    let result = client.try_create_match(
+        &player1,
+        &player2,
+        &100,
+        &unknown_token,
+        &String::from_str(&env, "game_unknown"),
+        &Platform::Lichess,
+    );
+    assert!(
+        result.is_err(),
+        "create_match should reject unknown token when allowlist is enforced"
+    );
+}

--- a/contracts/escrow/src/tests/token_allowlist.rs
+++ b/contracts/escrow/src/tests/token_allowlist.rs
@@ -32,3 +32,25 @@ fn test_add_allowed_token_emits_event() {
     let ev_token: Address = TryFromVal::try_from_val(&env, &data).unwrap();
     assert_eq!(ev_token, token);
 }
+
+#[test]
+fn test_removed_tokens_can_no_longer_be_used_for_new_matches() {
+    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    client.add_allowed_token(&token);
+    client.remove_allowed_token(&token);
+
+    let result = client.try_create_match(
+        &player1,
+        &player2,
+        &100,
+        &token,
+        &String::from_str(&env, "removed_token_game"),
+        &Platform::Lichess,
+    );
+    assert!(
+        result.is_err(),
+        "create_match should reject removed token"
+    );
+}

--- a/contracts/escrow/src/tests/token_allowlist.rs
+++ b/contracts/escrow/src/tests/token_allowlist.rs
@@ -1,0 +1,11 @@
+use super::*;
+
+#[test]
+fn test_is_token_allowed_returns_false_for_unknown_tokens() {
+    let (env, contract_id, _oracle, _player1, _player2, _token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let unknown_token = Address::generate(&env);
+    let result = client.is_token_allowed(&unknown_token);
+    assert!(!result, "unknown token should not be allowed");
+}

--- a/contracts/escrow/src/tests/token_allowlist.rs
+++ b/contracts/escrow/src/tests/token_allowlist.rs
@@ -9,3 +9,26 @@ fn test_is_token_allowed_returns_false_for_unknown_tokens() {
     let result = client.is_token_allowed(&unknown_token);
     assert!(!result, "unknown token should not be allowed");
 }
+
+#[test]
+fn test_add_allowed_token_emits_event() {
+    let (env, contract_id, _oracle, _player1, _player2, token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    client.add_allowed_token(&token);
+
+    let events = env.events().all();
+    let expected_topics = vec![
+        &env,
+        Symbol::new(&env, "admin").into_val(&env),
+        soroban_sdk::symbol_short!("token_add").into_val(&env),
+    ];
+    let matched = events
+        .iter()
+        .find(|(_, topics, _)| *topics == expected_topics);
+    assert!(matched.is_some(), "token_add event not emitted");
+
+    let (_, _, data) = matched.unwrap();
+    let ev_token: Address = TryFromVal::try_from_val(&env, &data).unwrap();
+    assert_eq!(ev_token, token);
+}

--- a/contracts/escrow/src/types.rs
+++ b/contracts/escrow/src/types.rs
@@ -52,4 +52,7 @@ pub enum DataKey {
     Paused,
     GameId(String),
     LiveMatches,
+    AllowedToken(Address),
+    AllowlistEnforced,
+    OracleRecord(u64),
 }


### PR DESCRIPTION
# Token Allowlist Tests - Issues #585, #586, #587, #588

## Summary

This PR implements comprehensive test coverage for the token allowlist feature in the Checkmate-Escrow smart contract. The implementation adds admin-controlled token allowlisting with event emission and enforcement in match creation.

## Changes

### Infrastructure
- Added `AllowedToken(Address)` and `AllowlistEnforced` to `DataKey` enum for persistent storage
- Added `OracleRecord(u64)` to `DataKey` enum (required by existing code)
- Added `TokenNotAllowed` error variant (error code 17)

### Contract Functions
- **`add_allowed_token(token: Address)`** — Admin-only function to add a token to the allowlist. Emits `admin/token_add` event and enables allowlist enforcement.
- **`remove_allowed_token(token: Address)`** — Admin-only function to remove a token from the allowlist. Emits `admin/token_remove` event.
- **`is_token_allowed(token: Address) -> bool`** — Public getter to check if a token is on the allowlist. Returns `false` for unknown tokens.
- **Allowlist enforcement in `create_match`** — When allowlist is enforced (after first token is added), only allowlisted tokens can be used for new matches.

### Tests (4 commits)

#### Commit 1: test(#587) - is_token_allowed returns false for unknown tokens
- Verifies that `is_token_allowed` returns `false` for tokens not on the allowlist
- Tests the getter behavior for unset values

#### Commit 2: test(#588) - adding an allowed token emits an event
- Verifies `add_allowed_token` emits `admin/token_add` event
- Asserts event topics and payload contain the correct token address

#### Commit 3: test(#586) - removed tokens can no longer be used for new matches
- Tests that after removing a token from the allowlist, `create_match` rejects it
- Verifies allowlist enforcement persists after token removal

#### Commit 4: test(#585) - multiple approved tokens can coexist after allowlist enforcement is enabled
- Adds two distinct tokens to the allowlist
- Creates matches using both approved tokens and verifies both succeed
- Asserts that an unrelated token still fails when allowlist is enforced

## Behavior

### Allowlist Enforcement
- **Before first token is added**: No allowlist enforcement; any token can be used
- **After first token is added**: Allowlist enforcement is enabled; only allowlisted tokens can be used
- **Token removal**: Removed tokens are immediately rejected for new matches

### Events
- `admin/token_add` — Emitted when a token is added to the allowlist
- `admin/token_remove` — Emitted when a token is removed from the allowlist

## Testing

All tests follow the existing test patterns in the codebase:
- Use the `setup()` helper to initialize contract and players
- Use `EscrowContractClient` for contract interactions
- Verify events using `env.events().all()`
- Use `try_*` methods to test error cases

## Related Issues

- #587 — Add Test: is_token_allowed returns false for unknown tokens
- #588 — Add Test: adding an allowed token emits an event
- #586 — Add Test: removed tokens can no longer be used for new matches
- #585 — Add Test: multiple approved tokens can coexist after allowlist enforcement is enabled

Closes #585 
Closes #586 
Closes #587 
Closes #588 