### PR TITLE
fix: resolve issues #770, #771, #772 — empty game_id, pending matches, oracle get_admin

### DIFF
--- a/contracts/escrow/src/tests/index.rs
+++ b/contracts/escrow/src/tests/index.rs
@@ -255,3 +255,12 @@ fn test_match_transitions_from_pending_to_active_matches() {
     assert_eq!(active_matches.len(), 1);
     assert_eq!(active_matches.get(0).unwrap().id, match_id);
 }
+
+#[test]
+fn test_get_pending_matches_empty() {
+    let (env, contract_id, _oracle, _player1, _player2, _token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let pending = client.get_pending_matches();
+    assert_eq!(pending.len(), 0);
+}

--- a/contracts/escrow/src/tests/lifecycle.rs
+++ b/contracts/escrow/src/tests/lifecycle.rs
@@ -1677,3 +1677,19 @@ fn test_get_pending_matches_returns_newly_created_matches() {
     assert!(pending.iter().any(|m| m.id == id1));
     assert!(pending.iter().any(|m| m.id == id2));
 }
+
+#[test]
+fn test_create_match_empty_game_id_rejected() {
+    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let result = client.try_create_match(
+        &player1,
+        &player2,
+        &100,
+        &token,
+        &String::from_str(&env, ""),
+        &Platform::Lichess,
+    );
+    assert_eq!(result, Err(Ok(Error::InvalidGameId)));
+}

--- a/contracts/oracle/src/lib.rs
+++ b/contracts/oracle/src/lib.rs
@@ -278,6 +278,18 @@ impl OracleContract {
         Ok(env.storage().persistent().has(&DataKey::Result(match_id)))
     }
 
+    /// Return the admin address stored in the contract.
+    ///
+    /// # Errors
+    /// - [`Error::Unauthorized`] — contract has not been initialized.
+    pub fn get_admin(env: Env) -> Result<Address, Error> {
+        extend_instance_ttl(&env);
+        env.storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(Error::Unauthorized)
+    }
+
     /// Admin removes a previously submitted result from persistent storage.
     /// Emits a `oracle / deleted` event with the `match_id`.
     ///

--- a/contracts/oracle/src/tests.rs
+++ b/contracts/oracle/src/tests.rs
@@ -1514,3 +1514,28 @@ fn test_high_volume_burst_is_throttled_then_recovers_next_hour() {
     );
     assert!(client.has_result(&999u64));
 }
+
+#[test]
+fn test_get_admin_returns_admin_after_initialize() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let contract_id = env.register_contract(None, OracleContract);
+    let client = OracleContractClient::new(&env, &contract_id);
+    client.initialize(&admin);
+
+    assert_eq!(client.get_admin(), admin);
+}
+
+#[test]
+fn test_get_admin_returns_unauthorized_when_not_initialized() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, OracleContract);
+    let client = OracleContractClient::new(&env, &contract_id);
+
+    let result = client.try_get_admin();
+    assert_eq!(result, Err(Ok(Error::Unauthorized)));
+}


### PR DESCRIPTION
## Summary

Closes #770 
closes #771 
closes #772
closes #773 

Four focused commits addressing three wave-ready issues.

### #770 — test: empty game_id is rejected
- Added `test_create_match_empty_game_id_rejected` in `contracts/escrow/src/tests/lifecycle.rs`
- Asserts `create_match` returns `Err(Error::InvalidGameId)` when an empty string is passed as `game_id`

### #771 — test: get_pending_matches returns empty list
- Added `test_get_pending_matches_empty` in `contracts/escrow/src/tests/index.rs`
- Asserts `get_pending_matches()` returns an empty `Vec` on a freshly initialized contract

### #772 — Oracle: add get_admin view function (2 commits)
- Added `pub fn get_admin(env: Env) -> Result<Address, Error>` to `contracts/oracle/src/lib.rs`
  - Returns the stored admin `Address` when initialized
  - Returns `Error::Unauthorized` when the contract has not been initialized
- Added two unit tests in `contracts/oracle/src/tests.rs`:
  - `test_get_admin_returns_admin_after_initialize`
  - `test_get_admin_returns_unauthorized_when_not_initialized`

## Files Changed
- `contracts/escrow/src/tests/lifecycle.rs`
- `contracts/escrow/src/tests/index.rs`
- `contracts/oracle/src/lib.rs`
- `contracts/oracle/src/tests.rs`