### PR TITLE
feat: add CODEOWNERS for reviewer routing

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,27 @@
+# CODEOWNERS — Reviewer routing for Checkmate-Escrow
+# Syntax: <pattern> <@owner-or-team>
+# GitHub automatically requests reviews from these owners when a PR touches the matched paths.
+# Replace placeholder handles with real GitHub usernames or team slugs (e.g. @StellarCheckMate/contracts).
+
+# Global fallback — catches anything not matched below
+*                               @StellarCheckMate/maintainers
+
+# Escrow smart contract
+/contracts/escrow/              @StellarCheckMate/contracts
+
+# Oracle smart contract
+/contracts/oracle/              @StellarCheckMate/contracts
+
+# Documentation
+/docs/                          @StellarCheckMate/docs
+
+# CI/CD and GitHub configuration
+/.github/                       @StellarCheckMate/maintainers
+
+# Scripts
+/scripts/                       @StellarCheckMate/maintainers
+
+# Root config and workspace files
+/Cargo.toml                     @StellarCheckMate/contracts
+/Cargo.lock                     @StellarCheckMate/contracts
+/environments.toml              @StellarCheckMate/maintainers

--- a/pr-description-650.md
+++ b/pr-description-650.md
@@ -1,0 +1,25 @@
+# Add CODEOWNERS for reviewer routing
+
+## Summary
+
+Adds `.github/CODEOWNERS` to route PR reviews automatically based on the changed paths.
+
+## Changes
+
+- **`.github/CODEOWNERS`** — new file mapping ownership areas:
+  - `contracts/escrow/` → `@StellarCheckMate/contracts`
+  - `contracts/oracle/` → `@StellarCheckMate/contracts`
+  - `docs/` → `@StellarCheckMate/docs`
+  - `scripts/` and `.github/` → `@StellarCheckMate/maintainers`
+  - Root config files (`Cargo.toml`, `environments.toml`) → appropriate teams
+  - Global fallback `*` → `@StellarCheckMate/maintainers`
+
+## Why
+
+With separate escrow, oracle, and docs areas, GitHub's CODEOWNERS file ensures the right reviewers are automatically requested on every PR, speeding up outside contributions without requiring manual triage.
+
+## Testing
+
+No code changes — reviewer routing is enforced by GitHub on PR open. Replace placeholder team slugs with real GitHub usernames or teams before merging.
+
+closes #650


### PR DESCRIPTION
# Add CODEOWNERS for reviewer routing

## Summary

Adds `.github/CODEOWNERS` to route PR reviews automatically based on the changed paths.

## Changes

- **`.github/CODEOWNERS`** — new file mapping ownership areas:
  - `contracts/escrow/` → `@StellarCheckMate/contracts`
  - `contracts/oracle/` → `@StellarCheckMate/contracts`
  - `docs/` → `@StellarCheckMate/docs`
  - `scripts/` and `.github/` → `@StellarCheckMate/maintainers`
  - Root config files (`Cargo.toml`, `environments.toml`) → appropriate teams
  - Global fallback `*` → `@StellarCheckMate/maintainers`

## Why

With separate escrow, oracle, and docs areas, GitHub's CODEOWNERS file ensures the right reviewers are automatically requested on every PR, speeding up outside contributions without requiring manual triage.

## Testing

No code changes — reviewer routing is enforced by GitHub on PR open. Replace placeholder team slugs with real GitHub usernames or teams before merging.

closes #650
