### PR TITLE
Feat/admin transfer tests

### DIFF
--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -436,6 +436,45 @@ impl EscrowContract {
             .ok_or(Error::Unauthorized)
     }
 
+    /// Propose a new admin. Current admin only. Stores pending admin without transferring authority.
+    pub fn propose_admin(env: Env, new_admin: Address) -> Result<(), Error> {
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(Error::Unauthorized)?;
+        admin.require_auth();
+
+        env.storage()
+            .instance()
+            .set(&DataKey::PendingAdmin, &new_admin);
+        env.events().publish(
+            (Symbol::new(&env, "admin"), symbol_short!("propose")),
+            new_admin,
+        );
+        Ok(())
+    }
+
+    /// Accept pending admin proposal. Pending admin only. Finalizes the transfer.
+    pub fn accept_admin(env: Env) -> Result<(), Error> {
+        let pending_admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::PendingAdmin)
+            .ok_or(Error::Unauthorized)?;
+        pending_admin.require_auth();
+
+        env.storage()
+            .instance()
+            .set(&DataKey::Admin, &pending_admin);
+        env.storage().instance().remove(&DataKey::PendingAdmin);
+        env.events().publish(
+            (Symbol::new(&env, "admin"), symbol_short!("xfer")),
+            pending_admin,
+        );
+        Ok(())
+    }
+
     /// Read a match by ID.
     pub fn get_match(env: Env, match_id: u64) -> Result<Match, Error> {
         env.storage()

--- a/contracts/escrow/src/tests/admin.rs
+++ b/contracts/escrow/src/tests/admin.rs
@@ -534,3 +534,43 @@ fn test_current_admin_retains_privileges_after_propose_before_accept() {
     client.pause();
     assert!(client.is_paused());
 }
+
+
+// #596 - proposing a second pending admin cleanly replaces the first proposal
+#[test]
+fn test_second_pending_admin_replaces_first_proposal() {
+    let (env, contract_id, _oracle, _player1, _player2, _token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let pending_admin_a = Address::generate(&env);
+    let pending_admin_b = Address::generate(&env);
+
+    client.propose_admin(&pending_admin_a);
+    client.propose_admin(&pending_admin_b);
+
+    env.mock_auths(&[MockAuth {
+        address: &pending_admin_a,
+        invoke: &MockAuthInvoke {
+            contract: &contract_id,
+            fn_name: "accept_admin",
+            args: ().into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+
+    let result = client.try_accept_admin();
+    assert!(result.is_err(), "pending_admin_a should not be able to accept");
+
+    env.mock_auths(&[MockAuth {
+        address: &pending_admin_b,
+        invoke: &MockAuthInvoke {
+            contract: &contract_id,
+            fn_name: "accept_admin",
+            args: ().into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+
+    client.accept_admin();
+    assert_eq!(client.get_admin(), pending_admin_b);
+}

--- a/contracts/escrow/src/tests/admin.rs
+++ b/contracts/escrow/src/tests/admin.rs
@@ -510,3 +510,27 @@ fn test_accept_admin_finalizes_transfer_and_emits_event() {
     let ev_new_admin: Address = TryFromVal::try_from_val(&env, &data).unwrap();
     assert_eq!(ev_new_admin, new_admin);
 }
+
+
+// #595 - current admin retains privileges after propose_admin and before accept_admin
+#[test]
+fn test_current_admin_retains_privileges_after_propose_before_accept() {
+    let (env, contract_id, _oracle, _player1, _player2, _token, admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let new_admin = Address::generate(&env);
+    client.propose_admin(&new_admin);
+
+    env.mock_auths(&[MockAuth {
+        address: &admin,
+        invoke: &MockAuthInvoke {
+            contract: &contract_id,
+            fn_name: "pause",
+            args: ().into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+
+    client.pause();
+    assert!(client.is_paused());
+}

--- a/contracts/escrow/src/tests/admin.rs
+++ b/contracts/escrow/src/tests/admin.rs
@@ -471,3 +471,42 @@ fn test_propose_admin_stores_pending_admin_and_emits_event() {
     let ev_pending: Address = TryFromVal::try_from_val(&env, &data).unwrap();
     assert_eq!(ev_pending, new_admin);
 }
+
+
+// #594 - accept_admin finalizes the transfer and emits an event
+#[test]
+fn test_accept_admin_finalizes_transfer_and_emits_event() {
+    let (env, contract_id, _oracle, _player1, _player2, _token, admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let new_admin = Address::generate(&env);
+    client.propose_admin(&new_admin);
+
+    env.mock_auths(&[MockAuth {
+        address: &new_admin,
+        invoke: &MockAuthInvoke {
+            contract: &contract_id,
+            fn_name: "accept_admin",
+            args: ().into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+
+    client.accept_admin();
+    assert_eq!(client.get_admin(), new_admin);
+
+    let events = env.events().all();
+    let expected_topics = vec![
+        &env,
+        Symbol::new(&env, "admin").into_val(&env),
+        symbol_short!("xfer").into_val(&env),
+    ];
+    let matched = events
+        .iter()
+        .find(|(_, topics, _)| *topics == expected_topics);
+    assert!(matched.is_some(), "xfer event not emitted");
+
+    let (_, _, data) = matched.unwrap();
+    let ev_new_admin: Address = TryFromVal::try_from_val(&env, &data).unwrap();
+    assert_eq!(ev_new_admin, new_admin);
+}

--- a/contracts/escrow/src/tests/admin.rs
+++ b/contracts/escrow/src/tests/admin.rs
@@ -445,3 +445,29 @@ fn test_is_paused_cycle() {
     client.unpause();
     assert!(!client.is_paused());
 }
+
+
+// #593 - propose_admin stores the pending admin and emits an event
+#[test]
+fn test_propose_admin_stores_pending_admin_and_emits_event() {
+    let (env, contract_id, _oracle, _player1, _player2, _token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let new_admin = Address::generate(&env);
+    client.propose_admin(&new_admin);
+
+    let events = env.events().all();
+    let expected_topics = vec![
+        &env,
+        Symbol::new(&env, "admin").into_val(&env),
+        symbol_short!("propose").into_val(&env),
+    ];
+    let matched = events
+        .iter()
+        .find(|(_, topics, _)| *topics == expected_topics);
+    assert!(matched.is_some(), "propose event not emitted");
+
+    let (_, _, data) = matched.unwrap();
+    let ev_pending: Address = TryFromVal::try_from_val(&env, &data).unwrap();
+    assert_eq!(ev_pending, new_admin);
+}

--- a/contracts/escrow/src/types.rs
+++ b/contracts/escrow/src/types.rs
@@ -49,7 +49,9 @@ pub enum DataKey {
     MatchCount,
     Oracle,
     Admin,
+    PendingAdmin,
     Paused,
     GameId(String),
     LiveMatches,
+    OracleRecord(u64),
 }


### PR DESCRIPTION
## Summary

Implements two-step admin transfer mechanism with comprehensive test coverage. Adds `propose_admin` and `accept_admin` functions to enable secure admin transitions where the current admin proposes a new admin, and the proposed admin must explicitly accept the transfer before authority changes hands.

## Related Issues

- #593 - Add Test: propose_admin stores the pending admin and emits an event
- #594 - Add Test: accept_admin finalizes the transfer and emits an event
- #595 - Add Test: current admin retains privileges after propose_admin and before accept_admin
- #596 - Add Test: proposing a second pending admin cleanly replaces the first proposal

## What changed

### Contracts
- Added `PendingAdmin` and `OracleRecord` variants to `DataKey` enum in `types.rs`
- Implemented `propose_admin(new_admin)` function: stores pending admin without transferring authority, emits `admin/propose` event
- Implemented `accept_admin()` function: finalizes transfer by setting pending admin as current admin, emits `admin/xfer` event

### Tests
- **#593**: `test_propose_admin_stores_pending_admin_and_emits_event` - Verifies proposal stores pending admin and emits event
- **#594**: `test_accept_admin_finalizes_transfer_and_emits_event` - Verifies acceptance finalizes transfer and emits event
- **#595**: `test_current_admin_retains_privileges_after_propose_before_accept` - Verifies current admin can still call admin functions during pending state
- **#596**: `test_second_pending_admin_replaces_first_proposal` - Verifies second proposal overwrites first, only second can accept

### Events / API / Storage
- New events: `admin/propose` (emits pending admin address), `admin/xfer` (emits new admin address)
- New storage key: `DataKey::PendingAdmin` to track pending admin during two-step transfer
- New storage key: `DataKey::OracleRecord(u64)` for oracle audit trail

## Verification

All tests pass and cover:
- ✅ Proposal stores pending admin correctly
- ✅ Acceptance finalizes transfer and updates admin
- ✅ Current admin retains full privileges during pending state
- ✅ Second proposal cleanly replaces first (only second can accept)
- ✅ Events emitted with correct data

## Checklist

- [x] I added tests covering all four scenarios
- [x] I confirmed no docs update is needed (existing runbook-rotation.md already documents this flow)
- [x] I confirmed event/storage changes are documented in this PR
- [x] I verified the two-step transfer flow is secure (current admin retains control until acceptance)
- [x] I linked this PR to the related issues

## Notes

- The two-step transfer provides security by allowing the current admin to change their mind before acceptance
- Proposing a new admin twice cleanly replaces the first proposal (no need for explicit cancellation)
- Current admin retains all privileges (pause, unpause, update_oracle) until the new admin accepts
- Once accepted, the old admin has no authority and must use the two-step process to regain control

Closes #593 
Closes #594 
Closes #595 
Closes #596 