### PR TITLE
feat: add lichesError

### DIFF
--- a/oracle-service/src/oracle/errors.rs
+++ b/oracle-service/src/oracle/errors.rs
@@ -23,3 +23,27 @@ pub enum ChessComError {
     #[error("game result is not available yet")]
     GameNotFinished,
 }
+
+#[derive(Debug, Error)]
+pub enum LichessError {
+    #[error("invalid lichess game id")]
+    InvalidGameId,
+
+    #[error("http request failed: {0}")]
+    Http(#[from] reqwest::Error),
+
+    #[error("request timed out")]
+    Timeout,
+
+    #[error("lichess returned non-success status: {status}")]
+    HttpStatus { status: reqwest::StatusCode },
+
+    #[error("game not found")]
+    GameNotFound,
+
+    #[error("game result is not available yet")]
+    GameNotFinished,
+
+    #[error("game is missing result fields or is in an unknown state")]
+    InvalidResponse,
+}


### PR DESCRIPTION
 Added LichessError enum to oracle-service/src/oracle/errors.rs
  
  Mirrors the existing ChessComError pattern with 7 variants covering all Lichess API failure modes:
  
  - InvalidGameId — malformed or rejected game ID
  - Http — wraps reqwest::Error for network-level failures
  - Timeout — request exceeded time limit
  - HttpStatus — non-2xx response from Lichess API
  - GameNotFound — game ID doesn't exist on Lichess
  - GameNotFinished — game is still in progress, result unavailable
  - InvalidResponse — response parsed but result fields are missing or unrecognized
  
  This gives the Lichess oracle client a typed error surface consistent with the Chess.com integration, making error handling exhaustive and unit-testable without
  relying on stringly-typed failures or generic anyhow errors.

closes #798 