### PR TITLE
Test/oracle events

### DIFF
--- a/contracts/oracle/src/tests.rs
+++ b/contracts/oracle/src/tests.rs
@@ -852,3 +852,36 @@ fn test_oracle_escrow_integration_submit_result_with_oracle_record() {
     let m = escrow_client.get_match(&match_id);
     assert_eq!(m.state, MatchState::Active);
 }
+
+
+// ── Test #599: delete_result emits event ────────────────────────────────
+
+#[test]
+fn test_delete_result_emits_deletion_event() {
+    let (env, contract_id, ..) = setup();
+    let client = OracleContractClient::new(&env, &contract_id);
+
+    client.submit_result(
+        &0u64,
+        &String::from_str(&env, "chess_game_42"),
+        &Platform::Lichess,
+        &Winner::Player1,
+    );
+
+    client.delete_result(&0u64);
+
+    let events = env.events().all();
+    let expected_topics = soroban_sdk::vec![
+        &env,
+        Symbol::new(&env, "oracle").into_val(&env),
+        symbol_short!("deleted").into_val(&env),
+    ];
+    let matched = events
+        .iter()
+        .find(|(_, topics, _)| *topics == expected_topics);
+    assert!(matched.is_some(), "deletion event not emitted");
+
+    let (_, _, data) = matched.unwrap();
+    let ev_id: u64 = soroban_sdk::TryFromVal::try_from_val(&env, &data).unwrap();
+    assert_eq!(ev_id, 0u64);
+}

--- a/contracts/oracle/src/tests.rs
+++ b/contracts/oracle/src/tests.rs
@@ -928,3 +928,32 @@ fn test_unpause_emits_unpaused_event() {
         .find(|(_, topics, _)| *topics == expected_topics);
     assert!(matched.is_some(), "unpaused event not emitted");
 }
+
+
+// ── Test #597: update_admin emits event ──────────────────────────────────
+
+#[test]
+fn test_update_admin_emits_rotation_event() {
+    let (env, contract_id, _escrow_id, old_admin, ..) = setup();
+    let client = OracleContractClient::new(&env, &contract_id);
+
+    let new_admin = Address::generate(&env);
+    client.update_admin(&new_admin);
+
+    let events = env.events().all();
+    let expected_topics = soroban_sdk::vec![
+        &env,
+        Symbol::new(&env, "admin").into_val(&env),
+        symbol_short!("admin_rot").into_val(&env),
+    ];
+    let matched = events
+        .iter()
+        .find(|(_, topics, _)| *topics == expected_topics);
+    assert!(matched.is_some(), "admin_rot event not emitted");
+
+    let (_, _, data) = matched.unwrap();
+    let (ev_old, ev_new): (Address, Address) =
+        soroban_sdk::TryFromVal::try_from_val(&env, &data).unwrap();
+    assert_eq!(ev_old, old_admin);
+    assert_eq!(ev_new, new_admin);
+}

--- a/contracts/oracle/src/tests.rs
+++ b/contracts/oracle/src/tests.rs
@@ -905,3 +905,26 @@ fn test_delete_result_leaves_has_result_false() {
     client.delete_result(&0u64);
     assert!(!client.has_result(&0u64));
 }
+
+
+// ── Test #598: unpause emits event ───────────────────────────────────────
+
+#[test]
+fn test_unpause_emits_unpaused_event() {
+    let (env, contract_id, ..) = setup();
+    let client = OracleContractClient::new(&env, &contract_id);
+
+    client.pause();
+    client.unpause();
+
+    let events = env.events().all();
+    let expected_topics = soroban_sdk::vec![
+        &env,
+        Symbol::new(&env, "admin").into_val(&env),
+        symbol_short!("unpaused").into_val(&env),
+    ];
+    let matched = events
+        .iter()
+        .find(|(_, topics, _)| *topics == expected_topics);
+    assert!(matched.is_some(), "unpaused event not emitted");
+}

--- a/contracts/oracle/src/tests.rs
+++ b/contracts/oracle/src/tests.rs
@@ -885,3 +885,23 @@ fn test_delete_result_emits_deletion_event() {
     let ev_id: u64 = soroban_sdk::TryFromVal::try_from_val(&env, &data).unwrap();
     assert_eq!(ev_id, 0u64);
 }
+
+
+// ── Test #600: delete_result leaves has_result false ──────────────────────
+
+#[test]
+fn test_delete_result_leaves_has_result_false() {
+    let (env, contract_id, ..) = setup();
+    let client = OracleContractClient::new(&env, &contract_id);
+
+    client.submit_result(
+        &0u64,
+        &String::from_str(&env, "chess_game_42"),
+        &Platform::Lichess,
+        &Winner::Player1,
+    );
+    assert!(client.has_result(&0u64));
+
+    client.delete_result(&0u64);
+    assert!(!client.has_result(&0u64));
+}


### PR DESCRIPTION
# Add Oracle Event Emission Tests

## Summary

This PR adds comprehensive test coverage for oracle contract event emissions across four key operations: result deletion, pause/unpause state transitions, and admin rotation. These tests ensure that all state-changing operations leave a visible audit trail on-chain.

## Changes

### Test Coverage Added

1. **#599 - delete_result emits event**
   - Verifies that deleting a result emits an `oracle / deleted` event
   - Asserts the event payload contains the correct match_id
   - Ensures audit trail for result cleanup operations

2. **#600 - delete_result leaves has_result false**
   - Validates state consistency after result deletion
   - Confirms `has_result()` returns false after deletion
   - Tests the basic state assertion for the oracle cleanup path

3. **#598 - unpause emits event**
   - Confirms unpause operation emits `admin / unpaused` event
   - Validates event emission during pause/unpause state transitions
   - Covers issue #28

4. **#597 - update_admin emits event**
   - Verifies admin rotation emits `admin / admin_rot` event
   - Asserts event payload contains both old and new admin addresses
   - Covers issue #27

## Testing

All tests follow the existing test patterns in the oracle contract:
- Use the `setup()` helper to initialize contracts
- Leverage `env.events().all()` to capture and verify event emissions
- Assert both event topics and data payloads
- Minimal, focused test implementations

## Commits

- `1118569` - test(oracle): add delete_result emits event test (#599)
- `89d520a` - test(oracle): add delete_result leaves has_result false test (#600)
- `2b964a0` - test(oracle): add unpause emits event test (#598)
- `885df0e` - test(oracle): add update_admin emits event test (#597)

## Related Issues

- Closes #599
- Closes #600
- Closes #598
- Closes #597