### PR TITLE
feat(oracle): add get_admin and test_oracle_admin_rotation

### DIFF
--- a/contracts/oracle/src/lib.rs
+++ b/contracts/oracle/src/lib.rs
@@ -319,6 +319,18 @@ impl OracleContract {
         Ok(())
     }
 
+    /// Return the current admin address.
+    ///
+    /// # Errors
+    /// - [`Error::Unauthorized`] — contract has not been initialized.
+    pub fn get_admin(env: Env) -> Result<Address, Error> {
+        extend_instance_ttl(&env);
+        env.storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(Error::Unauthorized)
+    }
+
     /// Rotate the admin to a new address. Requires current admin auth.
     /// Emits an `admin / admin_rot` event with `(old_admin, new_admin)`.
     ///

--- a/contracts/oracle/src/tests.rs
+++ b/contracts/oracle/src/tests.rs
@@ -818,6 +818,47 @@ fn test_update_admin_emits_rotation_event() {
 }
 
 #[test]
+fn test_oracle_admin_rotation() {
+    let (env, contract_id, _escrow_id, old_admin, ..) = setup();
+    let client = OracleContractClient::new(&env, &contract_id);
+
+    let new_admin = Address::generate(&env);
+
+    // Rotate admin
+    client.update_admin(&new_admin);
+
+    // get_admin reflects the new admin
+    assert_eq!(client.get_admin(), new_admin);
+
+    // Old admin can no longer call an admin-gated function (pause)
+    env.mock_auths(&[soroban_sdk::testutils::MockAuth {
+        address: &old_admin,
+        invoke: &soroban_sdk::testutils::MockAuthInvoke {
+            contract: &contract_id,
+            fn_name: "pause",
+            args: ().into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+    assert!(
+        client.try_pause().is_err(),
+        "old admin must be rejected after rotation"
+    );
+
+    // New admin can still call admin-gated functions
+    env.mock_auths(&[soroban_sdk::testutils::MockAuth {
+        address: &new_admin,
+        invoke: &soroban_sdk::testutils::MockAuthInvoke {
+            contract: &contract_id,
+            fn_name: "pause",
+            args: ().into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+    client.pause();
+}
+
+#[test]
 fn test_oracle_escrow_integration_submit_result_with_oracle_record() {
     let (env, oracle_id, escrow_id, oracle_admin, player1, player2, token_addr) = setup();
     let escrow_client = EscrowContractClient::new(&env, &escrow_id);


### PR DESCRIPTION
- Add get_admin() to OracleContract for querying the current admin
- Add test_oracle_admin_rotation covering the full happy path:
  - get_admin returns the new admin after update_admin
  - old admin is rejected from admin-gated functions post-rotation
  - new admin can successfully call admin-gated functions

## Summary

#Closes #777 

Provide a short description of the change and the problem it fixes.

## Related Issue

Link the issue number or task this PR addresses.

## What changed
- Contracts:
- Tests:
- Docs:
- Events / API / storage:

## Verification
- What did you run to verify this change?
  - `cargo test -p escrow`
  - `cargo test -p oracle`
  - `cargo fmt`
  - `cargo clippy`

## Checklist
- [ ] I added or updated tests covering this change.
- [ ] I updated documentation or confirmed no docs update is needed.
- [ ] I confirmed any event/API/storage changes are documented and backward-compatible.
- [ ] I manually verified the contract or CLI behavior where applicable.
- [ ] I linked this PR to the related issue.
- [ ] I included notes on any TTL or storage assumptions affecting contract state.

## Notes

Add any additional details, risks, or follow-up tasks here.
