### PR TITLE
fix(indexer): return real total_events in stats

### DIFF
--- a/services/event-indexer/src/api.rs
+++ b/services/event-indexer/src/api.rs
@@ -218,11 +218,23 @@ pub struct Stats {
 async fn get_stats(State(state): State<AppState>) -> Json<ApiResponse<Stats>> {
     let cache_lock = state.cache.read().await;
     let cache_size = cache_lock.size();
+    drop(cache_lock);
+
+    let total_events = match state.db.total_event_count() {
+        Ok(count) => count,
+        Err(e) => {
+            return Json(ApiResponse {
+                success: false,
+                data: None,
+                error: Some(format!("Database error: {}", e)),
+            })
+        }
+    };
 
     Json(ApiResponse {
         success: true,
         data: Some(Stats {
-            total_events: 0,
+            total_events,
             cache_size,
         }),
         error: None,

--- a/services/event-indexer/src/db.rs
+++ b/services/event-indexer/src/db.rs
@@ -78,6 +78,14 @@ impl Database {
         Ok(())
     }
 
+    pub fn total_event_count(&self) -> Result<i64> {
+        let conn = self.conn.lock().unwrap();
+
+        let count = conn.query_row("SELECT COUNT(*) FROM events", [], |row| row.get(0))?;
+
+        Ok(count)
+    }
+
     pub fn get_events_by_match(&self, match_id: u64) -> Result<Vec<IndexedEvent>> {
         let conn = self.conn.lock().unwrap();
 

--- a/services/event-indexer/src/lib.rs
+++ b/services/event-indexer/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod db;
+pub mod models;

--- a/services/event-indexer/tests/integration_tests.rs
+++ b/services/event-indexer/tests/integration_tests.rs
@@ -1,6 +1,27 @@
 use chrono::Utc;
-use std::sync::Arc;
-use tokio::sync::RwLock;
+use event_indexer::{
+    db::Database,
+    models::IndexedEvent,
+};
+
+fn sample_event(id: &str, ledger_sequence: u32, match_id: u64) -> IndexedEvent {
+    IndexedEvent {
+        id: id.to_string(),
+        ledger_sequence,
+        match_id,
+        event_type: "created".to_string(),
+        player1: Some("GPLAYER1".to_string()),
+        player2: Some("GPLAYER2".to_string()),
+        status: Some("pending".to_string()),
+        winner: None,
+        stake_amount: Some("10000000".to_string()),
+        token: Some("USDC".to_string()),
+        game_id: Some(format!("game-{match_id}")),
+        platform: Some("lichess".to_string()),
+        timestamp: Utc::now(),
+        txn_hash: Some(format!("txn-{id}")),
+    }
+}
 
 #[test]
 fn test_event_indexing() {
@@ -23,4 +44,17 @@ fn test_cache_operations() {
     rt.block_on(async {
         assert!(true, "Cache operations test placeholder");
     });
+}
+
+#[test]
+fn test_total_event_count_counts_inserted_events() {
+    let db = Database::new(":memory:").unwrap();
+    db.init_schema().unwrap();
+
+    assert_eq!(db.total_event_count().unwrap(), 0);
+
+    db.insert_event(&sample_event("event-1", 10, 1)).unwrap();
+    db.insert_event(&sample_event("event-2", 11, 2)).unwrap();
+
+    assert_eq!(db.total_event_count().unwrap(), 2);
 }


### PR DESCRIPTION
## Summary
- add Database::total_event_count() to count persisted indexed events
- update GET /stats to return the real database count instead of hardcoded 0
- expose the event-indexer database/model modules to integration tests and cover the new count behavior

## Related Issue
Fixes #807

## What changed
- Events / API / storage: /stats now uses the event database count while preserving cache size reporting.
- Tests: added an integration test for empty and populated event databases.
- Contracts: none.
- Docs: none.

## Verification
- Not run locally in this browser-only workflow; change was reviewed against the small Rust API/database surface and includes a focused integration test.

## Checklist
- [x] I added or updated tests covering this change.
- [x] I updated documentation or confirmed no docs update is needed.
- [x] I confirmed any event/API/storage changes are documented and backward-compatible.
- [x] I linked this PR to the related issue.
