### PR TITLE
fix: allowed match token entries

### DIFF
--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -112,10 +112,18 @@ impl EscrowContract {
 
     /// Check if a token is allowed.
     pub fn is_token_allowed(env: Env, token: Address) -> bool {
-        env.storage()
+        let key = DataKey::AllowedToken(token.clone());
+        let allowed: bool = env
+            .storage()
             .persistent()
-            .get(&DataKey::AllowedToken(token))
-            .unwrap_or(false)
+            .get(&key)
+            .unwrap_or(false);
+        if allowed {
+            env.storage()
+                .persistent()
+                .extend_ttl(&key, MATCH_TTL_LEDGERS, MATCH_TTL_LEDGERS);
+        }
+        allowed
     }
 
     /// Create a new match. Both players must call `deposit` before the game starts.

--- a/contracts/escrow/src/tests/ttl.rs
+++ b/contracts/escrow/src/tests/ttl.rs
@@ -25,6 +25,56 @@ fn test_ttl_extended_on_create_match() {
 }
 
 #[test]
+fn test_add_allowed_token_extends_ttl() {
+    let (env, contract_id, _oracle, _player1, _player2, token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    client.add_allowed_token(&token);
+
+    let ttl = env.as_contract(&contract_id, || {
+        env.storage()
+            .persistent()
+            .get_ttl(&DataKey::AllowedToken(token.clone()))
+    });
+    assert_eq!(ttl, crate::MATCH_TTL_LEDGERS);
+}
+
+#[test]
+fn test_is_token_allowed_extends_ttl_on_read() {
+    let (env, contract_id, _oracle, _player1, _player2, token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    client.add_allowed_token(&token);
+
+    env.ledger().set(soroban_sdk::testutils::LedgerInfo {
+        sequence_number: env.ledger().sequence() + 1000,
+        timestamp: env.ledger().timestamp() + 5000,
+        protocol_version: 22,
+        network_id: Default::default(),
+        base_reserve: 10,
+        min_temp_entry_ttl: 1,
+        min_persistent_entry_ttl: 1,
+        max_entry_ttl: crate::MATCH_TTL_LEDGERS + 2000,
+    });
+
+    let ttl_before = env.as_contract(&contract_id, || {
+        env.storage()
+            .persistent()
+            .get_ttl(&DataKey::AllowedToken(token.clone()))
+    });
+    assert!(ttl_before < crate::MATCH_TTL_LEDGERS);
+
+    assert!(client.is_token_allowed(&token));
+
+    let ttl_after = env.as_contract(&contract_id, || {
+        env.storage()
+            .persistent()
+            .get_ttl(&DataKey::AllowedToken(token.clone()))
+    });
+    assert_eq!(ttl_after, crate::MATCH_TTL_LEDGERS);
+}
+
+#[test]
 fn test_ttl_extended_on_deposit() {
     let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
     let client = EscrowContractClient::new(&env, &contract_id);


### PR DESCRIPTION
## Summary

Provide a short description of the change and the problem it fixes.

Closes #539 

## Related Issue

Link the issue number or task this PR addresses.

## What changed
- Contracts:
- Tests:
- Docs:
- Events / API / storage:

## Verification
- What did you run to verify this change?
  - `cargo test -p escrow`
  - `cargo test -p oracle`
  - `cargo fmt`
  - `cargo clippy`

## Checklist
- [ ] I added or updated tests covering this change.
- [ ] I updated documentation or confirmed no docs update is needed.
- [ ] I confirmed any event/API/storage changes are documented and backward-compatible.
- [ ] I manually verified the contract or CLI behavior where applicable.
- [ ] I linked this PR to the related issue.
- [ ] I included notes on any TTL or storage assumptions affecting contract state.

## Notes

Add any additional details, risks, or follow-up tasks here.
