### PR TITLE
Fix issues #798, #797, #790, #794

### DIFF
--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -1309,10 +1309,19 @@ impl EscrowContract {
             .unwrap_or(false)
     }
 
-    /// Returns true if the contract has been initialized.
+    /// Returns true if the contract is currently initialized.
     pub fn is_initialized(env: Env) -> bool {
         extend_instance_ttl(&env);
         env.storage().instance().has(&DataKey::Oracle)
+    }
+
+    /// Returns true if the token allowlist is currently enforced.
+    pub fn is_allowlist_enforced(env: Env) -> bool {
+        extend_instance_ttl(&env);
+        env.storage()
+            .instance()
+            .get(&DataKey::AllowlistEnforced)
+            .unwrap_or(false)
     }
 
 }

--- a/contracts/escrow/src/tests/events.rs
+++ b/contracts/escrow/src/tests/events.rs
@@ -448,3 +448,41 @@ fn test_remove_allowed_token_emits_event() {
     let ev_token: Address = TryFromVal::try_from_val(&env, &data).unwrap();
     assert_eq!(ev_token, token);
 }
+
+#[test]
+fn test_expire_match_emits_event() {
+    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let match_id = client.create_match(
+        &player1,
+        &player2,
+        &100,
+        &token,
+        &String::from_str(&env, "expire_game"),
+        &Platform::Lichess,
+    );
+
+    client.deposit(&match_id, &player1);
+
+    client.set_match_timeout(&1);
+
+    env.ledger().set(2);
+
+    client.expire_match(&match_id);
+
+    let events = env.events().all();
+    let expected_topics = vec![
+        &env,
+        Symbol::new(&env, "match").into_val(&env),
+        symbol_short!("expired").into_val(&env),
+    ];
+    let matched = events
+        .iter()
+        .find(|(_, topics, _)| *topics == expected_topics);
+    assert!(matched.is_some(), "match expired event not emitted");
+
+    let (_, _, data) = matched.unwrap();
+    let ev_match_id: u64 = TryFromVal::try_from_val(&env, &data).unwrap();
+    assert_eq!(ev_match_id, match_id);
+}

--- a/contracts/escrow/src/tests/token_allowlist.rs
+++ b/contracts/escrow/src/tests/token_allowlist.rs
@@ -216,3 +216,15 @@ fn test_multiple_approved_tokens_can_coexist_after_allowlist_enforcement_is_enab
         "create_match should reject unknown token when allowlist is enforced"
     );
 }
+
+#[test]
+fn test_allowlist_enforcement_clears_when_empty() {
+    let (env, contract_id, _oracle, _player1, _player2, token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    client.add_allowed_token(&token);
+    assert!(client.is_allowlist_enforced(), "allowlist should be enforced after adding token");
+
+    client.remove_allowed_token(&token);
+    assert!(!client.is_allowlist_enforced(), "allowlist enforcement should be false after last token is removed");
+}

--- a/oracle-service/src/oracle/errors.rs
+++ b/oracle-service/src/oracle/errors.rs
@@ -23,3 +23,27 @@ pub enum ChessComError {
     #[error("game result is not available yet")]
     GameNotFinished,
 }
+
+#[derive(Debug, Error)]
+pub enum LichessError {
+    #[error("invalid lichess game id")]
+    InvalidGameId,
+
+    #[error("http request failed: {0}")]
+    Http(#[from] reqwest::Error),
+
+    #[error("request timed out")]
+    Timeout,
+
+    #[error("lichess returned non-success status: {status}")]
+    HttpStatus { status: reqwest::StatusCode },
+
+    #[error("game not found")]
+    GameNotFound,
+
+    #[error("game is missing result fields or is in an unknown state")]
+    InvalidResponse,
+
+    #[error("game result is not available yet")]
+    GameNotFinished,
+}

--- a/oracle-service/src/oracle/lichess_client.rs
+++ b/oracle-service/src/oracle/lichess_client.rs
@@ -1,0 +1,184 @@
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use contracts_oracle::types::Winner;
+
+use reqwest::Client;
+use serde::Deserialize;
+use tokio::sync::Mutex;
+
+use super::errors::LichessError;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LichessGameResult {
+    pub winner: Winner,
+}
+
+#[derive(Clone)]
+pub struct LichessClient {
+    http: Client,
+    api_base: String,
+}
+
+impl LichessClient {
+    pub fn new() -> Result<Self, LichessError> {
+        Self::new_with_base_and_timeout(
+            "https://lichess.org".to_string(),
+            Duration::from_secs(30),
+        )
+    }
+
+    pub fn new_with_base_and_timeout(
+        api_base: String,
+        request_timeout: Duration,
+    ) -> Result<Self, LichessError> {
+        let http = Client::builder()
+            .timeout(request_timeout)
+            .build()
+            .map_err(LichessError::Http)?;
+
+        Ok(Self {
+            http,
+            api_base,
+        })
+    }
+
+    pub fn validate_game_id(game_id: &str) -> Result<(), LichessError> {
+        if game_id.len() != 8 {
+            return Err(LichessError::InvalidGameId);
+        }
+        if !game_id.chars().all(|c| c.is_ascii_alphanumeric()) {
+            return Err(LichessError::InvalidGameId);
+        }
+        Ok(())
+    }
+
+    pub async fn fetch_result(&self, game_id: &str) -> Result<LichessGameResult, LichessError> {
+        Self::validate_game_id(game_id)?;
+
+        let url = format!(
+            "{}/game/export/{}",
+            self.api_base.trim_end_matches('/'),
+            game_id
+        );
+
+        let resp = self.http.get(url).send().await.map_err(|e| {
+            if e.is_timeout() {
+                LichessError::Timeout
+            } else {
+                LichessError::Http(e)
+            }
+        })?;
+
+        let status = resp.status();
+        if status == reqwest::StatusCode::NOT_FOUND {
+            return Err(LichessError::GameNotFound);
+        }
+        if !status.is_success() {
+            return Err(LichessError::HttpStatus { status });
+        }
+
+        let body: LichessGame = resp.json().await.map_err(LichessError::Http)?;
+
+        let winner = match body.winner.as_deref() {
+            Some("white") => Winner::Player1,
+            Some("black") => Winner::Player2,
+            None => Winner::Draw,
+            _ => return Err(LichessError::InvalidResponse),
+        };
+
+        Ok(LichessGameResult { winner })
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct LichessGame {
+    winner: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mockito::Server;
+
+    #[test]
+    fn test_validate_game_id_valid() {
+        assert!(LichessClient::validate_game_id("abc12345").is_ok());
+    }
+
+    #[test]
+    fn test_validate_game_id_invalid_length() {
+        assert!(LichessClient::validate_game_id("abc123").is_err());
+    }
+
+    #[test]
+    fn test_validate_game_id_invalid_chars() {
+        assert!(LichessClient::validate_game_id("abc!2345").is_err());
+    }
+
+    #[tokio::test]
+    async fn test_fetch_result_white_wins() {
+        let mut server = Server::new();
+        let mock = server
+            .mock("GET", "/game/export/abc12345")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"winner":"white"}"#)
+            .create();
+
+        let client = LichessClient::new_with_base_and_timeout(server.url(), Duration::from_secs(30)).unwrap();
+        let result = client.fetch_result("abc12345").await.unwrap();
+
+        assert_eq!(result.winner, Winner::Player1);
+        mock.assert();
+    }
+
+    #[tokio::test]
+    async fn test_fetch_result_black_wins() {
+        let mut server = Server::new();
+        let mock = server
+            .mock("GET", "/game/export/abc12345")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"winner":"black"}"#)
+            .create();
+
+        let client = LichessClient::new_with_base_and_timeout(server.url(), Duration::from_secs(30)).unwrap();
+        let result = client.fetch_result("abc12345").await.unwrap();
+
+        assert_eq!(result.winner, Winner::Player2);
+        mock.assert();
+    }
+
+    #[tokio::test]
+    async fn test_fetch_result_draw() {
+        let mut server = Server::new();
+        let mock = server
+            .mock("GET", "/game/export/abc12345")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"winner":null}"#)
+            .create();
+
+        let client = LichessClient::new_with_base_and_timeout(server.url(), Duration::from_secs(30)).unwrap();
+        let result = client.fetch_result("abc12345").await.unwrap();
+
+        assert_eq!(result.winner, Winner::Draw);
+        mock.assert();
+    }
+
+    #[tokio::test]
+    async fn test_fetch_result_not_found() {
+        let mut server = Server::new();
+        let mock = server
+            .mock("GET", "/game/export/abc12345")
+            .with_status(404)
+            .create();
+
+        let client = LichessClient::new_with_base_and_timeout(server.url(), Duration::from_secs(30)).unwrap();
+        let result = client.fetch_result("abc12345").await;
+
+        assert!(matches!(result, Err(LichessError::GameNotFound)));
+        mock.assert();
+    }
+}

--- a/oracle-service/src/oracle/mod.rs
+++ b/oracle-service/src/oracle/mod.rs
@@ -1,5 +1,7 @@
 pub mod chess_com_client;
 pub mod errors;
+pub mod lichess_client;
 
 pub use chess_com_client::{ChessComClient, ChessComGameResult};
-pub use errors::ChessComError;
+pub use errors::{ChessComError, LichessError};
+pub use lichess_client::{LichessClient, LichessGameResult};


### PR DESCRIPTION
- Add LichessError error type with required variants (#798)
- Add Lichess API client with fetch_result and unit tests (#797)
- Add is_allowlist_enforced() function and test for enforcement clearing (#790)
- Add test for expire_match emitting match/expired event (#794)

## Summary


Provide a short description of the change and the problem it fixes.

## Related Issue

Link the issue number or task this PR addresses.

## What changed
- Contracts:
- Tests:
- Docs:
- Events / API / storage:

## Verification
- What did you run to verify this change?
  - `cargo test -p escrow`
  - `cargo test -p oracle`
  - `cargo fmt`
  - `cargo clippy`

## Checklist
- [ ] I added or updated tests covering this change.
- [ ] I updated documentation or confirmed no docs update is needed.
- [ ] I confirmed any event/API/storage changes are documented and backward-compatible.
- [ ] I manually verified the contract or CLI behavior where applicable.
- [ ] I linked this PR to the related issue.
- [ ] I included notes on any TTL or storage assumptions affecting contract state.

## Notes

Add any additional details, risks, or follow-up tasks here.
