### PR TITLE
feat: add MatchList component with loading, error, and empty states

### DIFF
--- a/frontend/src/components/MatchList.test.tsx
+++ b/frontend/src/components/MatchList.test.tsx
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MatchList } from '../components/MatchList';
+
+const baseMatch = {
+  matchId: 1,
+  player1: 'GAAA',
+  player2: 'GBBB',
+  stakeAmount: '50',
+  token: 'USDC',
+  status: 'active' as const,
+  platform: 'lichess' as const,
+};
+
+describe('MatchList', () => {
+  it('shows loading state', () => {
+    render(<MatchList matches={[]} loading />);
+    expect(screen.getByRole('status').textContent).toBe('Loading matches…');
+  });
+
+  it('shows error state', () => {
+    render(<MatchList matches={[]} error="Failed to load" />);
+    expect(screen.getByRole('alert').textContent).toBe('Failed to load');
+  });
+
+  it('shows empty state when no matches', () => {
+    render(<MatchList matches={[]} />);
+    expect(screen.getByText('No matches found.')).toBeTruthy();
+  });
+
+  it('renders a list with accessible semantics', () => {
+    render(<MatchList matches={[baseMatch]} />);
+    expect(screen.getByRole('list', { name: 'Match list' })).toBeTruthy();
+    expect(screen.getAllByRole('listitem')).toHaveLength(1);
+  });
+
+  it('renders one card per match', () => {
+    const matches = [baseMatch, { ...baseMatch, matchId: 2 }];
+    render(<MatchList matches={matches} />);
+    expect(screen.getAllByRole('listitem')).toHaveLength(2);
+  });
+
+  it('list items are keyboard focusable', () => {
+    render(<MatchList matches={[baseMatch]} />);
+    const item = screen.getByRole('listitem');
+    expect(item.getAttribute('tabindex')).toBe('0');
+  });
+
+  it('snapshot: populated list', () => {
+    const { container } = render(<MatchList matches={[baseMatch]} />);
+    expect(container).toMatchSnapshot();
+  });
+});

--- a/frontend/src/components/MatchList.tsx
+++ b/frontend/src/components/MatchList.tsx
@@ -1,0 +1,41 @@
+import { MatchCard } from './match/MatchCard';
+
+interface Match {
+  matchId: number;
+  player1: string;
+  player2: string;
+  stakeAmount: string;
+  token: string;
+  status: 'pending' | 'active' | 'completed' | 'cancelled';
+  platform: 'lichess' | 'chessdotcom';
+}
+
+interface MatchListProps {
+  matches: Match[];
+  loading?: boolean;
+  error?: string | null;
+}
+
+export function MatchList({ matches, loading = false, error = null }: MatchListProps) {
+  if (loading) {
+    return <p role="status" aria-live="polite">Loading matches…</p>;
+  }
+
+  if (error) {
+    return <p role="alert">{error}</p>;
+  }
+
+  if (matches.length === 0) {
+    return <p>No matches found.</p>;
+  }
+
+  return (
+    <ul aria-label="Match list">
+      {matches.map(match => (
+        <li key={match.matchId} tabIndex={0}>
+          <MatchCard {...match} />
+        </li>
+      ))}
+    </ul>
+  );
+}


### PR DESCRIPTION
closes #898 
- Renders a list of MatchCard components from a matches prop
- Shows loading status, error alert, or empty-state message
- Accessible: ul with aria-label, keyboard-focusable list items
- 7 tests covering all states, list semantics, and a snapshot

## Summary

Provide a short description of the change and the problem it fixes.

## Related Issue

Link the issue number or task this PR addresses.

## What changed
- Contracts:
- Tests:
- Docs:
- Events / API / storage:

## Verification
- What did you run to verify this change?
  - `cargo test -p escrow`
  - `cargo test -p oracle`
  - `cargo fmt`
  - `cargo clippy`

## Checklist
- [ ] I added or updated tests covering this change.
- [ ] I updated documentation or confirmed no docs update is needed.
- [ ] I confirmed any event/API/storage changes are documented and backward-compatible.
- [ ] I manually verified the contract or CLI behavior where applicable.
- [ ] I linked this PR to the related issue.
- [ ] I included notes on any TTL or storage assumptions affecting contract state.

## Notes

Add any additional details, risks, or follow-up tasks here.
