### PR TITLE
chore: test cancel_match

### DIFF
--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -130,11 +130,10 @@ impl EscrowContract {
             if count == 0 {
                 env.storage().instance().set(&DataKey::AllowlistEnforced, &true);
             }
-            Self::append_allowed_token(&env, &token);
         } else {
             env.storage().instance().set(&DataKey::AllowlistEnforced, &true);
-            Self::append_allowed_token(&env, &token);
         }
+        Self::append_allowed_token(&env, &token);
 
         env.events().publish(
             (Symbol::new(&env, "admin"), symbol_short!("token_add")),
@@ -592,11 +591,12 @@ impl EscrowContract {
             .get(&DataKey::Match(match_id))
             .ok_or(Error::MatchNotFound)?;
 
-        if m.state == MatchState::Active {
-            return Err(Error::MatchAlreadyActive);
-        }
         if m.state != MatchState::Pending {
-            return Err(Error::InvalidState);
+            return Err(if m.state == MatchState::Active {
+                Error::MatchAlreadyActive
+            } else {
+                Error::InvalidState
+            });
         }
 
         // Either player1 or player2 can cancel a pending match


### PR DESCRIPTION
 1. cancel_match — redundant state check (applied)
  
  The original checked state == Active then separately state != Pending. The second check already covers Active and every other non-Pending state. Collapsed into a
  single check that maps the state to the correct error.
  
  2. add_allowed_token — duplicated append_allowed_token call (applied)
  
  The if !already_allowed / else block called Self::append_allowed_token at the end of both branches — identical code. Lifted it out of the conditional so it runs
  once unconditionally after the branching logic.
  
  3. create_match — missing self-contract check for player1 (interrupted)
  
  The original only checked that player2 != contract_address. player1 had the same potential problem but was never validated against it. The fix extends the guard
  to cover both players in a single condition.

closes #795 