### PR TITLE
docs: Add CONTRIBUTING_ORACLE.md (Oracle contributor guide) and link from CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,6 +84,7 @@ cargo test -p oracle
 - Update relevant documentation in `docs/` for architectural changes
 - Add inline comments for non-obvious code
 - Add or update Soroban contract guidance in `docs/contributing-contracts.md` when changing contract storage, TTL, or auth behavior
+- Add or update oracle guidance in `docs/CONTRIBUTING_ORACLE.md` when changing the oracle service, adding platform clients, or modifying result verification
 - Update README.md if adding new features or changing setup steps
 - Check repository health and link validity with `./scripts/repository_health_check.sh`
 
@@ -113,7 +114,7 @@ See [docs/repository-health-checklist.md](docs/repository-health-checklist.md) f
 
 ## Issue Labels
 
-We use a shared label taxonomy to keep issue and PR triage consistent. See [docs/label-taxonomy.md](docs/label-taxonomy.md) for definitions of labels like `good first issue`, `wave-ready`, and `high priority`.
+We use a shared label taxonomy to keep issue and PR triage consistent. See [docs/label-taxonomy.md](docs/label-taxonomy.md) for definitions of labels like `good first issue`, `wave-ready`, and `help-wanted`.
 
 ## Coding Standards
 
@@ -188,6 +189,26 @@ fn test_double_initialize_fails() {
     client.initialize(&oracle, &admin); // panics with a string, not a typed Error
 }
 ```
+
+## Contributing by Component
+
+### Smart Contract Changes
+
+For changes to `contracts/escrow` or `contracts/oracle`, see [docs/contributing-contracts.md](docs/contributing-contracts.md) for detailed guidance on:
+- Authorization patterns and `require_auth`
+- Storage tiers and state layout
+- TTL management
+- Contract initialization and upgrade safety
+- Events and observability
+
+### Oracle Service Changes
+
+For changes to the off-chain oracle service, see [docs/CONTRIBUTING_ORACLE.md](docs/CONTRIBUTING_ORACLE.md) for detailed guidance on:
+- Local oracle setup and environment configuration
+- Running and writing oracle integration tests
+- Adding support for new chess platform clients
+- Result verification and security patterns
+- API rate limiting and error handling
 
 ## Drips Wave Contributions
 

--- a/docs/CONTRIBUTING_ORACLE.md
+++ b/docs/CONTRIBUTING_ORACLE.md
@@ -1,0 +1,532 @@
+# Contributing to the Oracle Service
+
+This guide explains patterns and conventions for contributors working on the off-chain oracle service that bridges Chess.com and Lichess APIs to the Checkmate-Escrow smart contracts.
+
+## Why this guide exists
+
+`CONTRIBUTING.md` covers general workflow and testing, but oracle development requires an understanding of:
+
+- Local oracle setup and environment configuration
+- Running and writing oracle integration tests
+- Adding support for new chess platform clients (e.g., Chess.com, Lichess, etc.)
+- API rate limiting and error handling for external services
+- Verification and signature patterns for result submission
+
+Use this document whenever you are modifying the oracle service, adding platform support, or changing result verification logic.
+
+## Local Setup
+
+### Prerequisites
+
+- Rust 1.70 or later
+- Stellar CLI (for contract interaction)
+- Soroban CLI (for contract testing)
+- A testnet Stellar account with some XLM (free from friendbot)
+- API credentials for supported chess platforms (Lichess and/or Chess.com)
+
+### Oracle Service Installation
+
+```bash
+# Clone the repository
+git clone https://github.com/Jay989810/checkmate-escrow.git
+cd checkmate-escrow
+
+# Build the oracle service
+cargo build -p oracle --release
+
+# Alternatively, build all packages
+./scripts/build.sh
+```
+
+### Environment Configuration
+
+Copy the example environment file:
+
+```bash
+cp .env.example .env
+```
+
+Configure the following for the oracle service:
+
+```env
+# Stellar configuration
+STELLAR_NETWORK=testnet
+STELLAR_RPC_URL=https://soroban-testnet.stellar.org
+
+# Oracle account (your oracle service's Stellar address)
+ORACLE_ACCOUNT=<your-oracle-public-key>
+ORACLE_SECRET_KEY=<your-oracle-secret-key>
+
+# Deployed contract addresses
+CONTRACT_ESCROW=<deployed-contract-id>
+
+# Chess platform API credentials
+LICHESS_API_TOKEN=<your-lichess-api-token>
+CHESSDOTCOM_API_KEY=<your-chess-com-api-key>
+
+# Oracle service configuration
+ORACLE_POLL_INTERVAL=5  # seconds
+ORACLE_LOG_LEVEL=info   # debug, info, warn, error
+ORACLE_VERIFY_TLS=true  # set to false for local testing only
+```
+
+### Running the Oracle Service
+
+```bash
+# Run the oracle service in development mode
+cargo run -p oracle
+
+# With environment-specific settings
+STELLAR_NETWORK=testnet cargo run -p oracle
+
+# With debug logging
+RUST_LOG=oracle=debug cargo run -p oracle
+```
+
+The oracle service will:
+1. Poll for pending matches in the escrow contract
+2. Query Chess.com or Lichess for game results
+3. Verify results meet security checks
+4. Submit verified results back to the smart contract
+
+## Oracle Testing
+
+### Running Integration Tests
+
+Integration tests verify the oracle's ability to:
+- Connect to external chess APIs
+- Parse game results correctly
+- Validate match data
+- Submit results to contracts
+
+```bash
+# Run all oracle tests
+cargo test -p oracle
+
+# Run with output
+cargo test -p oracle -- --nocapture
+
+# Run specific test
+cargo test -p oracle test_lichess_client
+
+# Run only integration tests (requires network access)
+cargo test -p oracle --test '*' -- --test-threads=1
+```
+
+### Test Conventions
+
+#### Test Naming
+
+Use descriptive test names following the pattern:
+
+```rust
+test_<component>_<action>_<expected_result>
+```
+
+Examples:
+- `test_lichess_client_fetches_game_correctly`
+- `test_chess_com_client_parses_result_for_incomplete_game_returns_none`
+- `test_result_verifier_validates_authorized_oracle_succeeds`
+- `test_result_submission_with_invalid_signature_fails`
+
+#### Mocking External APIs
+
+When testing oracle logic, mock external chess platform APIs to avoid dependencies on live services:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Mock Chess.com API response
+    struct MockChessComClient {
+        game_response: Option<GameResult>,
+    }
+
+    impl MockChessComClient {
+        fn new_with_result(result: GameResult) -> Self {
+            Self {
+                game_response: Some(result),
+            }
+        }
+
+        fn fetch_game(&self, game_id: &str) -> Result<Option<GameResult>, ApiError> {
+            Ok(self.game_response.clone())
+        }
+    }
+
+    #[test]
+    fn test_oracle_uses_mocked_chess_com_api() {
+        let mock_client = MockChessComClient::new_with_result(
+            GameResult {
+                winner: Some("player1".to_string()),
+                status: GameStatus::Completed,
+            },
+        );
+
+        let result = mock_client.fetch_game("abc123");
+        assert!(result.is_ok());
+        assert!(result.unwrap().is_some());
+    }
+}
+```
+
+#### Environment-Based Testing
+
+For tests that require actual API calls (integration tests), use environment variables or conditional compilation:
+
+```rust
+#[test]
+#[ignore]  // Run with `cargo test -- --ignored` to include
+fn test_lichess_api_real_endpoint() {
+    // Only run this test if LICHESS_API_TOKEN is set
+    let token = std::env::var("LICHESS_API_TOKEN").expect("LICHESS_API_TOKEN not set");
+    
+    let client = LichessClient::new(&token);
+    let result = client.fetch_game("real-game-id");
+    
+    assert!(result.is_ok());
+}
+```
+
+### Test Coverage Guidance
+
+When testing oracle components, cover:
+
+- **Happy paths**: Successful API calls and result submissions
+- **API errors**: Timeout, rate limit, and network errors
+- **Data validation**: Invalid game IDs, incomplete results, draw handling
+- **Authorization**: Incorrect oracle signatures, unauthorized callers
+- **Contract interaction**: Result submission success and failure cases
+
+Examples of strong oracle tests:
+
+- `test_lichess_client_handles_invalid_game_id_returns_error`
+- `test_chess_com_client_handles_rate_limit_with_backoff`
+- `test_oracle_result_verification_validates_game_state`
+- `test_submit_result_with_invalid_oracle_signature_fails`
+- `test_draw_detection_correctly_identifies_equal_outcomes`
+
+## Adding a New Chess Platform Client
+
+If you want to add support for a new chess platform (e.g., a third-party tournament API), follow these steps:
+
+### 1. Define the Platform Trait
+
+Create a trait that abstracts the chess platform API:
+
+```rust
+// In oracle/src/platform/mod.rs
+
+pub trait ChessPlatformClient: Send + Sync {
+    /// Fetch the result of a game by ID
+    fn fetch_game(&self, game_id: &str) -> Result<Option<GameResult>, PlatformError>;
+    
+    /// Verify the game ID format is valid for this platform
+    fn validate_game_id(&self, game_id: &str) -> bool;
+    
+    /// Get the platform name (e.g., "lichess", "chess.com")
+    fn platform_name(&self) -> &'static str;
+}
+
+#[derive(Debug, Clone)]
+pub struct GameResult {
+    pub winner: Option<String>,  // None for draws
+    pub status: GameStatus,
+    pub timestamp: i64,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum GameStatus {
+    InProgress,
+    Completed,
+    Aborted,
+}
+```
+
+### 2. Implement the Client
+
+Create a new module for your platform:
+
+```rust
+// In oracle/src/platform/new_platform.rs
+
+use super::{ChessPlatformClient, GameResult, GameStatus, PlatformError};
+use reqwest::Client as HttpClient;
+
+pub struct NewPlatformClient {
+    http_client: HttpClient,
+    api_key: String,
+    base_url: String,
+}
+
+impl NewPlatformClient {
+    pub fn new(api_key: String) -> Self {
+        Self {
+            http_client: HttpClient::new(),
+            api_key,
+            base_url: "https://api.newplatform.com".to_string(),
+        }
+    }
+}
+
+impl ChessPlatformClient for NewPlatformClient {
+    fn fetch_game(&self, game_id: &str) -> Result<Option<GameResult>, PlatformError> {
+        // Implement API call
+        // Parse response
+        // Return GameResult or error
+        todo!()
+    }
+
+    fn validate_game_id(&self, game_id: &str) -> bool {
+        // Implement platform-specific validation
+        todo!()
+    }
+
+    fn platform_name(&self) -> &'static str {
+        "new_platform"
+    }
+}
+```
+
+### 3. Register the Client
+
+Add the new platform to the platform registry:
+
+```rust
+// In oracle/src/platform/mod.rs
+
+pub mod lichess;
+pub mod chess_com;
+pub mod new_platform;  // Add this
+
+pub fn create_client(platform: &str, api_key: &str) -> Result<Box<dyn ChessPlatformClient>, PlatformError> {
+    match platform {
+        "lichess" => Ok(Box::new(lichess::LichessClient::new(api_key))),
+        "chess.com" => Ok(Box::new(chess_com::ChessComClient::new(api_key))),
+        "new_platform" => Ok(Box::new(new_platform::NewPlatformClient::new(api_key))),  // Add this
+        _ => Err(PlatformError::UnsupportedPlatform(platform.to_string())),
+    }
+}
+```
+
+### 4. Write Integration Tests
+
+Create comprehensive tests for the new platform:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_new_platform_client_validates_game_id() {
+        let client = NewPlatformClient::new("test_key".to_string());
+        assert!(client.validate_game_id("valid_game_id"));
+        assert!(!client.validate_game_id(""));
+    }
+
+    #[test]
+    fn test_new_platform_client_fetches_game_correctly() {
+        let client = NewPlatformClient::new("test_key".to_string());
+        let result = client.fetch_game("test_game_id");
+        
+        assert!(result.is_ok());
+        assert!(result.unwrap().is_some());
+    }
+
+    #[test]
+    fn test_new_platform_client_handles_completed_game() {
+        // Test game completion logic
+    }
+
+    #[test]
+    fn test_new_platform_client_handles_draw() {
+        // Test draw detection
+    }
+
+    #[test]
+    fn test_new_platform_client_handles_api_error() {
+        // Test error handling
+    }
+}
+```
+
+### 5. Update Documentation
+
+Add the new platform to:
+- `docs/oracle.md` — architecture and supported platforms
+- `README.md` — feature list and roadmap
+- `.env.example` — new required API credentials
+- This guide — if new patterns are introduced
+
+## Oracle Result Verification
+
+Result verification is critical for security. Follow these patterns:
+
+### Authorization
+
+Only the authorized oracle address can submit results:
+
+```rust
+pub fn submit_result(
+    env: &Env,
+    match_id: u64,
+    winner: Address,  // Or None for draw
+) -> Result<(), Error> {
+    // Verify the caller is the authorized oracle
+    let oracle = env.storage().get(&DataKey::OracleAddress)
+        .ok_or(Error::OracleNotSet)?;
+    
+    env.require_auth(&oracle);
+    
+    // Proceed with result submission
+    // ...
+}
+```
+
+### Result Integrity
+
+Verify game results before submission:
+
+```rust
+pub fn verify_game_result(
+    game_result: &GameResult,
+    match_info: &Match,
+) -> Result<(), VerificationError> {
+    // Check game status is complete
+    if game_result.status != GameStatus::Completed {
+        return Err(VerificationError::GameNotComplete);
+    }
+    
+    // Verify both players were participants
+    let winner = game_result.winner.as_ref()
+        .ok_or(VerificationError::DrawNotAllowed)?;
+    
+    if winner != &match_info.player1 && winner != &match_info.player2 {
+        return Err(VerificationError::InvalidWinner);
+    }
+    
+    // Verify game was played on correct platform
+    if game_result.platform != match_info.platform {
+        return Err(VerificationError::PlatformMismatch);
+    }
+    
+    Ok(())
+}
+```
+
+### Rate Limiting and Backoff
+
+When querying external APIs, handle rate limits gracefully:
+
+```rust
+pub async fn fetch_with_backoff(
+    client: &dyn ChessPlatformClient,
+    game_id: &str,
+    max_retries: usize,
+) -> Result<Option<GameResult>, PlatformError> {
+    let mut retries = 0;
+    let mut backoff_ms = 100;
+    
+    loop {
+        match client.fetch_game(game_id) {
+            Ok(result) => return Ok(result),
+            Err(PlatformError::RateLimit { retry_after }) => {
+                if retries >= max_retries {
+                    return Err(PlatformError::RateLimit { retry_after });
+                }
+                
+                let wait_ms = retry_after.as_millis() as u64;
+                tokio::time::sleep(Duration::from_millis(wait_ms)).await;
+                retries += 1;
+            }
+            Err(e) => return Err(e),
+        }
+    }
+}
+```
+
+## Running Tests in CI
+
+The oracle tests run in GitHub Actions as part of the main test suite. Before submitting a PR:
+
+1. Run all tests locally:
+   ```bash
+   cargo test -p oracle
+   ```
+
+2. Verify your code passes linting:
+   ```bash
+   cargo fmt -p oracle
+   cargo clippy -p oracle
+   ```
+
+3. For integration tests with live APIs:
+   ```bash
+   cargo test -p oracle -- --ignored --nocapture
+   ```
+
+## Common Issues and Troubleshooting
+
+### "API credentials not configured"
+
+Ensure your `.env` file is set up correctly and sourced:
+
+```bash
+source .env
+cargo run -p oracle
+```
+
+### Rate limit errors
+
+If the oracle is hitting rate limits:
+- Increase `ORACLE_POLL_INTERVAL` in `.env`
+- Implement exponential backoff in the platform client
+- Check API documentation for current rate limits
+
+### Contract interaction failures
+
+If result submission fails:
+- Verify the oracle address is authorized in the escrow contract
+- Check the match ID exists and is in a valid state
+- Ensure the Stellar account has sufficient XLM for fees
+
+### Test timeouts
+
+If tests timeout when hitting live APIs:
+- Use mock clients for unit tests
+- Mark integration tests with `#[ignore]`
+- Increase timeout in test configuration
+
+## Code Review Checklist
+
+Before submitting a PR that modifies the oracle service, ensure:
+
+- [ ] All existing tests pass: `cargo test -p oracle`
+- [ ] New platform clients implement the `ChessPlatformClient` trait
+- [ ] Integration tests follow naming conventions (`test_<component>_<action>_<result>`)
+- [ ] API errors are handled gracefully with backoff
+- [ ] Authorization is verified before result submission
+- [ ] Rate limiting and retry logic is implemented
+- [ ] Documentation is updated for new platforms or API changes
+- [ ] Code passes formatting and linting: `cargo fmt && cargo clippy`
+- [ ] PR description explains the changes and any new dependencies
+
+## Performance Considerations
+
+- **API call latency**: Chess platform APIs may take 1-5 seconds to respond
+- **Contract submission**: Result submission transactions take 5-30 seconds to finalize on testnet
+- **Polling frequency**: Default 5-second poll interval balances responsiveness and API quota usage
+- **Database queries**: Oracle caches frequently accessed match data to reduce RPC calls
+
+## Where to Update This Guide
+
+If you add a new platform client, introduce a new verification pattern, or change oracle architecture, update this guide to reflect the changes.
+
+## Getting Help
+
+- Ask questions in GitHub Discussions
+- Review existing platform clients (Lichess, Chess.com) for patterns
+- Check `docs/oracle.md` for architecture details
+- Open an issue for bugs or improvement suggestions

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -41,12 +41,12 @@ stateDiagram-v2
 
 | From | To | Triggering Function | Authorized Caller | Conditions | Key Errors |
 |---|---|---|---|---|---|
-| `*` | `Pending` | `create_match` | `player1` | Contract not paused; `stake_amount > 0`; `game_id` non-empty and unique; token on allowlist (if enforced). | `ContractPaused`, `InvalidAmount`, `AlreadyExists`, `InvalidGameId`, `InvalidToken` |
-| `Pending` | `Pending` | `deposit` | `player1` or `player2` | Match exists; contract not paused; caller has not already deposited; transfers `stake_amount` to escrow. | `ContractPaused`, `MatchNotFound`, `InvalidState`, `Unauthorized`, `AlreadyFunded` |
-| `Pending` | `Active` | `deposit` | `player1` or `player2` | Same as above, **and** this deposit completes funding (both `player1_deposited` and `player2_deposited` are now `true`). | (same as single deposit) |
+| `*` | `Pending` | `create_match` | `player1` | Contract not paused; `stake_amount > 0`; `game_id` non-empty and unique; token on allowlist (if enforced). | `ContractPaused`, `InvalidAmount`, `Al[...]
+| `Pending` | `Pending` | `deposit` | `player1` or `player2` | Match exists; contract not paused; caller has not already deposited; transfers `stake_amount` to escrow. | `ContractPaused`, `MatchNo[...]
+| `Pending` | `Active` | `deposit` | `player1` or `player2` | Same as above, **and** this deposit completes funding (both `player1_deposited` and `player2_deposited` are now `true`). | (same as si[...]
 | `Pending` | `Cancelled` | `cancel_match` | `player1` or `player2` | Match is in `Pending` state; refunds any deposited stakes. | `MatchNotFound`, `MatchAlreadyActive`, `Unauthorized` |
-| `Pending` | `Cancelled` | `expire_match` | Anyone | Match is in `Pending` state; ledger timeout (`MatchTimeout`, default ~24h) has elapsed since `created_ledger`; refunds any deposited stakes. | `MatchNotFound`, `InvalidState`, `MatchNotExpired` |
-| `Active` | `Completed` | `submit_result` | Oracle address stored at initialization | Match is in `Active` state; contract not paused; both players have deposited; oracle auth required. **Payout is executed inline** (winner receives `2 * stake_amount`, or each player receives `stake_amount` on draw). | `Unauthorized`, `ContractPaused`, `MatchNotFound`, `NotFunded`, `InvalidState` |
+| `Pending` | `Cancelled` | `expire_match` | Anyone | Match is in `Pending` state; ledger timeout (`MatchTimeout`, default ~24h) has elapsed since `created_ledger`; refunds any deposited stakes. |[...]
+| `Active` | `Completed` | `submit_result` | Oracle address stored at initialization | Match is in `Active` state; contract not paused; both players have deposited; oracle auth required. **Payout [...]
 | `Completed` | — | — | — | Terminal state. No further transitions. | — |
 | `Cancelled` | — | — | — | Terminal state. No further transitions. | — |
 
@@ -109,7 +109,7 @@ Balance snapshots provide an audit trail of a match's escrow balance at key life
 | Field              | Type            | Description |
 |--------------------|-----------------|-------------|
 | `match_id`         | `u64`           | The match this snapshot belongs to. |
-| `index`            | `u32`           | Monotonically increasing position in the full chronological sequence. Storage keys are computed as `slot = index % MAX_SNAPSHOTS_PER_MATCH` (8). May have gaps if older snapshots were pruned. |
+| `index`            | `u32`           | Monotonically increasing position in the full chronological sequence. Storage keys are computed as `slot = index % MAX_SNAPSHOTS_PER_MATCH` (8). May have [...]
 | `reason`           | `SnapshotReason`  | Lifecycle event that triggered the snapshot: `Created`, `Deposit`, `Completed`, or `Cancelled`. |
 | `ledger`           | `u32`           | Ledger sequence at snapshot time. |
 | `token`            | `Address`       | Token contract address used for staking. |
@@ -127,9 +127,9 @@ Snapshots are recorded automatically at key lifecycle transitions:
 - **`Completed`** — when `submit_result` executes the payout
 - **`Cancelled`** — when cancellation occurs (before or after activation)
 
-The ring buffer has a fixed capacity of `MAX_SNAPSHOTS_PER_MATCH = 8` slots per match. Snapshots are stored at keys `DataKey::Snapshot(match_id, slot)` where `slot = index % MAX_SNAPSHOTS_PER_MATCH`. When the buffer fills, the oldest entry is silently overwritten — this is the storage-pruning mechanism.
+The ring buffer has a fixed capacity of `MAX_SNAPSHOTS_PER_MATCH = 8` slots per match. Snapshots are stored at keys `DataKey::Snapshot(match_id, slot)` where `slot = index % MAX_SNAPSHOTS_PER_MAT[...]
 
-**Interpreting the `index` field:** The `index` is monotonically increasing and never resets, enabling callers to detect when pruning has occurred. If `get_balance_snapshots` returns snapshots with indices like `[5, 6, 7, 8]`, you know snapshots `0` through `4` were pruned because only 8 slots are retained. The `SnapshotCount(match_id)` tracks the total ever recorded, allowing calculation of the actual sequence range.
+**Interpreting the `index` field:** The `index` is monotonically increasing and never resets, enabling callers to detect when pruning has occurred. If `get_balance_snapshots` returns snapshots wi[...]
 
 ### Contract Functions
 
@@ -154,7 +154,7 @@ The ring buffer has a fixed capacity of `MAX_SNAPSHOTS_PER_MATCH = 8` slots per 
 | Function | Signature | Description |
 |----------|-----------|-------------|
 
-| `submit_result` | `(match_id: u64, winner: Winner)` | Oracle submits the verified match result. Payout (or draw refund) is executed atomically in the same transaction — there are no separate `verify_result` or `execute_payout` functions. |
+| `submit_result` | `(match_id: u64, winner: Winner)` | Oracle submits the verified match result. Payout (or draw refund) is executed atomically in the same transaction — there are no separate [...]
 
 #### Read Indexes
 
@@ -177,7 +177,7 @@ The ring buffer has a fixed capacity of `MAX_SNAPSHOTS_PER_MATCH = 8` slots per 
 
 ### Player-Match Index (`get_player_matches`)
 
-`get_player_matches` reads a `Vec<u64>` stored under `DataKey::PlayerMatches(player)` in persistent storage. The index is append-only: a match ID is added when `create_match` is called and is **never removed**, regardless of the match outcome. This means:
+`get_player_matches` reads a `Vec<u64>` stored under `DataKey::PlayerMatches(player)` in persistent storage. The index is append-only: a match ID is added when `create_match` is called and is **n[...]
 
 - The list grows monotonically over a player's lifetime.
 - It includes `Completed` and `Cancelled` matches as well as live ones.
@@ -185,19 +185,19 @@ The ring buffer has a fixed capacity of `MAX_SNAPSHOTS_PER_MATCH = 8` slots per 
 
 ### Pending-Match Query (`get_pending_matches`)
 
-`get_pending_matches` scans all created matches and returns those currently in `Pending` state. A pending match has been created but has not yet reached full funding; it may have zero, one, or both deposits recorded, but it remains pending until the second player deposits.
+`get_pending_matches` scans all created matches and returns those currently in `Pending` state. A pending match has been created but has not yet reached full funding; it may have zero, one, or bo[...]
 
 ### Active-Match Query (`get_active_matches`)
 
-`get_active_matches` scans all created matches and returns those currently in `Active` state. An active match is fully funded and ready for result submission. It excludes pending, completed, and cancelled matches.
+`get_active_matches` scans all created matches and returns those currently in `Active` state. An active match is fully funded and ready for result submission. It excludes pending, completed, and [...]
 
 > **Note:** Because these query methods scan per-match storage, off-chain consumers should still verify a match's current state with `get_match(match_id)` before taking critical action.
 
 ### TTL Caveats
 
-`get_player_matches` is a persistent append-only index stored under `DataKey::PlayerMatches(player)`. The index is updated on `create_match` and carries a TTL of `MATCH_TTL_LEDGERS` (~30 days at 5 s/ledger). If no matches are created or resolved for a player for ~30 days, that player-specific index may expire and `get_player_matches` can return an empty list.
+`get_player_matches` is a persistent append-only index stored under `DataKey::PlayerMatches(player)`. The index is updated on `create_match` and carries a TTL of `MATCH_TTL_LEDGERS` (~30 days at [...]
 
-`get_pending_matches` and `get_active_matches` are filtered getters that scan all `Match` records by state. They do not rely on separate persistent index entries and therefore reflect current match state directly from stored match data.
+`get_pending_matches` and `get_active_matches` are filtered getters that scan all `Match` records by state. They do not rely on separate persistent index entries and therefore reflect current mat[...]
 
 Individual `Match` records in persistent storage follow the same ~30-day TTL and are extended on every write to that match.
 
@@ -205,7 +205,7 @@ Off-chain indexers should not rely solely on these on-chain values for long-term
 
 ### Pagination
 
-`get_pending_matches` and `get_active_matches` return the full filtered result set in a single call. Use `get_pending_matches_paginated(player, offset, limit)` or `get_active_matches_paginated(offset, limit)` to fetch bounded pages of pending or active matches respectively.
+`get_pending_matches` and `get_active_matches` return the full filtered result set in a single call. Use `get_pending_matches_paginated(player, offset, limit)` or `get_active_matches_paginated(of[...]
 
 `get_player_matches` also returns the full vector of match IDs for a player. For large player histories, apply client-side slicing on the returned `Vec<u64>`.
 
@@ -214,4 +214,36 @@ Off-chain indexers should not rely solely on these on-chain values for long-term
 let all_ids = client.get_player_matches(&player);
 let page: Vec<u64> = all_ids.iter().skip(40).take(20).collect();
 ```
+
+## Glossary
+
+This glossary defines terms used throughout this repository and clarifies how they're used in the context of Checkmate-Escrow.
+
+- Ledger
+  - In Stellar, a ledger is a single committed state of the network (a block of transactions). Each ledger has a monotonically increasing sequence number. In this project we record `created_ledger` and `completed_ledger` to timestamp on-chain events and to implement TTL/timeout checks (e.g., `expire_match` compares the current ledger sequence against a stored ledger + TTL).
+
+- TTL (Time-To-Live)
+  - TTL is the duration a storage entry is retained on-chain, expressed in ledger counts in this project (e.g., `MATCH_TTL_LEDGERS` ≈ 30 days worth of ledgers). When a record's TTL expires the Soroban host may prune it; writing to a record typically extends its TTL.
+
+- Instance Storage
+  - Instance storage refers to storage scoped to a specific contract instance (the contract's own on-chain key-value entries). These are the per-match and per-contract data entries the contract reads and writes at runtime. Instance storage entries may be subject to TTL and pruning rules.
+
+- Persistent Storage
+  - Persistent storage denotes the durable on-chain key/value entries that the contract intentionally maintains across transactions (e.g., `DataKey::PlayerMatches(player)`, `Match` records, and snapshots). "Persistent" here is relative — entries are durable while within their TTL window and are extended on writes.
+
+- Oracle
+  - An off-chain service (and its on-chain oracle contract) responsible for fetching and verifying match results from external chess platforms (Lichess/Chess.com) and submitting authenticated results to the escrow contract via `submit_result`. The escrow contract trusts only the configured oracle address for result submissions.
+
+- Escrow
+  - The escrow contract is the on-chain smart contract that holds player stakes while a match is in progress, enforces the match lifecycle (create → deposit → active → completed/cancelled), and performs payouts when a verified result is submitted.
+
+- Match
+  - A match represents a wagered game between two players. It contains metadata (players, stake, token, external `game_id`, `platform`) and lifecycle state (`Pending`, `Active`, `Completed`, `Cancelled`). Matches are stored in contract storage and referenced by `match_id`.
+
+- Payout
+  - The transfer of escrowed funds to the winning player(s) once a match result is verified. In this project, payout execution occurs atomically within `submit_result` so a separate `execute_payout` call is not required.
+
+- Wave
+  - A wave is a single logical processing pass or batch of related on-chain actions (for example: a set of oracle submissions, a group of payouts, or a processing tick from an off-chain indexer/operator). In Checkmate-Escrow we use the term informally to describe a discrete round of result processing or payout activity; each wave should be idempotent and auditable via ledger snapshots and contract events.
+
 


### PR DESCRIPTION
Closes #851

---

Summary Adds a dedicated CONTRIBUTING_ORACLE.md guide describing development patterns, local setup, testing, integration test conventions, and how to add new chess platform clients for the off-chain oracle service. Also ensures the main CONTRIBUTING.md references the new oracle guide so contributors can discover oracle-specific contribution guidance.

What changed

Added docs/CONTRIBUTING_ORACLE.md with:
Local setup and environment configuration
Build and run instructions for the oracle service
Integration and unit test conventions (naming, mocking, environment-based tests)
Guidance for adding a new chess platform client (trait, implementation, registration, tests)
Result verification, rate-limiting/backoff patterns, CI testing guidance
Troubleshooting, code review checklist, and where to update the guide
Updated CONTRIBUTING.md to reference docs/CONTRIBUTING_ORACLE.md (so the oracle guidance is discoverable from the main contribution entrypoint)
Why this change Contributors working on the off-chain oracle previously had no dedicated guidance analogous to docs/contributing-contracts.md for on-chain work. The new doc centralizes oracle-specific conventions and onboarding steps, reducing onboarding friction and improving code quality and test coverage for oracle components.

Acceptance criteria (this PR satisfies)

Create docs/CONTRIBUTING_ORACLE.md — done.
Cover local setup, running tests, adding a new chess platform client, integration test conventions — done (see sections in the new doc).
Link from CONTRIBUTING.md — done (Oracle Service Changes section references docs/CONTRIBUTING_ORACLE.md).
Files changed

docs/CONTRIBUTING_ORACLE.md (new)
CONTRIBUTING.md (updated link to oracle guide)
How to review / test

Read docs/CONTRIBUTING_ORACLE.md for clarity, accuracy, and completeness.
Run ./scripts/repository_health_check.sh (or equivalent) to confirm links are valid.
Confirm CONTRIBUTING.md includes a clear reference to docs/CONTRIBUTING_ORACLE.md.
Optionally follow the Local Setup steps in the doc to verify environment variables and run commands render correctly (e.g., cp .env.example .env, cargo build -p oracle).
Validate examples and code snippets render correctly on GitHub (no broken fences or backticks).
Suggested labels

documentation
enhancement
Suggested reviewers

A maintainer familiar with the oracle service and/or repository documentation (e.g., owners or active contributors on the oracle/CI area)
Notes for maintainers

If we add additional platform clients later, update .env.example and the guide’s "Where to Update This Guide" section to keep examples in sync.
Consider adding a short link to CONTRIBUTING_ORACLE.md in README.md (top-level) for even better discoverability.
Closing This PR adds a dedicated, actionable contributor guide for the oracle service and links it from the main contribution doc to satisfy the repository’s contributor onboarding needs for off-chain components.