### PR TITLE
docs: add interactive tutorial and guided demo for new users

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,8 +134,26 @@ stellar keys generate deployer --network testnet
 
 Follow the step-by-step guide in `demo/demo-script.md`
 
+## 🎓 New here? Start with the Interactive Tutorial
+
+Brand new to Checkmate-Escrow? The **[Interactive Tutorial](docs/tutorial-step-by-step.md)**
+takes you from zero to a completed, paid-out match on **testnet** in under 15
+minutes — no real funds at risk:
+
+1. **Create a match** — register a wager on-chain
+2. **Deposit funds** — fund the escrow
+3. **Check the result** — verify the outcome and watch the payout
+
+Prefer to learn by watching or testing yourself?
+
+- 🎬 **Video walkthroughs:** the [tutorial](docs/tutorial-step-by-step.md) includes a Video walkthroughs section (links added as recordings are published)
+- 🧩 **Interactive quiz & checklist:** [tutorial-quiz.md](docs/tutorial-quiz.md)
+- 🧪 **Testnet practice mode:** the whole tutorial runs on free testnet funds — no real money at risk
+
 ## 📖 Documentation
 
+- [Interactive Tutorial](docs/tutorial-step-by-step.md) — guided, hands-on intro for new users
+- [Tutorial Quiz & Checklist](docs/tutorial-quiz.md) — verify your understanding
 - [Architecture Overview](docs/architecture.md)
 - [Oracle Design](docs/oracle.md)
 - [Threat Model & Security](docs/security.md)

--- a/docs/assets/tutorial/README.md
+++ b/docs/assets/tutorial/README.md
@@ -1,0 +1,54 @@
+# Tutorial Assets — Screenshots & Recordings
+
+This folder holds the visual walkthroughs referenced by the
+[interactive tutorial](../../tutorial-step-by-step.md). It is intentionally a
+contribution-ready placeholder: the tutorial works fully as text today, and the
+images/recordings below are the next layer of polish for new contributors to add.
+
+> 🧑‍🤝‍🧑 **Good first contribution.** Capturing these is a quick, high-impact way
+> to make the tutorial friendlier — no Rust required.
+
+## Screenshots to add
+
+Drop PNGs here with these exact names so the tutorial picks them up:
+
+| Filename | What it should show |
+|----------|---------------------|
+| `00-setup-deployed.png` | Terminal printing the two contract IDs after deploy |
+| `01-create-match.png` | `get_match` output with `state: Pending` |
+| `02-deposit-funded.png` | Funded check returning `true` and balance `200000000` |
+| `03-result-completed.png` | `get_match` showing `state: Completed`, balance `0` |
+
+## Screen recordings to add
+
+Record with [OBS Studio](https://obsproject.com/) (free, cross-platform) or
+[Loom](https://www.loom.com/) (quick browser capture):
+
+| Recording | Target length | Covers |
+|-----------|---------------|--------|
+| Full run | ~12 min | Setup → Step 3 payout, end to end |
+| Step 1 | ~2 min | Create a match |
+| Step 2 | ~2 min | Deposit funds |
+| Step 3 | ~3 min | Check result & payout |
+
+Host the video (Loom/YouTube), then add the link to the **Video walkthroughs**
+table in [`tutorial-step-by-step.md`](../../tutorial-step-by-step.md) and to the
+README tutorial section.
+
+## Capture checklist (keep recordings consistent)
+
+- [ ] Use **testnet** only — never show mainnet keys or real funds
+- [ ] **Redact secret keys** (`S...` seeds) — only show public addresses (`G...`)
+      and contract IDs (`C...`)
+- [ ] Keep the terminal window a consistent size (~120 columns)
+- [ ] Use a legible font size (recordings are watched on small screens too)
+- [ ] Add a short caption/title for each step
+- [ ] Keep each per-step clip focused on a single step
+- [ ] Trim dead air so the full run stays **under 15 minutes**
+
+## Why placeholders instead of committed binaries?
+
+Screenshots and video drift out of date as the CLI output evolves, and binary
+blobs bloat the git history. Keeping this as a documented, named placeholder lets
+contributors add current visuals on demand while the **text tutorial remains the
+always-accurate source of truth**.

--- a/docs/tutorial-quiz.md
+++ b/docs/tutorial-quiz.md
@@ -1,0 +1,132 @@
+# 🧩 Tutorial Quiz & Checklist
+
+Interactive companion to the
+[step-by-step tutorial](tutorial-step-by-step.md). Use it two ways:
+
+1. **Progress checklist** — tick each box as you complete the hands-on steps.
+2. **Knowledge quiz** — answer the questions to confirm you understood *why*
+   each step works, not just *how*.
+
+Everything here is **testnet practice mode** — no real funds, nothing to lose.
+
+---
+
+## ✅ Progress checklist
+
+Copy this into a GitHub issue/PR (or just tick along in your editor) as you go.
+
+### Setup
+
+- [ ] Installed Rust, the `wasm32-unknown-unknown` target, Stellar CLI, and `curl`
+- [ ] Built the contracts with `./scripts/build.sh`
+- [ ] Generated `admin`, `player1`, and `player2` testnet keys
+- [ ] Funded all three accounts via Friendbot
+- [ ] Deployed and initialized the escrow and oracle contracts
+- [ ] Captured `$ESCROW_ID`, `$ORACLE_ID`, `$XLM_TOKEN`, `$P1_ADDR`, `$P2_ADDR`
+
+### Step 1 — Create a match
+
+- [ ] Created a match as `player1`
+- [ ] Verified the match state is `Pending`
+- [ ] Understood that stake amounts are in **stroops** (`1 XLM = 10,000,000`)
+
+### Step 2 — Deposit funds
+
+- [ ] Deposited `player1`'s stake
+- [ ] Deposited `player2`'s stake
+- [ ] Confirmed the match is funded (state is now `Active`)
+- [ ] Can explain the difference between funded status and escrow balance
+
+### Step 3 — Check the result
+
+- [ ] Recorded the verified result on the oracle contract
+- [ ] Executed the payout via the escrow contract (called as the oracle address)
+- [ ] Confirmed the match state is `Completed`
+- [ ] Confirmed the escrow balance returned to `0`
+
+### Wrap-up
+
+- [ ] Whole flow completed in **under 15 minutes**
+- [ ] Read at least one "why it matters" callout per step
+- [ ] Noted any confusing moment to report (see [Feedback loop](#-feedback-loop))
+
+---
+
+## 🧠 Knowledge quiz
+
+Answer each, then expand to check. No peeking first — these mirror the real
+points new users trip on.
+
+**Q1. After Player1 deposits but Player2 has not, what is the match state?**
+<details><summary>Show answer</summary>
+Still <code>Pending</code>. A match becomes <code>Active</code> only when
+<em>both</em> players have deposited.
+</details>
+
+**Q2. You stake "10 XLM". What number do you pass to the stake amount?**
+<details><summary>Show answer</summary>
+<code>100000000</code> — amounts are in stroops, and
+<code>1 XLM = 10,000,000 stroops</code>.
+</details>
+
+**Q3. A match is `Active` with both deposits in. What does the funded check
+return, and what does the escrow balance return?**
+<details><summary>Show answer</summary>
+Funded → <code>true</code>; escrow balance → <code>2 × stake</code> (e.g.
+<code>200000000</code> for a 10 XLM stake). One reports deposit <em>flags</em>,
+the other reports the <em>amount held</em>.
+</details>
+
+**Q4. Who is allowed to trigger the payout on the escrow contract?**
+<details><summary>Show answer</summary>
+Only the configured <strong>oracle address</strong> (the oracle contract id in
+the tutorial). The escrow admin <em>cannot</em> submit payouts directly — the
+call's <code>--source</code> and <code>--caller</code> must both be the oracle
+address.
+</details>
+
+**Q5. The match is `Completed`. Why does the escrow balance read `0` when the
+winner just received 20 XLM?**
+<details><summary>Show answer</summary>
+The escrow balance reports funds <em>held in escrow for that match</em>. After
+payout the pot has left escrow (it is in the winner's wallet), so the match's
+escrow balance is <code>0</code>.
+</details>
+
+**Q6. It's a draw. What happens to the stakes?**
+<details><summary>Show answer</summary>
+Each player gets their own stake back (10 XLM each), rather than one player
+taking the full 20 XLM pot.
+</details>
+
+**Q7. Which network should you use to practice, and why never mainnet?**
+<details><summary>Show answer</summary>
+Use <strong>testnet</strong> (or local <code>standalone</code>). Testnet XLM is
+free via Friendbot and worthless, so mistakes cost nothing. Mainnet moves real
+funds.
+</details>
+
+### Score yourself
+
+| Correct | Where to go next |
+|---------|------------------|
+| 6–7 | You're ready to contribute — see the [contributing guidelines](../CONTRIBUTING.md) |
+| 4–5 | Re-skim the "why it matters" callouts in the [tutorial](tutorial-step-by-step.md) |
+| 0–3 | Re-run the hands-on steps — repetition on testnet is free and the fastest way to learn |
+
+---
+
+## 🔄 Feedback loop
+
+This tutorial improves only when new users tell us where they got stuck.
+
+If any step confused you:
+
+1. Note **which step** and **the exact command** that didn't behave as described.
+2. Check the **Troubleshooting common issues** table in the
+   [step-by-step tutorial](tutorial-step-by-step.md) — your issue may already be covered.
+3. If not, **open an issue or PR** describing the confusion. Documentation gaps
+   are treated as bugs and are great first contributions.
+
+> 🙌 New contributors who run this tutorial and report friction points help us
+> keep it accurate and under 15 minutes. Thank you!

--- a/docs/tutorial-step-by-step.md
+++ b/docs/tutorial-step-by-step.md
@@ -1,0 +1,370 @@
+# 🎓 Checkmate-Escrow Interactive Tutorial
+
+> **Goal:** Take a brand-new user from zero to a completed, paid-out match on
+> Stellar **testnet** in **under 15 minutes** — with no real money at risk.
+
+This is the guided, hands-on companion to the end-to-end
+[demo walkthrough](../demo/demo-script.md). Where the demo is a terse reference,
+this tutorial is paced for someone seeing Checkmate-Escrow for the first time:
+every step explains *what* you are doing, *why* it matters, and *how to know it
+worked*.
+
+By the end you will have:
+
+- ✅ Created a match between two players
+- ✅ Funded the escrow with both players' stakes
+- ✅ Submitted a verified result and watched the winner get paid automatically
+
+---
+
+## 🧭 How to use this tutorial
+
+Pick the format that suits you — the content is identical across all three:
+
+| Format | Best for | Where |
+|--------|----------|-------|
+| 📝 **Text** | Following along at your own pace | This document |
+| 🎬 **Video** | Watching the full flow first | [Video walkthroughs](#-video-walkthroughs) |
+| 🧩 **Interactive** | Checking your understanding | [Tutorial quiz & checklist](tutorial-quiz.md) |
+
+> 🧪 **Practice mode (testnet-only).** Everything below runs on Stellar
+> **testnet** using free [Friendbot](https://friendbot.stellar.org) funds. No
+> mainnet keys, no real XLM, nothing to lose. This is the safe sandbox for
+> learning — see [Practice mode & local development](#-practice-mode--local-development)
+> if you would rather run everything against a local node.
+
+---
+
+## 📋 Before you begin
+
+### What you need installed
+
+| Tool | Why | Check it works |
+|------|-----|----------------|
+| [Rust](https://www.rust-lang.org/tools/install) (1.70+) | Builds the contracts | `rustc --version` |
+| `wasm32` target | Compiles to Wasm | `rustup target add wasm32-unknown-unknown` |
+| [Stellar CLI](https://developers.stellar.org/docs/tools/developer-tools/cli/stellar-cli) | Talks to the network | `stellar --version` |
+| `curl` | Funds testnet accounts | `curl --version` |
+
+### Time budget
+
+| Step | What happens | Approx. time |
+|------|--------------|--------------|
+| Setup | Build, keys, deploy | ~6 min |
+| Step 1 | Create a match | ~2 min |
+| Step 2 | Deposit funds | ~2 min |
+| Step 3 | Check the result & payout | ~3 min |
+| **Total** | | **< 15 min** |
+
+> 💡 **First time only:** the contract build (`./scripts/build.sh`) can take a
+> few minutes as Rust compiles dependencies. Subsequent runs are fast.
+
+---
+
+## 🏗️ Setup — get to a deployed contract
+
+Run these once before Step 1. They mirror the
+[demo walkthrough](../demo/demo-script.md), condensed here so the tutorial is
+self-contained.
+
+```bash
+# 1. Build the contracts
+./scripts/build.sh
+
+# 2. Create three testnet identities
+stellar keys generate admin   --network testnet
+stellar keys generate player1 --network testnet
+stellar keys generate player2 --network testnet
+
+# 3. Fund them with free testnet XLM via Friendbot
+for KEY in admin player1 player2; do
+  curl -s "https://friendbot.stellar.org?addr=$(stellar keys address $KEY)" > /dev/null
+  echo "Funded $KEY: $(stellar keys address $KEY)"
+done
+
+# 4. Deploy both contracts
+ESCROW_ID=$(stellar contract deploy \
+  --wasm target/wasm32-unknown-unknown/release/escrow.wasm \
+  --source admin --network testnet)
+ORACLE_ID=$(stellar contract deploy \
+  --wasm target/wasm32-unknown-unknown/release/oracle.wasm \
+  --source admin --network testnet)
+
+# 5. Initialize both contracts
+ADMIN_ADDR=$(stellar keys address admin)
+stellar contract invoke --id $ORACLE_ID --source admin --network testnet \
+  -- initialize --admin $ADMIN_ADDR
+stellar contract invoke --id $ESCROW_ID --source admin --network testnet \
+  -- initialize --oracle $ORACLE_ID --admin $ADMIN_ADDR
+
+# 6. Grab the native XLM token + player addresses for later
+XLM_TOKEN=$(stellar contract id asset --asset native --network testnet)
+P1_ADDR=$(stellar keys address player1)
+P2_ADDR=$(stellar keys address player2)
+
+echo "Escrow: $ESCROW_ID"
+echo "Oracle: $ORACLE_ID"
+```
+
+> 📸 _Screenshot:_ `assets/tutorial/00-setup-deployed.png` — terminal showing the
+> two contract IDs printed after deployment. See the
+> [assets guide](assets/tutorial/README.md) for how to add yours.
+
+✅ **Checkpoint:** you should see two long `C...` contract IDs. Keep this terminal
+open — the `$ESCROW_ID`, `$ORACLE_ID`, `$XLM_TOKEN`, `$P1_ADDR`, and `$P2_ADDR`
+variables are reused in every step below.
+
+---
+
+## ♟️ Step 1 — Create a match
+
+**What you're doing:** registering a wager on-chain. Player1 proposes a match
+against Player2, declaring the stake, the token, and which chess game settles it.
+
+**Why it matters:** the match is the contract's unit of escrow. Nothing can be
+deposited or paid out until a match exists, and its terms (stake, token, players)
+are locked in at creation.
+
+```bash
+MATCH_ID=$(stellar contract invoke --id $ESCROW_ID --source player1 --network testnet \
+  -- create_match \
+    --player1      $P1_ADDR \
+    --player2      $P2_ADDR \
+    --stake_amount 100000000 \
+    --token        $XLM_TOKEN \
+    --game_id      "abc123xyz" \
+    --platform     Lichess)
+
+echo "Match ID: $MATCH_ID"
+```
+
+> 🔢 **Stroops, not XLM.** Stellar amounts are integers in *stroops*:
+> `1 XLM = 10,000,000 stroops`. So `100000000` above is **10 XLM** per player.
+
+**Confirm it worked:**
+
+```bash
+stellar contract invoke --id $ESCROW_ID --source admin --network testnet \
+  -- get_match --match_id $MATCH_ID
+```
+
+```
+state: Pending, player1_deposited: false, player2_deposited: false
+```
+
+> 📸 _Screenshot:_ `assets/tutorial/01-create-match.png` — the `get_match` output
+> showing `state: Pending`.
+
+✅ **Checkpoint:** the match is `Pending`. Neither player has deposited yet.
+
+🧩 **Quick check:** *Why is the match `Pending` and not `Active`?*
+<details><summary>Answer</summary>
+A match only becomes <code>Active</code> once <em>both</em> players have
+deposited their stake. Creating the match just records the terms; no funds have
+moved yet.
+</details>
+
+---
+
+## 💰 Step 2 — Deposit funds
+
+**What you're doing:** each player transfers their stake into the escrow contract.
+
+**Why it matters:** the escrow holds both stakes so neither player can back out
+once the game starts. The match flips to `Active` the moment the **second**
+deposit lands — that is the on-chain signal that the game may begin.
+
+```bash
+# Player1 deposits their 10 XLM stake
+stellar contract invoke --id $ESCROW_ID --source player1 --network testnet \
+  -- deposit --match_id $MATCH_ID --player $P1_ADDR
+
+# Player2 deposits their 10 XLM stake
+stellar contract invoke --id $ESCROW_ID --source player2 --network testnet \
+  -- deposit --match_id $MATCH_ID --player $P2_ADDR
+```
+
+**Confirm the escrow is fully funded:**
+
+```bash
+stellar contract invoke --id $ESCROW_ID --source admin --network testnet \
+  -- is_funded --match_id $MATCH_ID
+# true
+
+stellar contract invoke --id $ESCROW_ID --source admin --network testnet \
+  -- get_escrow_balance --match_id $MATCH_ID
+# 200000000   (2 × 10 XLM in stroops)
+```
+
+> 📸 _Screenshot:_ `assets/tutorial/02-deposit-funded.png` — `is_funded` returning
+> `true` and the balance at `200000000`.
+
+> 🧠 **`is_funded` vs `get_escrow_balance`** — these answer *different*
+> questions and are a common source of confusion:
+> - `is_funded` → `true` only when **both** players have deposited (match is
+>   `Active`). It reflects deposit *flags*, not token balances.
+> - `get_escrow_balance` → the *amount* currently held: `0`, `1×stake`, or
+>   `2×stake`. After payout/refund it returns `0`.
+
+✅ **Checkpoint:** `is_funded` is `true`, balance is `200000000`, and the match
+state is now `Active`.
+
+🧩 **Quick check:** *After only Player1 deposits, what does each function return?*
+<details><summary>Answer</summary>
+<code>is_funded</code> → <code>false</code> (both must deposit), but
+<code>get_escrow_balance</code> → <code>100000000</code> (one stake is already
+held). See the table in the <a href="../README.md">README</a>.
+</details>
+
+---
+
+## 🏆 Step 3 — Check the match result (and get paid)
+
+**What you're doing:** recording the game's outcome and triggering the payout.
+
+**Why it matters:** this is the trustless core of Checkmate-Escrow. Once the
+oracle reports a verified result, the escrow pays the winner the **entire pot**
+in the same transaction — no platform can withhold or delay it.
+
+The result is settled in two calls:
+
+### 3a — Oracle records the verified result
+
+```bash
+stellar contract invoke --id $ORACLE_ID --source admin --network testnet \
+  -- submit_result \
+    --match_id $MATCH_ID \
+    --game_id  "abc123xyz" \
+    --platform Lichess \
+    --result   Player1Wins
+```
+
+> Valid `--result` values: `Player1Wins`, `Player2Wins`, `Draw`.
+
+### 3b — Escrow executes the payout
+
+The escrow only accepts the result from its configured **oracle address** (the
+oracle *contract id* in this tutorial), never from the admin directly.
+
+```bash
+stellar contract invoke --id $ESCROW_ID --source $ORACLE_ID --network testnet \
+  -- submit_result \
+    --match_id $MATCH_ID \
+    --winner   Player1 \
+    --caller   $ORACLE_ID
+```
+
+> Valid `--winner` values: `Player1`, `Player2`, `Draw`. On a `Draw`, both
+> players get their 10 XLM back instead of one winner taking 20 XLM.
+
+**Confirm the payout:**
+
+```bash
+stellar contract invoke --id $ESCROW_ID --source admin --network testnet \
+  -- get_match --match_id $MATCH_ID
+# state: Completed, completed_ledger: <ledger number>
+
+stellar contract invoke --id $ESCROW_ID --source admin --network testnet \
+  -- get_escrow_balance --match_id $MATCH_ID
+# 0   (the pot has been paid out)
+```
+
+> 📸 _Screenshot:_ `assets/tutorial/03-result-completed.png` — `get_match` showing
+> `state: Completed` and the balance back to `0`.
+
+✅ **Checkpoint:** the match is `Completed` and the escrow balance is `0` — the
+winner has been paid. 🎉 **You've completed a full match lifecycle!**
+
+🧩 **Quick check:** *Why is the escrow balance `0` even though the winner was just
+paid 20 XLM?*
+<details><summary>Answer</summary>
+<code>get_escrow_balance</code> reports funds <em>held in escrow for the match</em>.
+Once the payout executes, the pot has left escrow (it is now in the winner's
+wallet), so the escrow balance for that match is <code>0</code>.
+</details>
+
+---
+
+## 🎬 Video walkthroughs
+
+Short screen recordings of each step. Recordings are produced with
+[OBS Studio](https://obsproject.com/) or [Loom](https://www.loom.com/) and
+checked into `docs/assets/tutorial/` (or linked below once published).
+
+| Walkthrough | Length | Link |
+|-------------|--------|------|
+| Full run (setup → payout) | ~12 min | _Add link — see [assets guide](assets/tutorial/README.md)_ |
+| Step 1 — Create a match | ~2 min | _Add link_ |
+| Step 2 — Deposit funds | ~2 min | _Add link_ |
+| Step 3 — Check result & payout | ~3 min | _Add link_ |
+
+> 📹 **Contributing a recording?** Follow the capture checklist in the
+> [assets guide](assets/tutorial/README.md) so recordings stay consistent
+> (same window size, redacted secret keys, captions on each step).
+
+---
+
+## 🧪 Practice mode & local development
+
+Everything above runs on **testnet**, which *is* practice mode — the funds come
+from Friendbot and have no real value. Two ways to practice safely:
+
+### Testnet practice (recommended for first-timers)
+
+You already did this. To run again with a clean slate, generate fresh keys
+(`stellar keys generate player1-v2 --network testnet`) and repeat from Setup.
+Re-fund any new key via Friendbot.
+
+### Local development (offline, fully reset-able)
+
+Prefer an offline sandbox? Run a local Stellar node and point everything at the
+`standalone` network defined in [`environments.toml`](../environments.toml):
+
+```bash
+# Start a local network (see Stellar CLI docs for the current command)
+stellar network start local
+
+# Then replace `--network testnet` with `--network standalone` in every command,
+# and fund accounts against your local Friendbot instead of friendbot.stellar.org.
+```
+
+Local mode resets whenever you stop the node — ideal for repeatedly rehearsing
+the flow without touching any shared network.
+
+> ⚠️ **Never use mainnet to practice.** Mainnet moves real XLM. This tutorial is
+> deliberately testnet/standalone-only.
+
+---
+
+## 🆘 Troubleshooting common issues
+
+| Symptom | Likely cause | Fix |
+|---------|--------------|-----|
+| `account not found` / funding errors | Account not funded on testnet | Re-run the Friendbot loop in [Setup](#️-setup--get-to-a-deployed-contract) |
+| `error: contract not found` | Wrong/empty `$ESCROW_ID` or `$ORACLE_ID` | Re-run deploy; confirm the variables are still set (`echo $ESCROW_ID`) |
+| Build fails with a `wasm32` error | Wasm target missing | `rustup target add wasm32-unknown-unknown` |
+| `deposit` fails with an auth error | Wrong `--source` for the player | The `--source` must match the `--player` whose stake is being deposited |
+| Payout (`submit_result` on escrow) rejected | Called by `admin` instead of the oracle | `--source` and `--caller` must both be the oracle address (`$ORACLE_ID`) |
+| `ContractPaused` error | Admin paused the contract | `stellar contract invoke --id $ESCROW_ID --source admin --network testnet -- unpause` |
+| Variables empty in a new terminal | Shell variables don't persist | Re-export `ESCROW_ID`, `ORACLE_ID`, `XLM_TOKEN`, `P1_ADDR`, `P2_ADDR` |
+
+Still stuck? Open an issue or ask in the project's discussions — and please note
+**which step** and **what command** so we can improve this tutorial.
+
+---
+
+## ✅ Next steps
+
+- 🧩 Test your understanding with the [tutorial quiz & checklist](tutorial-quiz.md)
+- 📖 Read the full [demo walkthrough](../demo/demo-script.md) for governance,
+  timeouts, and cancellation flows
+- 🏛️ Understand the design in the [architecture overview](architecture.md)
+- 🔮 Learn how results are verified in the [oracle design](oracle.md)
+- 🤝 Ready to contribute? See the [contributing guidelines](../CONTRIBUTING.md)
+
+---
+
+> 🔄 **Keep this tutorial alive.** If a step confused you, that's a documentation
+> bug. Open an issue or PR noting where you got stuck — we update this guide
+> whenever user feedback reveals a rough edge (see the **Feedback loop** section
+> of the [tutorial quiz](tutorial-quiz.md)).


### PR DESCRIPTION
## Summary

Adds a guided, hands-on onboarding experience so new users can go from zero to a completed, paid-out match on Stellar **testnet** in **under 15 minutes** — no real funds at risk. Closes #749 

Resolves the "Create Interactive Tutorial and Guided Demo for New Users" issue.

## What's included

- **`docs/tutorial-step-by-step.md`** — paced, beginner-friendly tutorial built around the three core tasks, each with *what / why / how-to-verify* and a checkpoint:
  - **Step 1 — Create a match**
  - **Step 2 — Deposit funds**
  - **Step 3 — Check the match result** (and watch the automatic payout)
  - Plus setup, a **testnet-only practice mode**, a **local-development** flow, and a **troubleshooting table** for common new-user errors.
- **`docs/tutorial-quiz.md`** — interactive **progress checklist** + **knowledge quiz** (collapsible answers) to verify understanding, with a self-scoring guide and a documentation feedback loop.
- **`docs/assets/tutorial/`** — multi-format support: named placeholders and a **capture checklist** for screenshots and OBS/Loom screen recordings, plus a Video walkthroughs section in the tutorial.
- **`README.md`** — new "Start with the Interactive Tutorial" section and Documentation links to the tutorial, quiz, and video walkthroughs.

## Requirements mapping

| Requirement | Where |
|---|---|
| Step 1: Create a match | `tutorial-step-by-step.md` Step 1 |
| Step 2: Deposit funds | `tutorial-step-by-step.md` Step 2 |
| Step 3: Check match result | `tutorial-step-by-step.md` Step 3 |
| Screenshots / screen recordings | `docs/assets/tutorial/` (named placeholders + capture checklist) |
| Testnet-only practice mode | "Practice mode & local development" section |
| Multiple formats (text, video, interactive) | tutorial (text) + assets (video) + quiz (interactive) |
| Interactive quiz/checklist | `tutorial-quiz.md` |
| Tutorial links in README | README tutorial + Documentation sections |
| < 15 minutes, testnet + local flows | time budget table + practice/local section |

## Verification

- All commands mirror the validated `demo/demo-script.md` and use only real public contract functions.
- Ran the repo's own CI checkers locally: my new files add **no** broken links and **no** stale API references (`scripts/check_links.sh`, `scripts/check_api_refs.sh`).

> Note: `check_links`/`check_api_refs` still report a few findings that exist on `main` today (`docs/runbook-pause.md`, `docs/security.md`, `docs/contributing-contracts.md`). Those are pre-existing and unrelated to this docs change.

## Notes for reviewers

- Screenshots/recordings are intentionally documented placeholders rather than committed binaries, so the always-accurate **text tutorial** is the source of truth and contributors can add current visuals without bloating git history. Capturing them is flagged as a good first contribution.