### PR TITLE
Add docker-compose.yml for local event-indexer development

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,23 @@
+services:
+  event-indexer:
+    build:
+      context: .
+      dockerfile: services/event-indexer/Dockerfile
+    ports:
+      - "8080:8080"
+    environment:
+      STELLAR_RPC_URL: ${STELLAR_RPC_URL:-https://soroban-testnet.stellar.org}
+      CONTRACT_ESCROW: ${CONTRACT_ESCROW}
+      EVENT_INDEXER_DB_PATH: /data/events.db
+      EVENT_INDEXER_BIND_ADDR: 0.0.0.0
+      EVENT_INDEXER_PORT: 8080
+      EVENT_INDEXER_CACHE_SIZE: ${EVENT_INDEXER_CACHE_SIZE:-10000}
+      EVENT_INDEXER_POLL_INTERVAL: ${EVENT_INDEXER_POLL_INTERVAL:-5}
+      EVENT_INDEXER_LOG_LEVEL: ${EVENT_INDEXER_LOG_LEVEL:-info}
+    env_file:
+      - .env
+    volumes:
+      - event-indexer-data:/data
+
+volumes:
+  event-indexer-data:

--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -57,6 +57,16 @@ cargo run --release
 
 The event indexer tracks on-chain events and indexes them for quick queries. Configuration is in `services/event-indexer/src/config.rs`.
 
+#### Using Docker Compose
+
+Alternatively, run the event indexer in a container via Docker Compose. Make sure `.env` is set up first (see [Environment variables](#environment-variables)):
+
+```bash
+docker compose up --build
+```
+
+This builds the `event-indexer` service from `services/event-indexer/Dockerfile`, persists its SQLite database in a named Docker volume, and exposes the API on `http://localhost:8080`. Environment variables are sourced from `.env` at the repo root, with sensible defaults applied for anything not set (see `docker-compose.yml`).
+
 ## Configuration
 
 ### Environment variables

--- a/services/event-indexer/Dockerfile
+++ b/services/event-indexer/Dockerfile
@@ -1,0 +1,11 @@
+FROM rust:1.75-slim AS builder
+WORKDIR /app
+COPY . .
+RUN cargo build --release --manifest-path services/event-indexer/Cargo.toml
+
+FROM debian:bookworm-slim
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates && rm -rf /var/lib/apt/lists/*
+WORKDIR /app
+COPY --from=builder /app/target/release/event-indexer /usr/local/bin/event-indexer
+EXPOSE 8080
+CMD ["event-indexer"]


### PR DESCRIPTION
## Summary
- Add `services/event-indexer/Dockerfile` to build the event-indexer service
- Add `docker-compose.yml` at the repo root with an `event-indexer` service, SQLite data persisted in a named volume, and environment variables sourced from `.env`
- Document Docker Compose usage in `docs/local-dev.md`

## Test plan
- [x] `docker compose config` validates the compose file (after copying `.env.example` to `.env`)
- [ ] `docker compose up --build` builds and starts the event-indexer, reachable at `http://localhost:8080/health`

Closes #869