### PR TITLE
test/feat: resolve issues #766, #767, #769, #805

### DIFF
--- a/contracts/escrow/src/tests/admin.rs
+++ b/contracts/escrow/src/tests/admin.rs
@@ -650,3 +650,35 @@ fn test_set_match_timeout_requires_admin_authorization() {
     let result = client.try_set_match_timeout(&new_timeout);
     assert!(result.is_err(), "non-admin should not be able to set timeout");
 }
+
+// #766 — two-step admin transfer: propose_admin + accept_admin happy-path
+#[test]
+fn test_two_step_admin_transfer() {
+    let (env, contract_id, _oracle, _player1, _player2, _token, admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let new_admin = Address::generate(&env);
+
+    // Propose: current admin should not change yet
+    client.propose_admin(&new_admin);
+    assert_eq!(client.get_admin(), admin, "admin must not change before accept");
+
+    // Accept: new_admin calls accept_admin
+    env.mock_auths(&[MockAuth {
+        address: &new_admin,
+        invoke: &MockAuthInvoke {
+            contract: &contract_id,
+            fn_name: "accept_admin",
+            args: ().into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+    client.accept_admin();
+
+    // Admin is now new_admin and PendingAdmin key is cleared
+    assert_eq!(client.get_admin(), new_admin, "admin must be new_admin after accept");
+    let pending: Option<Address> = env.as_contract(&contract_id, || {
+        env.storage().instance().get(&DataKey::PendingAdmin)
+    });
+    assert!(pending.is_none(), "PendingAdmin key must be cleared after acceptance");
+}

--- a/contracts/escrow/src/tests/lifecycle.rs
+++ b/contracts/escrow/src/tests/lifecycle.rs
@@ -1677,3 +1677,21 @@ fn test_get_pending_matches_returns_newly_created_matches() {
     assert!(pending.iter().any(|m| m.id == id1));
     assert!(pending.iter().any(|m| m.id == id2));
 }
+
+// #769 — game_id exceeding MAX_GAME_ID_LEN (64) must return Error::InvalidGameId
+#[test]
+fn test_create_match_game_id_too_long() {
+    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let game_id_65 = String::from_str(&env, &"x".repeat(65));
+    let result = client.try_create_match(
+        &player1,
+        &player2,
+        &100,
+        &token,
+        &game_id_65,
+        &Platform::Lichess,
+    );
+    assert_eq!(result, Err(Ok(Error::InvalidGameId)));
+}

--- a/contracts/escrow/src/tests/security.rs
+++ b/contracts/escrow/src/tests/security.rs
@@ -622,3 +622,28 @@ fn test_security_oracle_cannot_be_contract() {
     let result = client.try_initialize(&contract_id, &admin);
     assert!(result.is_err(), "Should reject contract as oracle (InvalidAddress)");
 }
+
+// #767 — accept_admin called by a non-pending-admin address must be rejected
+#[test]
+fn test_accept_admin_wrong_caller_rejected() {
+    let (env, contract_id, _oracle, _player1, _player2, _token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let pending_admin = Address::generate(&env);
+    let wrong_caller = Address::generate(&env);
+
+    client.propose_admin(&pending_admin);
+
+    env.mock_auths(&[MockAuth {
+        address: &wrong_caller,
+        invoke: &MockAuthInvoke {
+            contract: &contract_id,
+            fn_name: "accept_admin",
+            args: ().into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+
+    let result = client.try_accept_admin();
+    assert_eq!(result, Err(Ok(Error::Unauthorized)));
+}

--- a/oracle-service/src/oracle/chess_com_client.rs
+++ b/oracle-service/src/oracle/chess_com_client.rs
@@ -32,6 +32,18 @@ pub struct ChessComClient {
     last_request: Arc<Mutex<Instant>>,
 }
 
+/// Implements [`Default`] by delegating to [`ChessComClient::new`].
+///
+/// # Panics
+/// Panics if the underlying HTTP client cannot be constructed (e.g. TLS
+/// initialisation failure). Use [`ChessComClient::new`] directly when you
+/// need to handle that error explicitly.
+impl Default for ChessComClient {
+    fn default() -> Self {
+        Self::new().expect("failed to construct ChessComClient")
+    }
+}
+
 impl ChessComClient {
     pub fn new() -> Result<Self, ChessComError> {
         Self::new_with_base_and_timeout(


### PR DESCRIPTION
## Summary

Resolves four wave-ready issues in a single PR. Each issue has its own focused commit.

## Changes

### #766 — Two-step admin transfer happy-path test (admin.rs)
- Added `test_two_step_admin_transfer`
- Asserts `get_admin` still returns the old admin after `propose_admin`
- Asserts `get_admin` returns the new admin after `accept_admin`
- Asserts `PendingAdmin` instance-storage key is cleared after acceptance

### #767 — accept_admin wrong-caller rejection test (security.rs)
- Added `test_accept_admin_wrong_caller_rejected`
- Proposes a pending admin, then calls `accept_admin` from an unrelated address
- Asserts `Err(Error::Unauthorized)` is returned

### #769 — game_id too-long rejection test (lifecycle.rs)
- Added `test_create_match_game_id_too_long`
- Passes a 65-character game ID (exceeds MAX_GAME_ID_LEN of 64)
- Asserts `Err(Error::InvalidGameId)` is returned

### #805 — Default implementation for ChessComClient (chess_com_client.rs)
- Implemented `Default` delegating to `ChessComClient::new().expect(...)`
- Added doc comment explaining the panic condition (TLS / HTTP client build failure)

## Testing

No new production logic — all changes are either tests or a trivial trait impl.
New tests run as part of `cargo test`.

Closes #766
Closes #767
Closes #769
Closes #805
