### PR TITLE
feat: implement event-indexer improvements (#809, #818, #815, #811)

### DIFF
--- a/docs/EVENT_INDEXER_API.md
+++ b/docs/EVENT_INDEXER_API.md
@@ -47,14 +47,20 @@ REST API (Axum)
 
 **Endpoint:** `GET /health`
 
-**Description:** Check if the service is running and healthy.
+**Description:** Check if the service is running and healthy, including a live database connectivity check.
 
-**Response:**
+**Response (healthy):**
 ```json
 {
-  "success": true,
-  "data": "Event Indexer is healthy",
-  "error": null
+  "db": "ok"
+}
+```
+
+**Response (database error):**
+```json
+{
+  "db": "error",
+  "detail": "unable to open database file"
 }
 ```
 
@@ -113,14 +119,18 @@ curl "http://localhost:8080/events?player_address=GA7QSTFKSQX4K3DWORVLKFWQIHD7DK
 
 **Endpoint:** `GET /events/:match_id`
 
-**Description:** Get all events for a specific match in chronological order.
+**Description:** Get events for a specific match in chronological order. Supports pagination.
 
 **Path Parameters:**
 - `match_id` (required): The match ID to query
 
+**Query Parameters:**
+- `limit` (optional): Maximum number of results (default: 100)
+- `offset` (optional): Pagination offset (default: 0)
+
 **Example Request:**
 ```bash
-curl "http://localhost:8080/events/1"
+curl "http://localhost:8080/events/1?limit=50&offset=100"
 ```
 
 **Response:**
@@ -161,7 +171,49 @@ curl "http://localhost:8080/events/1"
 
 ---
 
-### 4. Get Match Info
+### 4. Get Matches
+
+**Endpoint:** `GET /matches`
+
+**Description:** Get all matches, optionally filtered by status.
+
+**Query Parameters:**
+- `status` (optional): Filter by match status (`pending`, `active`, `completed`, `cancelled`, `expired`)
+
+**Example Request:**
+```bash
+curl "http://localhost:8080/matches?status=active"
+```
+
+**Response:**
+```json
+{
+  "success": true,
+  "data": [
+    {
+      "match_id": 1,
+      "player1": "GA7QSTFKSQX4K3DWORVLKFWQIHD7DKD3UD5RN7NXLKPX22FQVQY5HQW",
+      "player2": "GBBD47UZQ5SYWBZMW5XJBZPMZ5XLQNB4BBFZGHKZVKNXZX2FMGD2KVYF",
+      "status": "active",
+      "winner": null,
+      "stake_amount": "1000000",
+      "token": "CABD7H7QWXSTDZ6YPMPZRJ2FLGDWP5AYWLF5PYQRB5PQV6PDBGFPMTD",
+      "game_id": "abc12345",
+      "platform": "lichess",
+      "created_ledger": 10000,
+      "completed_ledger": 10000,
+      "events": []
+    }
+  ],
+  "error": null
+}
+```
+
+**Latency:** < 50ms
+
+---
+
+### 5. Get Match Info
 
 **Endpoint:** `GET /match/:match_id`
 
@@ -209,7 +261,7 @@ curl "http://localhost:8080/match/1"
 
 ---
 
-### 5. Get Statistics
+### 6. Get Statistics
 
 **Endpoint:** `GET /stats`
 

--- a/services/event-indexer/src/api.rs
+++ b/services/event-indexer/src/api.rs
@@ -1,10 +1,11 @@
 use axum::{
     extract::{Query, Path, State},
     http::StatusCode,
-    routing::{get, post},
+    routing::get,
     Json, Router,
 };
 use serde::{Deserialize, Serialize};
+use serde_json;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 use tracing::info;
@@ -38,6 +39,17 @@ pub struct EventQuery {
     pub offset: Option<i64>,
 }
 
+#[derive(Deserialize)]
+pub struct MatchQuery {
+    pub status: Option<String>,
+}
+
+#[derive(Deserialize)]
+pub struct PaginationQuery {
+    pub limit: Option<i64>,
+    pub offset: Option<i64>,
+}
+
 pub fn build_router(
     db: Arc<Database>,
     cache: Arc<RwLock<EventCache>>,
@@ -48,6 +60,7 @@ pub fn build_router(
         .route("/health", get(health_check))
         .route("/events", get(get_events))
         .route("/events/:match_id", get(get_match_events))
+        .route("/matches", get(get_matches))
         .route("/match/:match_id", get(get_match_info))
         .route("/stats", get(get_stats))
         .with_state(state)
@@ -71,12 +84,11 @@ pub async fn start_server(
     Ok(())
 }
 
-async fn health_check() -> Json<ApiResponse<String>> {
-    Json(ApiResponse {
-        success: true,
-        data: Some("Event Indexer is healthy".to_string()),
-        error: None,
-    })
+async fn health_check(State(state): State<AppState>) -> Json<serde_json::Value> {
+    match state.db.ping() {
+        Ok(_) => Json(serde_json::json!({"db": "ok"})),
+        Err(e) => Json(serde_json::json!({"db": "error", "detail": e.to_string()})),
+    }
 }
 
 async fn get_events(
@@ -135,23 +147,30 @@ async fn get_events(
 async fn get_match_events(
     State(state): State<AppState>,
     Path(match_id): Path<u64>,
+    Query(pagination): Query<PaginationQuery>,
 ) -> (StatusCode, Json<ApiResponse<Vec<IndexedEvent>>>) {
-    let cache_lock = state.cache.read().await;
-    let cached_events = cache_lock.get_by_match(match_id);
-    drop(cache_lock);
+    let limit = pagination.limit.unwrap_or(100);
+    let offset = pagination.offset.unwrap_or(0);
 
-    if !cached_events.is_empty() {
-        return (
-            StatusCode::OK,
-            Json(ApiResponse {
-                success: true,
-                data: Some(cached_events),
-                error: None,
-            }),
-        );
+    // Only use cache when no pagination is requested (default first page, default limit)
+    if pagination.limit.is_none() && pagination.offset.is_none() {
+        let cache_lock = state.cache.read().await;
+        let cached_events = cache_lock.get_by_match(match_id);
+        drop(cache_lock);
+
+        if !cached_events.is_empty() {
+            return (
+                StatusCode::OK,
+                Json(ApiResponse {
+                    success: true,
+                    data: Some(cached_events),
+                    error: None,
+                }),
+            );
+        }
     }
 
-    match state.db.get_events_by_match(match_id) {
+    match state.db.get_events_by_match_paginated(match_id, limit, offset) {
         Ok(events) => {
             if events.is_empty() {
                 (
@@ -173,6 +192,39 @@ async fn get_match_events(
                 )
             }
         }
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ApiResponse {
+                success: false,
+                data: None,
+                error: Some(format!("Database error: {}", e)),
+            }),
+        ),
+    }
+}
+
+async fn get_matches(
+    State(state): State<AppState>,
+    Query(query): Query<MatchQuery>,
+) -> (StatusCode, Json<ApiResponse<Vec<MatchInfo>>>) {
+    let status = query.status.as_ref().map(|s| match s.as_str() {
+        "pending" => MatchStatus::Pending,
+        "active" => MatchStatus::Active,
+        "completed" => MatchStatus::Completed,
+        "cancelled" => MatchStatus::Cancelled,
+        "expired" => MatchStatus::Expired,
+        _ => MatchStatus::Pending,
+    });
+
+    match state.db.get_matches_by_status(status.as_ref()) {
+        Ok(matches) => (
+            StatusCode::OK,
+            Json(ApiResponse {
+                success: true,
+                data: Some(matches),
+                error: None,
+            }),
+        ),
         Err(e) => (
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(ApiResponse {

--- a/services/event-indexer/src/config.rs
+++ b/services/event-indexer/src/config.rs
@@ -21,6 +21,13 @@ impl Config {
         let contract_escrow = env::var("CONTRACT_ESCROW")
             .map_err(|_| anyhow!("CONTRACT_ESCROW environment variable not set"))?;
 
+        if contract_escrow.len() != 56 || !contract_escrow.chars().all(|c| c.is_ascii_alphanumeric()) {
+            return Err(anyhow!(
+                "CONTRACT_ESCROW must be a valid 56-character Stellar contract address, got {:?}",
+                contract_escrow
+            ));
+        }
+
         let db_path = env::var("EVENT_INDEXER_DB_PATH")
             .unwrap_or_else(|_| "./events.db".to_string());
 
@@ -67,7 +74,32 @@ mod tests {
     use super::*;
 
     fn base_env() {
-        env::set_var("CONTRACT_ESCROW", "CTEST");
+        env::set_var("CONTRACT_ESCROW", "CABD7H7QWXSTDZ6YPMPZRJ2FLGDWP5AYWLF5PYQRB5PQV6PDBGFPMTD");
+    }
+
+    fn valid_contract_address() -> &'static str {
+        "CABD7H7QWXSTDZ6YPMPZRJ2FLGDWP5AYWLF5PYQRB5PQV6PDBGFPMTD"
+    }
+
+    #[test]
+    fn valid_56_char_contract_address_is_accepted() {
+        env::set_var("CONTRACT_ESCROW", valid_contract_address());
+        env::set_var("EVENT_INDEXER_POLL_INTERVAL", "5");
+        assert!(Config::from_env().is_ok());
+    }
+
+    #[test]
+    fn short_contract_address_is_rejected() {
+        env::set_var("CONTRACT_ESCROW", "CSHORT");
+        env::set_var("EVENT_INDEXER_POLL_INTERVAL", "5");
+        assert!(Config::from_env().is_err());
+    }
+
+    #[test]
+    fn empty_contract_address_is_rejected() {
+        env::set_var("CONTRACT_ESCROW", "");
+        env::set_var("EVENT_INDEXER_POLL_INTERVAL", "5");
+        assert!(Config::from_env().is_err());
     }
 
     #[test]

--- a/services/event-indexer/src/db.rs
+++ b/services/event-indexer/src/db.rs
@@ -193,6 +193,84 @@ impl Database {
         Ok(result)
     }
 
+    pub fn get_events_by_match_paginated(&self, match_id: u64, limit: i64, offset: i64) -> Result<Vec<IndexedEvent>> {
+        let conn = self.conn.lock().unwrap();
+
+        let mut stmt = conn.prepare(
+            "SELECT id, ledger_sequence, match_id, event_type, player1, player2, status,
+                    winner, stake_amount, token, game_id, platform, timestamp, txn_hash
+             FROM events WHERE match_id = ? ORDER BY ledger_sequence ASC LIMIT ? OFFSET ?"
+        )?;
+
+        let events = stmt.query_map(params![match_id, limit, offset], |row| {
+            Ok(IndexedEvent {
+                id: row.get(0)?,
+                ledger_sequence: row.get(1)?,
+                match_id: row.get(2)?,
+                event_type: row.get(3)?,
+                player1: row.get(4)?,
+                player2: row.get(5)?,
+                status: row.get(6)?,
+                winner: row.get(7)?,
+                stake_amount: row.get(8)?,
+                token: row.get(9)?,
+                game_id: row.get(10)?,
+                platform: row.get(11)?,
+                timestamp: DateTime::parse_from_rfc3339(&row.get::<_, String>(12)?)
+                    .map(|dt| dt.with_timezone(&Utc))
+                    .unwrap_or_else(|_| Utc::now()),
+                txn_hash: row.get(13)?,
+            })
+        })?;
+
+        let mut result = Vec::new();
+        for event in events {
+            result.push(event?);
+        }
+        Ok(result)
+    }
+
+    pub fn get_matches_by_status(&self, status: Option<&MatchStatus>) -> Result<Vec<MatchInfo>> {
+        let match_ids: Vec<u64> = {
+            let conn = self.conn.lock().unwrap();
+            let (query, param): (&str, Option<&str>) = match status {
+                Some(s) => (
+                    "SELECT DISTINCT match_id FROM events WHERE status = ?",
+                    Some(match s {
+                        MatchStatus::Pending => "pending",
+                        MatchStatus::Active => "active",
+                        MatchStatus::Completed => "completed",
+                        MatchStatus::Cancelled => "cancelled",
+                        MatchStatus::Expired => "expired",
+                    }),
+                ),
+                None => ("SELECT DISTINCT match_id FROM events", None),
+            };
+
+            let mut stmt = conn.prepare(query)?;
+            let ids: Vec<u64> = if let Some(p) = param {
+                stmt.query_map(params![p], |row| row.get(0))?.filter_map(|r| r.ok()).collect()
+            } else {
+                stmt.query_map([], |row| row.get(0))?.filter_map(|r| r.ok()).collect()
+            };
+            ids
+        };
+
+        let mut matches = Vec::new();
+        for id in match_ids {
+            if let Some(info) = self.build_match_info(id)? {
+                matches.push(info);
+            }
+        }
+        Ok(matches)
+    }
+
+    pub fn ping(&self) -> Result<()> {
+        let conn = self.conn.lock().unwrap();
+        conn.query_row("SELECT 1", [], |_| Ok(()))?;
+        Ok(())
+    }
+
     pub fn total_event_count(&self) -> Result<i64> {
         let conn = self.conn.lock().unwrap();
         let count = conn.query_row("SELECT COUNT(*) FROM events", [], |row| row.get(0))?;


### PR DESCRIPTION
Closes #809 : Add GET /matches?status= endpoint filtered at DB layer
Closes #818 : Add limit/offset pagination to GET /events/:match_id (default 100)
Closes #815 : Validate CONTRACT_ESCROW is a valid 56-char Stellar address on startup
Closes #811 : Add DB ping (SELECT 1) to GET /health, return {db: ok/error}
- Update docs/EVENT_INDEXER_API.md with new response schemas

## Summary

Provide a short description of the change and the problem it fixes.

## Related Issue

Link the issue number or task this PR addresses.

## What changed
- Contracts:
- Tests:
- Docs:
- Events / API / storage:

## Verification
- What did you run to verify this change?
  - `cargo test -p escrow`
  - `cargo test -p oracle`
  - `cargo fmt`
  - `cargo clippy`

## Checklist
- [ ] I added or updated tests covering this change.
- [ ] I updated documentation or confirmed no docs update is needed.
- [ ] I confirmed any event/API/storage changes are documented and backward-compatible.
- [ ] I manually verified the contract or CLI behavior where applicable.
- [ ] I linked this PR to the related issue.
- [ ] I included notes on any TTL or storage assumptions affecting contract state.

## Notes

Add any additional details, risks, or follow-up tasks here.
