### PR TITLE
fix: add lichess_client and expire_match event test

### DIFF
--- a/contracts/escrow/src/tests/events.rs
+++ b/contracts/escrow/src/tests/events.rs
@@ -448,3 +448,37 @@ fn test_remove_allowed_token_emits_event() {
     let ev_token: Address = TryFromVal::try_from_val(&env, &data).unwrap();
     assert_eq!(ev_token, token);
 }
+
+#[test]
+fn test_expire_match_emits_event() {
+    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let id = client.create_match(
+        &player1,
+        &player2,
+        &100,
+        &token,
+        &String::from_str(&env, "game_expire_evt"),
+        &Platform::Lichess,
+    );
+
+    // Advance ledger past the timeout so expire_match succeeds.
+    env.ledger().set_sequence_number(100 + 17_280);
+    client.expire_match(&id);
+
+    let events = env.events().all();
+    let expected_topics = vec![
+        &env,
+        Symbol::new(&env, "match").into_val(&env),
+        soroban_sdk::symbol_short!("expired").into_val(&env),
+    ];
+    let matched = events
+        .iter()
+        .find(|(_, topics, _)| *topics == expected_topics);
+    assert!(matched.is_some(), "match/expired event not emitted");
+
+    let (_, _, data) = matched.unwrap();
+    let ev_id: u64 = TryFromVal::try_from_val(&env, &data).unwrap();
+    assert_eq!(ev_id, id);
+}

--- a/oracle-service/src/oracle/lichess_client.rs
+++ b/oracle-service/src/oracle/lichess_client.rs
@@ -1,0 +1,129 @@
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use contracts_oracle::types::Winner;
+use reqwest::Client;
+use serde::Deserialize;
+use tokio::sync::Mutex;
+
+use super::errors::ChessComError;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LichessGameResult {
+    pub winner: Winner,
+}
+
+/// Lichess off-chain client.
+///
+/// - Validates Lichess game IDs (exactly 8 alphanumeric characters).
+/// - Applies a per-request timeout (30s).
+#[derive(Clone)]
+pub struct LichessClient {
+    http: Client,
+    api_base: String,
+    min_spacing: Duration,
+    last_request: Arc<Mutex<Instant>>,
+}
+
+impl Default for LichessClient {
+    fn default() -> Self {
+        Self::new().expect("failed to construct LichessClient")
+    }
+}
+
+impl LichessClient {
+    pub fn new() -> Result<Self, ChessComError> {
+        Self::new_with_base_and_timeout(
+            "https://lichess.org".to_string(),
+            Duration::from_secs(30),
+        )
+    }
+
+    pub fn new_with_base_and_timeout(
+        api_base: String,
+        request_timeout: Duration,
+    ) -> Result<Self, ChessComError> {
+        let http = Client::builder()
+            .timeout(request_timeout)
+            .build()
+            .map_err(ChessComError::Http)?;
+
+        let min_spacing = Duration::from_secs(2);
+
+        Ok(Self {
+            http,
+            api_base,
+            min_spacing,
+            last_request: Arc::new(Mutex::new(Instant::now() - min_spacing)),
+        })
+    }
+
+    /// Validates that a Lichess game ID is exactly 8 alphanumeric characters.
+    pub fn validate_game_id(game_id: &str) -> Result<(), ChessComError> {
+        if game_id.len() != 8 || !game_id.chars().all(|c| c.is_ascii_alphanumeric()) {
+            return Err(ChessComError::InvalidGameId);
+        }
+        Ok(())
+    }
+
+    async fn enforce_rate_limit(&self) -> Result<(), ChessComError> {
+        let mut last = self.last_request.lock().await;
+        let elapsed = Instant::now().saturating_duration_since(*last);
+        if elapsed < self.min_spacing {
+            tokio::time::sleep(self.min_spacing - elapsed).await;
+        }
+        *last = Instant::now();
+        Ok(())
+    }
+
+    pub async fn fetch_result(&self, game_id: &str) -> Result<LichessGameResult, ChessComError> {
+        Self::validate_game_id(game_id)?;
+
+        self.enforce_rate_limit().await?;
+
+        let url = format!(
+            "{}/game/export/{}",
+            self.api_base.trim_end_matches('/'),
+            game_id
+        );
+
+        let resp = self
+            .http
+            .get(&url)
+            .header("Accept", "application/json")
+            .send()
+            .await
+            .map_err(|e| {
+                if e.is_timeout() {
+                    ChessComError::Timeout
+                } else {
+                    ChessComError::Http(e)
+                }
+            })?;
+
+        let status = resp.status();
+        if status == reqwest::StatusCode::NOT_FOUND {
+            return Err(ChessComError::GameNotFound);
+        }
+        if !status.is_success() {
+            return Err(ChessComError::HttpStatus { status });
+        }
+
+        let body: LichessGame = resp.json().await.map_err(ChessComError::Http)?;
+
+        // Lichess: "winner" field is "white", "black", or absent (draw).
+        let winner = match body.winner.as_deref() {
+            Some("white") => Winner::Player1,
+            Some("black") => Winner::Player2,
+            None => Winner::Draw,
+            _ => return Err(ChessComError::InvalidResponse),
+        };
+
+        Ok(LichessGameResult { winner })
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct LichessGame {
+    winner: Option<String>,
+}

--- a/oracle-service/src/oracle/mod.rs
+++ b/oracle-service/src/oracle/mod.rs
@@ -1,5 +1,7 @@
 pub mod chess_com_client;
 pub mod errors;
+pub mod lichess_client;
 
 pub use chess_com_client::{ChessComClient, ChessComGameResult};
 pub use errors::ChessComError;
+pub use lichess_client::{LichessClient, LichessGameResult};

--- a/oracle-service/tests/lichess_client_unit.rs
+++ b/oracle-service/tests/lichess_client_unit.rs
@@ -1,0 +1,135 @@
+use oracle_service::oracle::{ChessComError, LichessClient, LichessGameResult};
+
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+#[tokio::test]
+async fn validate_game_id_rejects_empty() {
+    assert!(LichessClient::validate_game_id("").is_err());
+}
+
+#[tokio::test]
+async fn validate_game_id_rejects_non_alphanumeric() {
+    assert!(LichessClient::validate_game_id("abc!defg").is_err());
+    assert!(LichessClient::validate_game_id("abc def1").is_err());
+}
+
+#[tokio::test]
+async fn validate_game_id_rejects_wrong_length() {
+    // 7 chars
+    assert!(LichessClient::validate_game_id("abcdefg").is_err());
+    // 9 chars
+    assert!(LichessClient::validate_game_id("abcdefghi").is_err());
+}
+
+#[tokio::test]
+async fn validate_game_id_accepts_8_alphanumeric() {
+    LichessClient::validate_game_id("abcd1234").unwrap();
+    LichessClient::validate_game_id("ABCD1234").unwrap();
+}
+
+#[tokio::test]
+async fn fetch_result_maps_white_to_player1() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/game/export/abcd1234"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "winner": "white"
+        })))
+        .mount(&server)
+        .await;
+
+    let client = LichessClient::new_with_base_and_timeout(
+        server.uri(),
+        std::time::Duration::from_secs(30),
+    )
+    .unwrap();
+
+    let res = client.fetch_result("abcd1234").await.unwrap();
+    assert_eq!(res.winner, contracts_oracle::types::Winner::Player1);
+}
+
+#[tokio::test]
+async fn fetch_result_maps_black_to_player2() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/game/export/abcd5678"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "winner": "black"
+        })))
+        .mount(&server)
+        .await;
+
+    let client = LichessClient::new_with_base_and_timeout(
+        server.uri(),
+        std::time::Duration::from_secs(30),
+    )
+    .unwrap();
+
+    let res: LichessGameResult = client.fetch_result("abcd5678").await.unwrap();
+    assert_eq!(res.winner, contracts_oracle::types::Winner::Player2);
+}
+
+#[tokio::test]
+async fn fetch_result_maps_absent_winner_to_draw() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/game/export/draw1234"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({})))
+        .mount(&server)
+        .await;
+
+    let client = LichessClient::new_with_base_and_timeout(
+        server.uri(),
+        std::time::Duration::from_secs(30),
+    )
+    .unwrap();
+
+    let res = client.fetch_result("draw1234").await.unwrap();
+    assert_eq!(res.winner, contracts_oracle::types::Winner::Draw);
+}
+
+#[tokio::test]
+async fn fetch_result_404_maps_to_game_not_found() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/game/export/notfound"))
+        .respond_with(ResponseTemplate::new(404))
+        .mount(&server)
+        .await;
+
+    let client = LichessClient::new_with_base_and_timeout(
+        server.uri(),
+        std::time::Duration::from_secs(30),
+    )
+    .unwrap();
+
+    let err = client.fetch_result("notfound").await.unwrap_err();
+    assert!(matches!(err, ChessComError::GameNotFound));
+}
+
+#[tokio::test]
+async fn fetch_result_unknown_winner_errors() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/game/export/unk12345"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "winner": "unknown_value"
+        })))
+        .mount(&server)
+        .await;
+
+    let client = LichessClient::new_with_base_and_timeout(
+        server.uri(),
+        std::time::Duration::from_secs(30),
+    )
+    .unwrap();
+
+    let err = client.fetch_result("unk12345").await.unwrap_err();
+    assert!(matches!(err, ChessComError::InvalidResponse));
+}


### PR DESCRIPTION
- Add oracle-service/src/oracle/lichess_client.rs (issue #797)
  - LichessClient::fetch_result calls https://lichess.org/game/export/{id}
  - Maps winner: white->Player1, black->Player2, absent->Draw
  - Validates game ID as exactly 8 alphanumeric chars
  - Unit tests with wiremock mock HTTP server

- Add test_expire_match_emits_event in contracts/escrow/src/tests/events.rs (issue #794)
  - Asserts topic is (match, expired) and payload is match_id

- Export LichessClient/LichessGameResult from oracle/mod.rs
- closes #794 
- closes #797 

## Summary

Provide a short description of the change and the problem it fixes.

## Related Issue

Link the issue number or task this PR addresses.

## What changed
- Contracts:
- Tests:
- Docs:
- Events / API / storage:

## Verification
- What did you run to verify this change?
  - `cargo test -p escrow`
  - `cargo test -p oracle`
  - `cargo fmt`
  - `cargo clippy`

## Checklist
- [ ] I added or updated tests covering this change.
- [ ] I updated documentation or confirmed no docs update is needed.
- [ ] I confirmed any event/API/storage changes are documented and backward-compatible.
- [ ] I manually verified the contract or CLI behavior where applicable.
- [ ] I linked this PR to the related issue.
- [ ] I included notes on any TTL or storage assumptions affecting contract state.

## Notes

Add any additional details, risks, or follow-up tasks here.
