### PR TITLE
Add albedo.ts unit tests

### DIFF
--- a/docs/issue-839-albedo-unit-tests.md
+++ b/docs/issue-839-albedo-unit-tests.md
@@ -1,0 +1,66 @@
+# Add albedo.ts unit tests
+
+## Issue
+
+Issue #839: The Albedo wallet integration has no unit tests.
+
+## Acceptance Criteria
+
+1. Create `frontend/src/test/albedo.test.ts`
+2. Test `albedoIsAvailable` in browser-like environment
+3. Test `albedoGetPublicKey` returns pubkey or throws
+
+## Changes Made
+
+### Created Files
+
+- `frontend/src/test/albedo.test.ts`
+
+### Detailed Change Description
+
+Created a dedicated unit test file for the Albedo wallet adapter (`frontend/src/wallets/albedo.ts`).
+
+**Mock Setup:**
+- Mocked the `@albedo-link/intent` package using `vi.mock()` at the top level.
+- Exposed the `publicKey` method as a mock function for configuring return values and rejections.
+
+**Test 1: `test_albedo_is_available_browser`**
+- Calls `albedoIsAvailable()` directly in the jsdom test environment.
+- Asserts the function returns `true` when `window` is defined, simulating a browser-like environment.
+
+**Test 2: `test_albedo_get_public_key_success`**
+- Mocks `albedo.publicKey({})` to resolve with an object containing a fake public key (`GALBEDO...`).
+- Calls `albedoGetPublicKey()` and asserts the returned string matches the mocked pubkey.
+- Verifies the mock was called with `{}` as the argument.
+
+**Test 3: `test_albedo_get_public_key_throws`**
+- Mocks `albedo.publicKey({})` to reject with an error (`User rejected`).
+- Calls `albedoGetPublicKey()` and asserts the promise rejects with the expected error message using `rejects.toThrow()`.
+
+**Behavior Verified:**
+- `albedoIsAvailable()` correctly detects browser environments.
+- `albedoGetPublicKey()` successfully propagates the `pubkey` from the Albedo API response.
+- `albedoGetPublicKey()` properly throws when the underlying Albedo call fails.
+
+## Test Results
+
+All 3 tests pass successfully:
+
+- `test_albedo_is_available_browser`
+- `test_albedo_get_public_key_success`
+- `test_albedo_get_public_key_throws`
+
+```json
+{
+  "Test Files": 1,
+  "Tests": 3,
+  "Passed": 3,
+  "Failed": 0
+}
+```
+
+## Related
+
+- Pull Request: https://github.com/StellarCheckMate/Checkmate-Escrow/pull/923
+
+closes #839

--- a/frontend/src/test/albedo.test.ts
+++ b/frontend/src/test/albedo.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@albedo-link/intent', () => ({
+  default: {
+    publicKey: vi.fn(),
+  },
+}));
+
+import albedo from '@albedo-link/intent';
+import { albedoIsAvailable, albedoGetPublicKey } from '../wallets/albedo';
+
+const FAKE_PUBKEY = 'GALBEDO1234567890ABCDE1234567890ABCDE1234567890ABCDE1234567890';
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('albedo', () => {
+  it('test_albedo_is_available_browser', () => {
+    expect(albedoIsAvailable()).toBe(true);
+  });
+
+  it('test_albedo_get_public_key_success', async () => {
+    vi.mocked(albedo.publicKey).mockResolvedValue({ pubkey: FAKE_PUBKEY });
+    const key = await albedoGetPublicKey();
+    expect(key).toBe(FAKE_PUBKEY);
+    expect(albedo.publicKey).toHaveBeenCalledWith({});
+  });
+
+  it('test_albedo_get_public_key_throws', async () => {
+    vi.mocked(albedo.publicKey).mockRejectedValue(new Error('User rejected'));
+    await expect(albedoGetPublicKey()).rejects.toThrow('User rejected');
+  });
+});


### PR DESCRIPTION
# Summary

Adds unit tests for the Albedo wallet adapter (`albedo.ts`).

## Changes

- Created `frontend/src/test/albedo.test.ts`
- Tests `albedoIsAvailable` in browser-like environment (jsdom)
- Tests `albedoGetPublicKey` returns pubkey on success
- Tests `albedoGetPublicKey` throws on rejection

## Acceptance Criteria

- [x] Create `frontend/src/test/albedo.test.ts`
- [x] Test `albedoIsAvailable` in browser-like environment
- [x] Test `albedoGetPublicKey` returns pubkey or throws

## Files Changed

- `frontend/src/test/albedo.test.ts`

## Verification

```bash
cd frontend && npx vitest run src/test/albedo.test.ts
```

Closes #839