### PR TITLE
fix: add Vite dev proxy for /api to resolve CORS errors in local development

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,4 +1,46 @@
-# React + TypeScript + Vite
+# Checkmate-Escrow Frontend
+
+React + TypeScript + Vite frontend for the Checkmate-Escrow platform.
+
+## Local Development
+
+### Prerequisites
+
+- Node.js 18+
+- npm
+
+### Setup
+
+```bash
+cd frontend
+npm install
+```
+
+### Running the dev server
+
+```bash
+npm run dev
+```
+
+The dev server starts on `http://localhost:5173` by default.
+
+#### API proxy (CORS)
+
+During local development, requests to `/api` are automatically proxied to the event-indexer at `http://localhost:8080`, avoiding CORS errors. Start the event-indexer on port 8080 before running the frontend.
+
+### Running tests
+
+```bash
+npm test
+```
+
+### Building for production
+
+```bash
+npm run build
+```
+
+---
 
 This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
 

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -5,6 +5,11 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    proxy: {
+      '/api': 'http://localhost:8080',
+    },
+  },
   test: {
     environment: 'jsdom',
     globals: true,


### PR DESCRIPTION
## Summary

During local development the frontend and the event-indexer run on different ports, causing CORS errors when the frontend calls `/api` endpoints.

### Changes

- **`frontend/vite.config.ts`** — adds a `server.proxy` entry that transparently forwards every `/api` request to `http://localhost:8080` (the event-indexer) while the Vite dev server is running.
- **`frontend/README.md`** — replaces the generic Vite template README with project-specific local development instructions, including how to start the dev server and an explanation of the API proxy.

### Testing

Start the event-indexer on port 8080, then run `npm run dev` in the `frontend/` directory. Requests to `/api` are proxied without CORS errors.

Closes #841
Closes #842
Closes #843
Closes #844