### PR TITLE
fix: resolve issues #800 and #819

### DIFF
--- a/oracle-service/tests/chess_com_client_unit.rs
+++ b/oracle-service/tests/chess_com_client_unit.rs
@@ -104,6 +104,28 @@ async fn fetch_result_404_maps_to_game_not_found() {
 }
 
 #[tokio::test]
+async fn test_chess_com_draw_result() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/pub/game/42"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "end": {"result": "draw"}
+        })))
+        .mount(&server)
+        .await;
+
+    let client = ChessComClient::new_with_base_and_timeout(
+        server.uri(),
+        std::time::Duration::from_secs(30),
+    )
+    .unwrap();
+
+    let res: ChessComGameResult = client.fetch_result("42").await.unwrap();
+    assert_eq!(res.winner, contracts_oracle::types::Winner::Draw);
+}
+
+#[tokio::test]
 async fn fetch_result_invalid_response_errors() {
     let server = MockServer::start().await;
 

--- a/services/event-indexer/src/config.rs
+++ b/services/event-indexer/src/config.rs
@@ -39,6 +39,13 @@ impl Config {
             .unwrap_or_else(|_| "5".to_string())
             .parse::<u64>()?;
 
+        if poll_interval_secs < 1 || poll_interval_secs > 60 {
+            return Err(anyhow!(
+                "poll_interval_secs must be between 1 and 60, got {}",
+                poll_interval_secs
+            ));
+        }
+
         let log_level = env::var("EVENT_INDEXER_LOG_LEVEL")
             .unwrap_or_else(|_| "info".to_string());
 
@@ -52,5 +59,42 @@ impl Config {
             poll_interval_secs,
             log_level,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn base_env() {
+        env::set_var("CONTRACT_ESCROW", "CTEST");
+    }
+
+    #[test]
+    fn poll_interval_zero_is_rejected() {
+        base_env();
+        env::set_var("EVENT_INDEXER_POLL_INTERVAL", "0");
+        assert!(Config::from_env().is_err());
+    }
+
+    #[test]
+    fn poll_interval_61_is_rejected() {
+        base_env();
+        env::set_var("EVENT_INDEXER_POLL_INTERVAL", "61");
+        assert!(Config::from_env().is_err());
+    }
+
+    #[test]
+    fn poll_interval_1_is_accepted() {
+        base_env();
+        env::set_var("EVENT_INDEXER_POLL_INTERVAL", "1");
+        assert!(Config::from_env().is_ok());
+    }
+
+    #[test]
+    fn poll_interval_60_is_accepted() {
+        base_env();
+        env::set_var("EVENT_INDEXER_POLL_INTERVAL", "60");
+        assert!(Config::from_env().is_ok());
     }
 }


### PR DESCRIPTION

i Added `test_chess_com_draw_result` to
`oracle-service/tests/chess_com_client_unit.rs`.

### How it was done
- Spun up a wiremock MockServer
- Registered a GET handler on `/pub/game/42` returning `{"end": {"result": "draw"}}` with HTTP 200
- Constructed a `ChessComClient` pointing at the mock server via `new_with_base_and_timeout`
- Called `client.fetch_result("42")` and asserted the returned `ChessComGameResult` has `winner == Winner::Draw`

Closes #800

---

## Issue #819 — Add poll_interval_secs validation (min 1, max 60)

### Problem
`poll_interval_secs` in the event-indexer Config accepted any u64 value. A value of 0 causes a tight polling loop; values above 60 make the indexer unresponsive for too long.

i  What was done
Added bounds validation in `services/event-indexer/src/config.rs` and four unit tests covering the boundary values.

### How it was done
- After parsing `EVENT_INDEXER_POLL_INTERVAL` into a u64, added a check: if the value is < 1 or > 60, `from_env()` returns an `Err` with a descriptive message.
- Added a `#[cfg(test)] mod tests` block with four tests:
  - `poll_interval_zero_is_rejected` — value 0 → Err
  - `poll_interval_61_is_rejected`  — value 61 → Err
  - `poll_interval_1_is_accepted`   — value 1 → Ok (lower boundary)
  - `poll_interval_60_is_accepted`  — value 60 → Ok (upper boundary)

Closes #819
pdated tests covering this change.
- [ ] I updated documentation or confirmed no docs update is needed.
- [ ] I confirmed any event/API/storage changes are documented and backward-compatible.
- [ ] I manually verified the contract or CLI behavior where applicable.
- [ ] I linked this PR to the related issue.
- [ ] I included notes on any TTL or storage assumptions affecting contract state.

## Notes

Add any additional details, risks, or follow-up tasks here.
