### PR TITLE
test: add integration tests for full match lifecycle

### DIFF
--- a/contracts/escrow/src/tests/integration.rs
+++ b/contracts/escrow/src/tests/integration.rs
@@ -1,0 +1,81 @@
+/// Integration tests: full match lifecycle (create → deposit → result → payout)
+use super::*;
+
+/// Full lifecycle — player1 wins: both deposit, oracle submits Player1 win,
+/// winner receives the full pot and escrow balance drops to zero.
+#[test]
+fn test_full_lifecycle_winner_payout() {
+    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+    let tc = token_client(&env, &token);
+
+    let stake: i128 = 100;
+    let match_id = client.create_match(
+        &player1,
+        &player2,
+        &stake,
+        &token,
+        &String::from_str(&env, "integration_winner_game"),
+        &Platform::Lichess,
+    );
+
+    // Both players deposit — match becomes Active
+    client.deposit(&match_id, &player1);
+    client.deposit(&match_id, &player2);
+
+    assert!(client.is_funded(&match_id));
+    assert_eq!(client.get_escrow_balance(&match_id), stake * 2);
+
+    let p1_before = tc.balance(&player1);
+    let p2_before = tc.balance(&player2);
+
+    // Oracle submits result — player1 wins
+    client.submit_result(&match_id, &Winner::Player1);
+
+    // Escrow must be zero after payout
+    assert_eq!(client.get_escrow_balance(&match_id), 0);
+
+    // Winner received the full pot; loser balance unchanged
+    assert_eq!(tc.balance(&player1), p1_before + stake * 2);
+    assert_eq!(tc.balance(&player2), p2_before);
+
+    // Match is in terminal Completed state
+    let m = client.get_match(&match_id);
+    assert_eq!(m.state, MatchState::Completed);
+}
+
+/// Full lifecycle — draw: both deposit, oracle submits Draw, each player gets
+/// their stake back and escrow balance drops to zero.
+#[test]
+fn test_full_lifecycle_draw_refund() {
+    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+    let tc = token_client(&env, &token);
+
+    let stake: i128 = 100;
+    let match_id = client.create_match(
+        &player1,
+        &player2,
+        &stake,
+        &token,
+        &String::from_str(&env, "integration_draw_game"),
+        &Platform::Lichess,
+    );
+
+    client.deposit(&match_id, &player1);
+    client.deposit(&match_id, &player2);
+
+    let p1_before = tc.balance(&player1);
+    let p2_before = tc.balance(&player2);
+
+    // Oracle submits draw
+    client.submit_result(&match_id, &Winner::Draw);
+
+    // Each player gets their stake back
+    assert_eq!(tc.balance(&player1), p1_before + stake);
+    assert_eq!(tc.balance(&player2), p2_before + stake);
+
+    // Escrow is empty and match is Completed
+    assert_eq!(client.get_escrow_balance(&match_id), 0);
+    assert_eq!(client.get_match(&match_id).state, MatchState::Completed);
+}

--- a/contracts/escrow/src/tests/mod.rs
+++ b/contracts/escrow/src/tests/mod.rs
@@ -13,6 +13,7 @@ pub mod helpers;
 mod admin;
 mod events;
 mod index;
+mod integration;
 mod invariants;
 mod lifecycle;
 mod pagination;


### PR DESCRIPTION
Closes #893

## Summary

Adds `contracts/escrow/src/tests/integration.rs` with two end-to-end tests that walk the full match state machine in a single flow, catching state-handoff bugs that unit tests miss.

## Tests added

**`test_full_lifecycle_winner_payout`**
- create_match → deposit (player1) → deposit (player2) → submit_result(Player1)
- Asserts: winner balance increases by 2×stake, loser balance unchanged, escrow = 0, state = Completed

**`test_full_lifecycle_draw_refund`**
- create_match → deposit (player1) → deposit (player2) → submit_result(Draw)
- Asserts: each player refunded their stake, escrow = 0, state = Completed

## What was tested
Both tests use the existing `setup()` fixture and `token_client()` helper, following the conventions established in the test suite.