### PR TITLE
feat(event-indexer): add configurable log level via EVENT_INDEXER_LOG…

### DIFF
--- a/services/event-indexer/README.md
+++ b/services/event-indexer/README.md
@@ -80,6 +80,7 @@ Environment variables:
 | `EVENT_INDEXER_PORT` | `8080` | API port |
 | `EVENT_INDEXER_CACHE_SIZE` | `10000` | Maximum cache entries |
 | `EVENT_INDEXER_POLL_INTERVAL` | `5` | Polling interval in seconds |
+| `EVENT_INDEXER_LOG_LEVEL` | `info` | Log verbosity (`error`, `warn`, `info`, `debug`, `trace`) |
 
 ## Testing
 

--- a/services/event-indexer/src/config.rs
+++ b/services/event-indexer/src/config.rs
@@ -10,6 +10,7 @@ pub struct Config {
     pub bind_port: u16,
     pub cache_size: usize,
     pub poll_interval_secs: u64,
+    pub log_level: String,
 }
 
 impl Config {
@@ -38,6 +39,9 @@ impl Config {
             .unwrap_or_else(|_| "5".to_string())
             .parse::<u64>()?;
 
+        let log_level = env::var("EVENT_INDEXER_LOG_LEVEL")
+            .unwrap_or_else(|_| "info".to_string());
+
         Ok(Config {
             rpc_url,
             contract_escrow,
@@ -46,6 +50,7 @@ impl Config {
             bind_port,
             cache_size,
             poll_interval_secs,
+            log_level,
         })
     }
 }

--- a/services/event-indexer/src/main.rs
+++ b/services/event-indexer/src/main.rs
@@ -13,14 +13,14 @@ use tracing::{info, error};
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    let config = Config::from_env()?;
+
     tracing_subscriber::fmt()
         .with_env_filter(
             tracing_subscriber::EnvFilter::from_default_env()
-                .add_directive("event_indexer=info".parse()?),
+                .add_directive(format!("event_indexer={}", config.log_level).parse()?),
         )
         .init();
-
-    let config = Config::from_env()?;
     info!("Event Indexer starting with config: {:?}", config);
 
     let db = Arc::new(db::Database::new(&config.db_path)?);


### PR DESCRIPTION
…_LEVEL

- Add log_level: String field to Config, defaulting to "info"
- Read from EVENT_INDEXER_LOG_LEVEL env var
- Apply directive in tracing_subscriber init in main.rs
- Document variable in services/event-indexer/README.md

## Summary

Provide a short description of the change and the problem it fixes.

## Related Issue

Link the issue number or task this PR addresses.

## What changed
- Contracts:
- Tests:
- Docs:
- Events / API / storage:

## Verification
- What did you run to verify this change?
  - `cargo test -p escrow`
  - `cargo test -p oracle`
  - `cargo fmt`
  - `cargo clippy`

## Checklist
- [ ] I added or updated tests covering this change.
- [ ] I updated documentation or confirmed no docs update is needed.
- [ ] I confirmed any event/API/storage changes are documented and backward-compatible.
- [ ] I manually verified the contract or CLI behavior where applicable.
- [ ] I linked this PR to the related issue.
- [ ] I included notes on any TTL or storage assumptions affecting contract state.

## Notes

Add any additional details, risks, or follow-up tasks here.
closes #816 