### PR TITLE
ci: add Dependabot config for Cargo and npm weekly updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "npm"
+    directory: "/frontend"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5


### PR DESCRIPTION
closes #867 

## Summary

Adds `.github/dependabot.yml` to keep dependencies from drifting over time.

## Changes

- Configures weekly Dependabot updates for `cargo` (root workspace)
- Configures weekly Dependabot updates for `npm` (`/frontend` directory)
- Sets `open-pull-requests-limit: 5` for each ecosystem

## Acceptance Criteria

- [x] `.github/dependabot.yml` created
- [x] Weekly updates configured for `cargo`
- [x] Weekly updates configured for `npm` (directory: `/frontend`)
- [x] `open-pull-requests-limit: 5` set for each