### PR TITLE
feat: typed MatchStatus deserialization in GET /events and /matches (#820)

### DIFF
--- a/services/event-indexer/src/api.rs
+++ b/services/event-indexer/src/api.rs
@@ -1,6 +1,7 @@
 use axum::{
-    extract::{Query, Path, State},
-    http::StatusCode,
+    async_trait,
+    extract::{rejection::QueryRejection, FromRequestParts, Path, Query, State},
+    http::{request::Parts, StatusCode},
     routing::get,
     Json, Router,
 };
@@ -13,7 +14,7 @@ use tracing::info;
 use crate::{
     cache::EventCache,
     db::Database,
-    models::{IndexedEvent, MatchInfo, QueryFilters, MatchStatus},
+    models::{IndexedEvent, MatchInfo, MatchStatus, QueryFilters},
     rpc::SorobanRpcClient,
 };
 
@@ -31,17 +32,46 @@ pub struct ApiResponse<T> {
     pub error: Option<String>,
 }
 
+/// A custom `Query` extractor that returns a `400 ApiResponse` on deserialization failure
+/// instead of axum's default 422 with a plain-text body.
+pub struct TypedQuery<T>(pub T);
+
+#[async_trait]
+impl<T, S> FromRequestParts<S> for TypedQuery<T>
+where
+    T: serde::de::DeserializeOwned,
+    S: Send + Sync,
+{
+    type Rejection = (StatusCode, Json<ApiResponse<()>>);
+
+    async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
+        axum::extract::Query::<T>::from_request_parts(parts, state)
+            .await
+            .map(|axum::extract::Query(inner)| TypedQuery(inner))
+            .map_err(|e: QueryRejection| {
+                (
+                    StatusCode::BAD_REQUEST,
+                    Json(ApiResponse {
+                        success: false,
+                        data: None,
+                        error: Some(format!("Invalid query parameter: {}", e.body_text())),
+                    }),
+                )
+            })
+    }
+}
+
 #[derive(Deserialize)]
 pub struct EventQuery {
     pub player_address: Option<String>,
-    pub status: Option<String>,
+    pub status: Option<MatchStatus>,
     pub limit: Option<i64>,
     pub offset: Option<i64>,
 }
 
 #[derive(Deserialize)]
 pub struct MatchQuery {
-    pub status: Option<String>,
+    pub status: Option<MatchStatus>,
 }
 
 #[derive(Deserialize)]
@@ -93,18 +123,11 @@ async fn health_check(State(state): State<AppState>) -> Json<serde_json::Value> 
 
 async fn get_events(
     State(state): State<AppState>,
-    Query(query): Query<EventQuery>,
+    TypedQuery(query): TypedQuery<EventQuery>,
 ) -> (StatusCode, Json<ApiResponse<Vec<IndexedEvent>>>) {
     let filters = QueryFilters {
         player_address: query.player_address,
-        status: query.status.as_ref().map(|s| match s.as_str() {
-            "pending" => MatchStatus::Pending,
-            "active" => MatchStatus::Active,
-            "completed" => MatchStatus::Completed,
-            "cancelled" => MatchStatus::Cancelled,
-            "expired" => MatchStatus::Expired,
-            _ => MatchStatus::Pending,
-        }),
+        status: query.status,
         start_date: None,
         end_date: None,
         limit: query.limit.or(Some(100)),
@@ -205,16 +228,9 @@ async fn get_match_events(
 
 async fn get_matches(
     State(state): State<AppState>,
-    Query(query): Query<MatchQuery>,
+    TypedQuery(query): TypedQuery<MatchQuery>,
 ) -> (StatusCode, Json<ApiResponse<Vec<MatchInfo>>>) {
-    let status = query.status.as_ref().map(|s| match s.as_str() {
-        "pending" => MatchStatus::Pending,
-        "active" => MatchStatus::Active,
-        "completed" => MatchStatus::Completed,
-        "cancelled" => MatchStatus::Cancelled,
-        "expired" => MatchStatus::Expired,
-        _ => MatchStatus::Pending,
-    });
+    let status = query.status;
 
     match state.db.get_matches_by_status(status.as_ref()) {
         Ok(matches) => (

--- a/services/event-indexer/tests/integration_tests.rs
+++ b/services/event-indexer/tests/integration_tests.rs
@@ -10,6 +10,7 @@ use event_indexer::{
     rpc::SorobanRpcClient,
 };
 use rusqlite::Connection;
+use serde_json;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 use tower::ServiceExt;
@@ -164,4 +165,37 @@ async fn test_get_match_info_404_returns_error_body() {
 
     assert!(!parsed.success);
     assert_eq!(parsed.error.as_deref(), Some("Match 9999 not found"));
+}
+
+#[tokio::test]
+async fn test_unknown_status_returns_400() {
+    for uri in ["/events?status=bogus", "/matches?status=bogus"] {
+        let app = test_app();
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri(uri)
+                    .body(axum::body::Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            response.status(),
+            StatusCode::BAD_REQUEST,
+            "expected 400 for {uri}"
+        );
+
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let parsed: ApiResponse<serde_json::Value> = serde_json::from_slice(&body).unwrap();
+
+        assert!(!parsed.success, "success must be false for {uri}");
+        assert!(
+            parsed.error.as_deref().unwrap_or("").contains("Invalid query parameter"),
+            "expected 'Invalid query parameter' in error for {uri}, got: {:?}",
+            parsed.error
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #820.

Replaces manual string-to-`MatchStatus` mapping in the `GET /events` and `GET /matches` handlers with direct serde deserialization, and returns a structured `400` error on unknown status values.

## Changes

### `services/event-indexer/src/api.rs`
- Added `TypedQuery<T>` custom extractor: wraps axum's `Query<T>`, maps `QueryRejection` → `400 BAD_REQUEST` with an `ApiResponse` error body (consistent with the rest of the API)
- `EventQuery.status` and `MatchQuery.status`: `Option<String>` → `Option<MatchStatus>`
- Removed both manual `match s.as_str()` blocks (which also silently defaulted unknown strings to `Pending`)
- `get_events` and `get_matches` now use `TypedQuery` instead of axum's `Query`

### `services/event-indexer/tests/integration_tests.rs`
- Added `test_unknown_status_returns_400`: covers `/events?status=bogus` and `/matches?status=bogus`, asserts `400`, `success: false`, and `"Invalid query parameter"` in the error message

## What was tested
- Static review of all changed code paths
- All existing integration tests are unmodified and should continue to pass

closes #820 