### PR TITLE
feat: add balance snapshot and audit trail for escrows

### DIFF
--- a/contracts/escrow/src/errors.rs
+++ b/contracts/escrow/src/errors.rs
@@ -23,4 +23,5 @@ pub enum Error {
     InvalidAddress = 18,
     MatchAlreadyActive = 19,
     InvalidTimeout = 20,
+    SnapshotNotFound = 21,
 }

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -4,11 +4,17 @@ pub mod errors;
 pub mod types;
 
 use errors::Error;
-use soroban_sdk::{contract, contractimpl, symbol_short, token, Address, Env, String, Symbol};
-use types::{DataKey, Match, MatchState, Platform, Winner};
+use soroban_sdk::{contract, contractimpl, symbol_short, token, Address, Env, String, Symbol, Vec};
+use types::{BalanceSnapshot, DataKey, Match, MatchState, Platform, SnapshotReason, Winner};
 
 /// ~30 days at 5s/ledger. Used as the default TTL and expiration threshold.
 const MATCH_TTL_LEDGERS: u32 = 518_400;
+
+/// Fixed-size ring buffer capacity for balance snapshots per match. A normal
+/// match lifecycle (created + 2 deposits + completed/cancelled) produces at
+/// most 4 snapshots, so this leaves headroom while bounding storage growth
+/// for matches that somehow generate more transitions.
+const MAX_SNAPSHOTS_PER_MATCH: u32 = 8;
 
 /// Default match expiration timeout used when no explicit timeout is configured.
 pub const DEFAULT_MATCH_TIMEOUT_LEDGERS: u32 = MATCH_TTL_LEDGERS;
@@ -383,6 +389,8 @@ impl EscrowContract {
             MATCH_TTL_LEDGERS,
         );
 
+        Self::record_snapshot(&env, &m, SnapshotReason::Created);
+
         env.events().publish(
             (Symbol::new(&env, "match"), symbol_short!("created")),
             (id, m.player1, m.player2, stake_amount),
@@ -463,6 +471,9 @@ impl EscrowContract {
             MATCH_TTL_LEDGERS,
             MATCH_TTL_LEDGERS,
         );
+
+        Self::record_snapshot(&env, &m, SnapshotReason::Deposit);
+
         Ok(())
     }
 
@@ -526,6 +537,8 @@ impl EscrowContract {
             MATCH_TTL_LEDGERS,
             MATCH_TTL_LEDGERS,
         );
+
+        Self::record_snapshot(&env, &m, SnapshotReason::Completed);
 
         let topics = (Symbol::new(&env, "match"), symbol_short!("completed"));
         env.events().publish(topics, (match_id, winner));
@@ -612,6 +625,8 @@ impl EscrowContract {
             MATCH_TTL_LEDGERS,
         );
 
+        Self::record_snapshot(&env, &m, SnapshotReason::Cancelled);
+
         env.events().publish(
             (Symbol::new(&env, "match"), symbol_short!("cancelled")),
             match_id,
@@ -660,6 +675,8 @@ impl EscrowContract {
             MATCH_TTL_LEDGERS,
             MATCH_TTL_LEDGERS,
         );
+
+        Self::record_snapshot(&env, &m, SnapshotReason::Cancelled);
 
         env.events().publish(
             (Symbol::new(&env, "match"), symbol_short!("expired")),
@@ -856,12 +873,7 @@ impl EscrowContract {
             .persistent()
             .get(&DataKey::Match(match_id))
             .ok_or(Error::MatchNotFound)?;
-        if m.state == MatchState::Completed || m.state == MatchState::Cancelled {
-            return Ok(0);
-        }
-        // Count depositors explicitly — avoids fragile bool-to-integer casting.
-        let depositors: i128 = Self::depositor_count(&m);
-        Ok(depositors * m.stake_amount)
+        Ok(Self::escrow_balance_of(&m))
     }
 
     fn depositor_count(m: &Match) -> i128 {
@@ -869,6 +881,200 @@ impl EscrowContract {
         if m.player1_deposited { count += 1; }
         if m.player2_deposited { count += 1; }
         count
+    }
+
+    /// Tokens currently held in escrow for a match. Zero once the match has
+    /// reached a terminal state, since funds have been disbursed by then.
+    fn escrow_balance_of(m: &Match) -> i128 {
+        if m.state == MatchState::Completed || m.state == MatchState::Cancelled {
+            0
+        } else {
+            Self::depositor_count(m) * m.stake_amount
+        }
+    }
+
+    // ── Balance snapshots ───────────────────────────────────────────────────
+
+    /// Best-effort token symbol lookup for snapshots.
+    ///
+    /// `create_match` deliberately accepts any address as `token` without
+    /// verifying it's a deployed token contract — validity is only enforced
+    /// later, when `deposit` actually transfers funds. Snapshots must not
+    /// break that contract, so this uses `try_invoke_contract` and falls
+    /// back to an empty string if the address isn't a callable token (or
+    /// isn't a contract at all) rather than panicking.
+    fn fetch_token_symbol(env: &Env, token: &Address) -> String {
+        match env.try_invoke_contract::<String, Error>(
+            token,
+            &Symbol::new(env, "symbol"),
+            soroban_sdk::vec![env],
+        ) {
+            Ok(Ok(symbol)) => symbol,
+            _ => String::from_str(env, ""),
+        }
+    }
+
+    /// Record a balance snapshot for `m` at a lifecycle transition.
+    ///
+    /// Snapshots are stored in a fixed-size ring buffer keyed by
+    /// `DataKey::Snapshot(match_id, slot)` where `slot = index %
+    /// MAX_SNAPSHOTS_PER_MATCH`. Once a match's snapshot count exceeds the
+    /// buffer capacity, the oldest entry is silently overwritten — this is
+    /// the storage-pruning mechanism. `DataKey::SnapshotCount` tracks the
+    /// total ever recorded so callers can detect that pruning occurred.
+    fn record_snapshot(env: &Env, m: &Match, reason: SnapshotReason) {
+        let token_symbol = Self::fetch_token_symbol(env, &m.token);
+        let escrow_balance = Self::escrow_balance_of(m);
+
+        let index: u32 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::SnapshotCount(m.id))
+            .unwrap_or(0);
+        let slot = index % MAX_SNAPSHOTS_PER_MATCH;
+
+        let snapshot = BalanceSnapshot {
+            match_id: m.id,
+            index,
+            reason,
+            ledger: env.ledger().sequence(),
+            token: m.token.clone(),
+            token_symbol,
+            stake_amount: m.stake_amount,
+            escrow_balance,
+            player1_deposited: m.player1_deposited,
+            player2_deposited: m.player2_deposited,
+        };
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Snapshot(m.id, slot), &snapshot);
+        env.storage().persistent().extend_ttl(
+            &DataKey::Snapshot(m.id, slot),
+            MATCH_TTL_LEDGERS,
+            MATCH_TTL_LEDGERS,
+        );
+
+        let next_index = index.saturating_add(1);
+        env.storage()
+            .persistent()
+            .set(&DataKey::SnapshotCount(m.id), &next_index);
+        env.storage().persistent().extend_ttl(
+            &DataKey::SnapshotCount(m.id),
+            MATCH_TTL_LEDGERS,
+            MATCH_TTL_LEDGERS,
+        );
+
+        env.events().publish(
+            (Symbol::new(env, "match"), symbol_short!("snapshot")),
+            (m.id, index, escrow_balance),
+        );
+    }
+
+    /// Authorize a snapshot query. Returns `Ok(true)` for the admin (full
+    /// access to exact amounts), `Ok(false)` for either player in the match
+    /// (partial access — amounts redacted), or `Err(Unauthorized)` otherwise.
+    fn authorize_snapshot_query(env: &Env, caller: &Address, m: &Match) -> Result<bool, Error> {
+        caller.require_auth();
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(Error::Unauthorized)?;
+        if *caller == admin {
+            Ok(true)
+        } else if *caller == m.player1 || *caller == m.player2 {
+            Ok(false)
+        } else {
+            Err(Error::Unauthorized)
+        }
+    }
+
+    /// Zero out sensitive amount fields for non-admin callers.
+    fn redact_snapshot(mut snapshot: BalanceSnapshot) -> BalanceSnapshot {
+        snapshot.stake_amount = 0;
+        snapshot.escrow_balance = 0;
+        snapshot
+    }
+
+    /// Return the full snapshot history for a match, oldest first.
+    ///
+    /// Only the admin sees exact `stake_amount`/`escrow_balance` values; the
+    /// match's players may also call this but receive amounts redacted to 0.
+    /// Any other caller is rejected with `Error::Unauthorized`.
+    pub fn get_balance_snapshots(
+        env: Env,
+        caller: Address,
+        match_id: u64,
+    ) -> Result<Vec<BalanceSnapshot>, Error> {
+        let m: Match = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Match(match_id))
+            .ok_or(Error::MatchNotFound)?;
+        let full_access = Self::authorize_snapshot_query(&env, &caller, &m)?;
+
+        let count: u32 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::SnapshotCount(match_id))
+            .unwrap_or(0);
+        let available = count.min(MAX_SNAPSHOTS_PER_MATCH);
+        let start = count.saturating_sub(available);
+
+        let mut result = soroban_sdk::vec![&env];
+        for i in start..count {
+            let slot = i % MAX_SNAPSHOTS_PER_MATCH;
+            if let Some(snapshot) = env
+                .storage()
+                .persistent()
+                .get::<DataKey, BalanceSnapshot>(&DataKey::Snapshot(match_id, slot))
+            {
+                result.push_back(if full_access {
+                    snapshot
+                } else {
+                    Self::redact_snapshot(snapshot)
+                });
+            }
+        }
+        Ok(result)
+    }
+
+    /// Return the most recently recorded snapshot for a match.
+    ///
+    /// Same access rules as [`Self::get_balance_snapshots`]: admin sees exact
+    /// amounts, players see redacted amounts, anyone else is unauthorized.
+    pub fn get_latest_snapshot(
+        env: Env,
+        caller: Address,
+        match_id: u64,
+    ) -> Result<BalanceSnapshot, Error> {
+        let m: Match = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Match(match_id))
+            .ok_or(Error::MatchNotFound)?;
+        let full_access = Self::authorize_snapshot_query(&env, &caller, &m)?;
+
+        let count: u32 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::SnapshotCount(match_id))
+            .unwrap_or(0);
+        if count == 0 {
+            return Err(Error::SnapshotNotFound);
+        }
+        let slot = (count - 1) % MAX_SNAPSHOTS_PER_MATCH;
+        let snapshot: BalanceSnapshot = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Snapshot(match_id, slot))
+            .ok_or(Error::SnapshotNotFound)?;
+        Ok(if full_access {
+            snapshot
+        } else {
+            Self::redact_snapshot(snapshot)
+        })
     }
 
     fn collect_matches_by_state(

--- a/contracts/escrow/src/tests/mod.rs
+++ b/contracts/escrow/src/tests/mod.rs
@@ -17,6 +17,7 @@ mod invariants;
 mod lifecycle;
 mod pagination;
 mod security;
+mod snapshots;
 mod ttl;
 mod token_allowlist;
 

--- a/contracts/escrow/src/tests/security.rs
+++ b/contracts/escrow/src/tests/security.rs
@@ -11,24 +11,24 @@ fn test_fuzz_stake_amounts() {
     let (env, contract_id, oracle, player1, player2, token, _admin) = setup();
     let client = EscrowContractClient::new(&env, &contract_id);
 
-    let test_amounts = vec![
+    let test_amounts = std::vec![
         1i128,                 // Minimum valid amount
         100i128,               // Normal amount
         1000i128,              // Large amount
         i128::MAX / 2,         // Very large but safe
     ];
 
-    for amount in test_amounts {
+    for (i, amount) in test_amounts.into_iter().enumerate() {
         env.mock_all_auths();
-        let match_id = client.create_match(
+        let result = client.try_create_match(
             &player1,
             &player2,
             &amount,
             &token,
-            &String::from_slice(&env, "game123"),
+            &String::from_str(&env, &format!("game123_{}", i)),
             &Platform::ChessDotCom,
         );
-        assert!(match_id.is_ok(), "Failed for amount: {}", amount);
+        assert!(result.is_ok(), "Failed for amount: {}", amount);
     }
 }
 
@@ -38,7 +38,7 @@ fn test_fuzz_invalid_stake_amounts() {
     let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
     let client = EscrowContractClient::new(&env, &contract_id);
 
-    let invalid_amounts = vec![
+    let invalid_amounts = std::vec![
         0i128,                 // Zero amount
         -1i128,                // Negative amount
         -100i128,              // Large negative

--- a/contracts/escrow/src/tests/snapshots.rs
+++ b/contracts/escrow/src/tests/snapshots.rs
@@ -1,0 +1,380 @@
+use super::*;
+use soroban_sdk::testutils::Ledger as _;
+
+#[test]
+fn test_create_match_records_created_snapshot() {
+    let (env, contract_id, _oracle, player1, player2, token, admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let id = client.create_match(
+        &player1,
+        &player2,
+        &100,
+        &token,
+        &String::from_str(&env, "snap_created"),
+        &Platform::Lichess,
+    );
+
+    let snaps = client.get_balance_snapshots(&admin, &id);
+    assert_eq!(snaps.len(), 1);
+    let snap = snaps.get(0).unwrap();
+    assert_eq!(snap.match_id, id);
+    assert_eq!(snap.index, 0);
+    assert_eq!(snap.reason, SnapshotReason::Created);
+    assert_eq!(snap.token, token);
+    assert_eq!(snap.stake_amount, 100);
+    assert_eq!(snap.escrow_balance, 0);
+    assert!(!snap.player1_deposited);
+    assert!(!snap.player2_deposited);
+
+    let token_client = TokenClient::new(&env, &token);
+    assert_eq!(snap.token_symbol, token_client.symbol());
+}
+
+#[test]
+fn test_deposit_records_a_snapshot_per_deposit() {
+    let (env, contract_id, _oracle, player1, player2, token, admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let id = client.create_match(
+        &player1,
+        &player2,
+        &100,
+        &token,
+        &String::from_str(&env, "snap_deposit"),
+        &Platform::Lichess,
+    );
+
+    client.deposit(&id, &player1);
+    let snaps = client.get_balance_snapshots(&admin, &id);
+    assert_eq!(snaps.len(), 2);
+    let after_p1 = snaps.get(1).unwrap();
+    assert_eq!(after_p1.reason, SnapshotReason::Deposit);
+    assert_eq!(after_p1.escrow_balance, 100);
+    assert!(after_p1.player1_deposited);
+    assert!(!after_p1.player2_deposited);
+
+    client.deposit(&id, &player2);
+    let snaps = client.get_balance_snapshots(&admin, &id);
+    assert_eq!(snaps.len(), 3);
+    let after_p2 = snaps.get(2).unwrap();
+    assert_eq!(after_p2.reason, SnapshotReason::Deposit);
+    assert_eq!(after_p2.escrow_balance, 200);
+    assert!(after_p2.player1_deposited);
+    assert!(after_p2.player2_deposited);
+}
+
+#[test]
+fn test_submit_result_records_completed_snapshot_with_zero_balance() {
+    let (env, contract_id, _oracle, player1, player2, token, admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let id = client.create_match(
+        &player1,
+        &player2,
+        &100,
+        &token,
+        &String::from_str(&env, "snap_completed"),
+        &Platform::Lichess,
+    );
+    client.deposit(&id, &player1);
+    client.deposit(&id, &player2);
+    client.submit_result(&id, &Winner::Player1);
+
+    let latest = client.get_latest_snapshot(&admin, &id);
+    assert_eq!(latest.reason, SnapshotReason::Completed);
+    assert_eq!(latest.escrow_balance, 0);
+    assert_eq!(latest.index, 3);
+}
+
+#[test]
+fn test_cancel_match_records_cancelled_snapshot_with_zero_balance() {
+    let (env, contract_id, _oracle, player1, player2, token, admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let id = client.create_match(
+        &player1,
+        &player2,
+        &100,
+        &token,
+        &String::from_str(&env, "snap_cancelled"),
+        &Platform::Lichess,
+    );
+    client.deposit(&id, &player1);
+    client.cancel_match(&id, &player1);
+
+    let latest = client.get_latest_snapshot(&admin, &id);
+    assert_eq!(latest.reason, SnapshotReason::Cancelled);
+    assert_eq!(latest.escrow_balance, 0);
+    assert_eq!(latest.index, 2);
+}
+
+#[test]
+fn test_expire_match_records_cancelled_snapshot() {
+    let (env, contract_id, _oracle, player1, player2, token, admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    client.set_match_timeout(&17_280);
+    env.ledger().set_sequence_number(100);
+
+    let id = client.create_match(
+        &player1,
+        &player2,
+        &100,
+        &token,
+        &String::from_str(&env, "snap_expired"),
+        &Platform::Lichess,
+    );
+    client.deposit(&id, &player1);
+
+    env.ledger().set_sequence_number(100 + 17_280);
+    client.expire_match(&id);
+
+    let latest = client.get_latest_snapshot(&admin, &id);
+    assert_eq!(latest.reason, SnapshotReason::Cancelled);
+    assert_eq!(latest.escrow_balance, 0);
+}
+
+#[test]
+fn test_full_lifecycle_snapshot_sequence_is_chronological() {
+    let (env, contract_id, _oracle, player1, player2, token, admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let id = client.create_match(
+        &player1,
+        &player2,
+        &100,
+        &token,
+        &String::from_str(&env, "snap_sequence"),
+        &Platform::Lichess,
+    );
+    client.deposit(&id, &player1);
+    client.deposit(&id, &player2);
+    client.submit_result(&id, &Winner::Player2);
+
+    let snaps = client.get_balance_snapshots(&admin, &id);
+    assert_eq!(snaps.len(), 4);
+
+    let reasons: std::vec::Vec<SnapshotReason> = snaps.iter().map(|s| s.reason.clone()).collect();
+    assert_eq!(
+        reasons,
+        std::vec![
+            SnapshotReason::Created,
+            SnapshotReason::Deposit,
+            SnapshotReason::Deposit,
+            SnapshotReason::Completed,
+        ]
+    );
+
+    for (i, snap) in snaps.iter().enumerate() {
+        assert_eq!(snap.index, i as u32);
+    }
+}
+
+#[test]
+fn test_admin_sees_exact_amounts_in_snapshots() {
+    let (env, contract_id, _oracle, player1, player2, token, admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let id = client.create_match(
+        &player1,
+        &player2,
+        &250,
+        &token,
+        &String::from_str(&env, "snap_admin_view"),
+        &Platform::Lichess,
+    );
+    client.deposit(&id, &player1);
+
+    let latest = client.get_latest_snapshot(&admin, &id);
+    assert_eq!(latest.stake_amount, 250);
+    assert_eq!(latest.escrow_balance, 250);
+}
+
+#[test]
+fn test_player_sees_redacted_amounts_in_snapshots() {
+    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let id = client.create_match(
+        &player1,
+        &player2,
+        &250,
+        &token,
+        &String::from_str(&env, "snap_player_view"),
+        &Platform::Lichess,
+    );
+    client.deposit(&id, &player1);
+
+    // player1 is a participant — gets partial (redacted) data, not Unauthorized.
+    let latest = client.get_latest_snapshot(&player1, &id);
+    assert_eq!(
+        latest.stake_amount, 0,
+        "stake_amount must be redacted for non-admin callers"
+    );
+    assert_eq!(
+        latest.escrow_balance, 0,
+        "escrow_balance must be redacted for non-admin callers"
+    );
+    // Non-sensitive fields remain visible.
+    assert_eq!(latest.reason, SnapshotReason::Deposit);
+    assert!(latest.player1_deposited);
+
+    // player2 (the other participant) also gets partial data.
+    let latest_p2 = client.get_latest_snapshot(&player2, &id);
+    assert_eq!(latest_p2.stake_amount, 0);
+    assert_eq!(latest_p2.escrow_balance, 0);
+}
+
+#[test]
+fn test_unrelated_caller_cannot_query_snapshots() {
+    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+    let outsider = Address::generate(&env);
+
+    let id = client.create_match(
+        &player1,
+        &player2,
+        &100,
+        &token,
+        &String::from_str(&env, "snap_unauthorized"),
+        &Platform::Lichess,
+    );
+
+    let result = client.try_get_balance_snapshots(&outsider, &id);
+    assert_eq!(result, Err(Ok(Error::Unauthorized)));
+
+    let result = client.try_get_latest_snapshot(&outsider, &id);
+    assert_eq!(result, Err(Ok(Error::Unauthorized)));
+}
+
+#[test]
+fn test_get_latest_snapshot_on_nonexistent_match_returns_match_not_found() {
+    let (env, contract_id, _oracle, _player1, _player2, _token, admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let result = client.try_get_latest_snapshot(&admin, &9999u64);
+    assert_eq!(result, Err(Ok(Error::MatchNotFound)));
+}
+
+#[test]
+fn test_multi_token_matches_record_independent_symbols_and_amounts() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let oracle = Address::generate(&env);
+    let player1 = Address::generate(&env);
+    let player2 = Address::generate(&env);
+
+    let token_a_id = env.register_stellar_asset_contract_v2(admin.clone());
+    let token_a = token_a_id.address();
+    let token_b_id = env.register_stellar_asset_contract_v2(admin.clone());
+    let token_b = token_b_id.address();
+
+    for token in [&token_a, &token_b] {
+        let asset_client = StellarAssetClient::new(&env, token);
+        asset_client.mint(&player1, &1000);
+        asset_client.mint(&player2, &1000);
+    }
+
+    let contract_id = env.register_contract(None, EscrowContract);
+    let client = EscrowContractClient::new(&env, &contract_id);
+    client.initialize(&oracle, &admin);
+
+    let match_a = client.create_match(
+        &player1,
+        &player2,
+        &100,
+        &token_a,
+        &String::from_str(&env, "multi_token_a"),
+        &Platform::Lichess,
+    );
+    let match_b = client.create_match(
+        &player1,
+        &player2,
+        &60,
+        &token_b,
+        &String::from_str(&env, "multi_token_b"),
+        &Platform::ChessDotCom,
+    );
+
+    client.deposit(&match_a, &player1);
+    client.deposit(&match_b, &player1);
+
+    let snap_a = client.get_latest_snapshot(&admin, &match_a);
+    let snap_b = client.get_latest_snapshot(&admin, &match_b);
+
+    assert_eq!(snap_a.token, token_a);
+    assert_eq!(snap_a.escrow_balance, 100);
+    assert_eq!(snap_b.token, token_b);
+    assert_eq!(snap_b.escrow_balance, 60);
+}
+
+#[test]
+fn test_snapshot_ring_buffer_prunes_oldest_entries() {
+    let (env, contract_id, _oracle, player1, player2, token, admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let id = client.create_match(
+        &player1,
+        &player2,
+        &100,
+        &token,
+        &String::from_str(&env, "snap_pruning"),
+        &Platform::Lichess,
+    );
+
+    // Drive far more snapshots than MAX_SNAPSHOTS_PER_MATCH by calling the
+    // internal recorder directly — exercises the ring-buffer overwrite path
+    // that a normal 4-event lifecycle never reaches.
+    env.as_contract(&contract_id, || {
+        let m: Match = env.storage().persistent().get(&DataKey::Match(id)).unwrap();
+        for _ in 0..(MAX_SNAPSHOTS_PER_MATCH * 3) {
+            EscrowContract::record_snapshot(&env, &m, SnapshotReason::Deposit);
+        }
+    });
+
+    let snaps = client.get_balance_snapshots(&admin, &id);
+    assert_eq!(
+        snaps.len() as u32,
+        MAX_SNAPSHOTS_PER_MATCH,
+        "ring buffer must cap stored snapshots at MAX_SNAPSHOTS_PER_MATCH"
+    );
+
+    // Oldest surviving entries must be the most recently written ones —
+    // older entries were overwritten, not appended past the cap.
+    let total_written = 1 + MAX_SNAPSHOTS_PER_MATCH * 3; // +1 for the Created snapshot
+    let first_surviving_index = total_written - MAX_SNAPSHOTS_PER_MATCH;
+    assert_eq!(snaps.get(0).unwrap().index, first_surviving_index);
+    assert_eq!(snaps.get(snaps.len() - 1).unwrap().index, total_written - 1);
+}
+
+#[test]
+fn test_get_balance_snapshots_empty_for_match_with_no_recorded_history() {
+    // Defensive case: if SnapshotCount were ever absent for an existing match,
+    // queries should degrade to an empty list rather than panicking.
+    let (env, contract_id, _oracle, player1, player2, token, admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let id = client.create_match(
+        &player1,
+        &player2,
+        &100,
+        &token,
+        &String::from_str(&env, "snap_wipe_history"),
+        &Platform::Lichess,
+    );
+
+    env.as_contract(&contract_id, || {
+        env.storage()
+            .persistent()
+            .remove(&DataKey::SnapshotCount(id));
+    });
+
+    let snaps = client.get_balance_snapshots(&admin, &id);
+    assert_eq!(snaps.len(), 0);
+
+    let result = client.try_get_latest_snapshot(&admin, &id);
+    assert_eq!(result, Err(Ok(Error::SnapshotNotFound)));
+}

--- a/contracts/escrow/src/types.rs
+++ b/contracts/escrow/src/types.rs
@@ -60,4 +60,44 @@ pub enum DataKey {
     AllowlistEnforced,
     AllowedTokens,
     OracleRecord(u64),
+    /// Balance snapshot for a match at a given ring-buffer slot.
+    /// Slot = (snapshot index) % MAX_SNAPSHOTS_PER_MATCH — see lib.rs.
+    Snapshot(u64, u32),
+    /// Total number of snapshots ever recorded for a match (monotonic, never reset).
+    SnapshotCount(u64),
+}
+
+/// The lifecycle event that triggered a balance snapshot.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum SnapshotReason {
+    Created,
+    Deposit,
+    Completed,
+    Cancelled,
+}
+
+/// A point-in-time record of a match's escrowed balance, taken at key
+/// lifecycle transitions for audit purposes.
+///
+/// Snapshots are stored in a fixed-size ring buffer per match (see
+/// `MAX_SNAPSHOTS_PER_MATCH`); `index` identifies the snapshot's position in
+/// the full chronological sequence so callers can detect gaps caused by
+/// pruning of older entries.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct BalanceSnapshot {
+    pub match_id: u64,
+    /// Monotonically increasing position in the match's snapshot history.
+    pub index: u32,
+    pub reason: SnapshotReason,
+    /// Ledger sequence number at the time of the snapshot.
+    pub ledger: u32,
+    pub token: Address,
+    pub token_symbol: String,
+    pub stake_amount: i128,
+    /// Total tokens held in escrow for this match at snapshot time.
+    pub escrow_balance: i128,
+    pub player1_deposited: bool,
+    pub player2_deposited: bool,
 }

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -178,3 +178,37 @@ To re-run the benchmarks locally:
 ```bash
 cargo test bench -- --nocapture
 ```
+
+---
+
+## Balance Snapshot Storage Overhead
+
+`EscrowContract` records a `BalanceSnapshot` (match id, lifecycle reason,
+ledger sequence, token address + symbol, stake amount, escrow balance, and
+both players' deposit flags) at four lifecycle points: match creation, each
+deposit, completion, and cancellation (including timeout-driven expiry).
+
+Snapshots are stored per-match in a fixed-size ring buffer
+(`MAX_SNAPSHOTS_PER_MATCH = 8` in `contracts/escrow/src/lib.rs`) under
+`DataKey::Snapshot(match_id, slot)`, with `DataKey::SnapshotCount(match_id)`
+tracking the total ever recorded. Once a match's snapshot count exceeds the
+buffer capacity, the oldest entry is overwritten — this caps growth so a
+single match can never accumulate unbounded snapshot history regardless of
+how many lifecycle transitions it goes through.
+
+**Estimated overhead per match**, based on the `BalanceSnapshot` field
+layout (two `Address`/`String` fields plus four numeric/bool fields, each XDR
+ledger-entry holding one snapshot):
+
+| Quantity                                   | Approx. size      |
+|---------------------------------------------|-------------------|
+| One `BalanceSnapshot` entry                  | ~200–250 bytes    |
+| `SnapshotCount` entry (once per match)       | ~40 bytes         |
+| Typical lifecycle (created + 2 deposits + completed/cancelled = 4 entries) | ~1.0 KB |
+| Worst case at ring-buffer cap (8 entries)    | ~2.0 KB           |
+
+These are conservative engineering estimates, not measured fee figures —
+confirm exact ledger-entry sizes with `stellar contract invoke --fee` on
+testnet before relying on them for capacity planning. All snapshot entries
+share the same TTL behavior as their parent match (`MATCH_TTL_LEDGERS`,
+refreshed on every write), so they expire alongside it.


### PR DESCRIPTION
closes #735
- Store balance snapshots at key lifecycle points (created, deposit, completed, cancelled/expired) in a fixed-size per-match ring buffer
- Implement TTL-aware snapshot storage with predictable keys (DataKey::Snapshot(match_id, slot) / SnapshotCount(match_id))
- Add get_balance_snapshots / get_latest_snapshot query functions — admin sees exact amounts, match participants see redacted amounts, anyone else is rejected as unauthorized
- Token symbol lookup is best-effort (try_invoke_contract) so snapshots never break create_match's existing tolerance for unvalidated tokens
- Add comprehensive snapshot tests covering all lifecycle transitions, access control, multi-token isolation, and ring-buffer pruning
- Document snapshot storage overhead per match in docs/deployment.md

Also fixes 3 pre-existing compile errors in tests/security.rs (soroban_sdk's vec! macro shadowing std's via glob import, and a stray .is_ok() call on a non-Result type) that were silently blocking the entire escrow test suite from compiling.

## Summary

Provide a short description of the change and the problem it fixes.

## Related Issue

Link the issue number or task this PR addresses.

## What changed
- Contracts:
- Tests:
- Docs:
- Events / API / storage:

## Verification
- What did you run to verify this change?
  - `cargo test -p escrow`
  - `cargo test -p oracle`
  - `cargo fmt`
  - `cargo clippy`

## Checklist
- [ ] I added or updated tests covering this change.
- [ ] I updated documentation or confirmed no docs update is needed.
- [ ] I confirmed any event/API/storage changes are documented and backward-compatible.
- [ ] I manually verified the contract or CLI behavior where applicable.
- [ ] I linked this PR to the related issue.
- [ ] I included notes on any TTL or storage assumptions affecting contract state.

## Notes

Add any additional details, risks, or follow-up tasks here.
