### PR TITLE
test(useBalance): verify 10s polling interval fires a second fetch

### DIFF
--- a/frontend/src/test/useBalance.test.ts
+++ b/frontend/src/test/useBalance.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { useBalance } from '../hooks/useBalance';
+
+const mockLoadAccount = vi.fn();
+
+vi.mock('@stellar/stellar-sdk', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@stellar/stellar-sdk')>();
+  return {
+    ...actual,
+    Horizon: {
+      ...actual.Horizon,
+      Server: vi.fn().mockImplementation(() => ({ loadAccount: mockLoadAccount })),
+    },
+  };
+});
+
+describe('useBalance', () => {
+  beforeEach(() => {
+    mockLoadAccount.mockResolvedValue({
+      balances: [{ asset_type: 'native', balance: '42.0' }],
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('test_use_balance_polls_every_10_seconds', async () => {
+    vi.useFakeTimers();
+
+    const { unmount } = renderHook(() => useBalance('GABC123'));
+
+    // Wait for the initial fetch
+    await waitFor(() => expect(mockLoadAccount).toHaveBeenCalledTimes(1));
+
+    // Advance time by 10 seconds to trigger the interval
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    expect(mockLoadAccount).toHaveBeenCalledTimes(2);
+
+    unmount();
+    vi.useRealTimers();
+  });
+});


### PR DESCRIPTION
## Summary

Provide a short description of the change and the problem it fixes.

## Related Issue

Link the issue number or task this PR addresses.

## What changed
- Contracts:
- Tests:
- Docs:
- Events / API / storage:

## Verification
- What did you run to verify this change?
  - `cargo test -p escrow`
  - `cargo test -p oracle`
  - `cargo fmt`
  - `cargo clippy`

## Checklist
- [ ] I added or updated tests covering this change.
- [ ] I updated documentation or confirmed no docs update is needed.
- [ ] I confirmed any event/API/storage changes are documented and backward-compatible.
- [ ] I manually verified the contract or CLI behavior where applicable.
- [ ] I linked this PR to the related issue.
- [ ] I included notes on any TTL or storage assumptions affecting contract state.

## Notes

Add any additional details, risks, or follow-up tasks here.
closes #834 