### PR TITLE
test: add cache-hit test for GET /events/:match_id (#817)

### DIFF
--- a/services/event-indexer/src/lib.rs
+++ b/services/event-indexer/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod cache;
+pub mod models;

--- a/services/event-indexer/tests/integration_tests.rs
+++ b/services/event-indexer/tests/integration_tests.rs
@@ -1,4 +1,6 @@
 use chrono::Utc;
+use event_indexer::cache::EventCache;
+use event_indexer::models::IndexedEvent;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
@@ -22,5 +24,39 @@ fn test_cache_operations() {
 
     rt.block_on(async {
         assert!(true, "Cache operations test placeholder");
+    });
+}
+
+#[test]
+fn test_get_match_events_served_from_cache() {
+    let rt = tokio::runtime::Runtime::new().unwrap();
+
+    rt.block_on(async {
+        let cache = Arc::new(RwLock::new(EventCache::new(100)));
+
+        let event = IndexedEvent {
+            id: "evt-1".to_string(),
+            ledger_sequence: 42,
+            match_id: 99,
+            event_type: "match_created".to_string(),
+            player1: None,
+            player2: None,
+            status: None,
+            winner: None,
+            stake_amount: None,
+            token: None,
+            game_id: None,
+            platform: None,
+            timestamp: Utc::now(),
+            txn_hash: None,
+        };
+
+        cache.write().await.insert(event.clone());
+
+        // Replicate the handler's cache-check logic: if non-empty, DB is never reached
+        let cached = cache.read().await.get_by_match(99);
+        assert!(!cached.is_empty(), "cache should contain events for match 99");
+        assert_eq!(cached[0].id, event.id);
+        assert_eq!(cached[0].match_id, 99);
     });
 }


### PR DESCRIPTION
## Summary

Provide a short description of the change and the problem it fixes.

## Related Issue

Link the issue number or task this PR addresses.

## What changed
- Contracts:
- Tests:
- Docs:
- Events / API / storage:

## Verification
- What did you run to verify this change?
  - `cargo test -p escrow`
  - `cargo test -p oracle`
  - `cargo fmt`
  - `cargo clippy`

## Checklist
- [ ] I added or updated tests covering this change.
- [ ] I updated documentation or confirmed no docs update is needed.
- [ ] I confirmed any event/API/storage changes are documented and backward-compatible.
- [ ] I manually verified the contract or CLI behavior where applicable.
- [ ] I linked this PR to the related issue.
- [ ] I included notes on any TTL or storage assumptions affecting contract state.

## Notes

Add any additional details, risks, or follow-up tasks here.
Closes #817