### PR TITLE
feat: add StakeAmountInput component with validation and integrate in…

### DIFF
--- a/frontend/src/components/StakeAmountInput.test.tsx
+++ b/frontend/src/components/StakeAmountInput.test.tsx
@@ -1,0 +1,43 @@
+import { vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { StakeAmountInput } from './StakeAmountInput';
+
+describe('StakeAmountInput', () => {
+  const onChange = vi.fn();
+
+  test('renders token symbol suffix', () => {
+    render(
+      <StakeAmountInput tokenSymbol="ETH" value="" onChange={onChange} min={0} />
+    );
+    expect(screen.getByText('ETH')).toBeInTheDocument();
+  });
+
+  test('shows error for non‑numeric input', () => {
+    render(
+      <StakeAmountInput tokenSymbol="ETH" value="abc" onChange={onChange} min={0} />
+    );
+    expect(screen.getByRole('alert')).toHaveTextContent('Amount must be a number');
+  });
+
+  test('shows error for zero or negative input', () => {
+    const { rerender } = render(
+      <StakeAmountInput tokenSymbol="ETH" value="0" onChange={onChange} min={0} />
+    );
+    expect(screen.getByRole('alert')).toHaveTextContent('Amount must be greater than 0');
+
+    rerender(
+      <StakeAmountInput tokenSymbol="ETH" value="-5" onChange={onChange} min={0} />
+    );
+    expect(screen.getByRole('alert')).toHaveTextContent('Amount must be greater than 0');
+  });
+
+  test('calls onChange when user edits input', () => {
+    render(
+      <StakeAmountInput tokenSymbol="ETH" value="" onChange={onChange} min={0} />
+    );
+    const input = screen.getByRole('textbox');
+    fireEvent.change(input, { target: { value: '10' } });
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/components/StakeAmountInput.tsx
+++ b/frontend/src/components/StakeAmountInput.tsx
@@ -1,0 +1,77 @@
+import React, { useId } from 'react';
+
+type StakeAmountInputProps = {
+  /** HTML id for the input element – needed for label association */
+  id?: string;
+  /** Symbol of the token to display as a suffix */
+  tokenSymbol: string;
+  /** Current string value of the input */
+  value: string;
+  /** Change handler */
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  /** Minimum allowed amount (default 0) */
+  min?: number;
+};
+
+/**
+ * Input component for entering a staking amount.
+ * Displays the token symbol as a suffix and performs inline validation.
+ * Uses a plain text input (type="text") so it works with the test suite's
+ * `getByRole('textbox')` query while still allowing numeric validation.
+ */
+export const StakeAmountInput: React.FC<StakeAmountInputProps> = ({
+  id,
+  tokenSymbol,
+  value,
+  onChange,
+  min = 0,
+}) => {
+  const errorId = useId();
+  const numericValue = Number(value);
+  const isValidNumber = !isNaN(numericValue) && value.trim() !== '';
+  const hasError = value !== '' && (!isValidNumber || numericValue <= min);
+  const errorMessage =
+    !isValidNumber
+      ? 'Amount must be a number'
+      : numericValue <= min
+      ? `Amount must be greater than ${min}`
+      : '';
+
+  return (
+    <div style={{ position: 'relative', display: 'inline-block', width: '100%' }}>
+      <input
+        id={id}
+        type="text"
+        inputMode="decimal"
+        value={value}
+        onChange={onChange}
+        min={min}
+        aria-describedby={hasError ? errorId : undefined}
+        style={{
+          width: '100%',
+          paddingRight: `${tokenSymbol.length + 2}ch`, // extra space for suffix
+          boxSizing: 'border-box',
+        }}
+      />
+      <span
+        style={{
+          position: 'absolute',
+          right: '8px',
+          top: '50%',
+          transform: 'translateY(-50%)',
+          pointerEvents: 'none',
+          color: '#555',
+          fontWeight: 'bold',
+        }}
+        aria-hidden="true"
+      >
+        {tokenSymbol}
+      </span>
+      {hasError && (
+        <span id={errorId} role="alert" style={{ color: 'red', fontSize: '0.875rem' }}>
+          {errorMessage}
+        </span>
+      )}
+    </div>
+  );
+};

--- a/frontend/src/components/match/CreateMatchForm.tsx
+++ b/frontend/src/components/match/CreateMatchForm.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { StakeAmountInput } from '../StakeAmountInput';
 
 export interface CreateMatchData {
   player2: string;
@@ -50,8 +51,13 @@ export function CreateMatchForm({ onSubmit }: CreateMatchFormProps) {
       </div>
       <div>
         <label htmlFor="stakeAmount">Stake Amount</label>
-        <input id="stakeAmount" type="number" min="0" value={form.stakeAmount} onChange={set('stakeAmount')} />
-        {errors.stakeAmount && <span role="alert">{errors.stakeAmount}</span>}
+        <StakeAmountInput
+          id="stakeAmount"
+          tokenSymbol={form.token || "TOKEN"}
+          value={form.stakeAmount}
+          onChange={set('stakeAmount')}
+          min={0}
+        />
       </div>
       <div>
         <label htmlFor="token">Token Address</label>

--- a/frontend/src/test/useBalance.test.ts
+++ b/frontend/src/test/useBalance.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { renderHook, waitFor } from '@testing-library/react';
+import { renderHook, act, waitFor } from '@testing-library/react';
 import { useBalance } from '../hooks/useBalance';
 
 const mockLoadAccount = vi.fn();
@@ -10,7 +10,9 @@ vi.mock('@stellar/stellar-sdk', async (importOriginal) => {
     ...actual,
     Horizon: {
       ...actual.Horizon,
-      Server: vi.fn().mockImplementation(() => ({ loadAccount: mockLoadAccount })),
+      Server: vi.fn().mockImplementation(function (this: any) {
+        this.loadAccount = mockLoadAccount;
+      }),
     },
   };
 });
@@ -30,12 +32,16 @@ describe('useBalance', () => {
     vi.useFakeTimers();
 
     const { unmount } = renderHook(() => useBalance('GABC123'));
+    
+    // Let React run effects and resolve the mock loadAccount
+    await act(async () => {});
 
-    // Wait for the initial fetch
-    await waitFor(() => expect(mockLoadAccount).toHaveBeenCalledTimes(1));
+    expect(mockLoadAccount).toHaveBeenCalledTimes(1);
 
     // Advance time by 10 seconds to trigger the interval
-    await vi.advanceTimersByTimeAsync(10_000);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10_000);
+    });
 
     expect(mockLoadAccount).toHaveBeenCalledTimes(2);
 

--- a/frontend/src/test/useMatch.test.ts
+++ b/frontend/src/test/useMatch.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { renderHook, waitFor } from '@testing-library/react';
+import { renderHook, act } from '@testing-library/react';
 import { useMatch } from '../hooks/useMatch';
 
 describe('useMatch', () => {
@@ -33,15 +33,18 @@ describe('useMatch', () => {
     vi.stubGlobal('fetch', fetchMock);
 
     const { result } = renderHook(() => useMatch(1));
-
-    await waitFor(() => expect(result.current.match).toEqual(matchResponse.data));
+ 
+    await act(async () => {});
+    expect(result.current.match).toEqual(matchResponse.data);
     expect(result.current.loading).toBe(false);
     expect(result.current.error).toBeNull();
     expect(fetchMock).toHaveBeenCalledWith('http://localhost:8080/match/1');
-
-    vi.advanceTimersByTime(10_000);
-
-    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+ 
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10_000);
+    });
+ 
+    expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
   it('sets error when matchId is null', () => {


### PR DESCRIPTION
this pr closes #905 

## Description
This PR implements the dedicated `StakeAmountInput` component, integrates it into the `CreateMatchForm`, and resolves related test suite issues.

### Key Changes
1. **Created `StakeAmountInput` Component** (`frontend/src/components/StakeAmountInput.tsx`):
   - Validates that the input is a positive, non-zero numeric value.
   - Renders the token symbol inside the input field as a suffix.
   - Supports accessibility with proper `label` association and `aria-describedby` referencing inline validation error messages.

2. **Added Unit Tests** (`frontend/src/components/StakeAmountInput.test.tsx`):
   - Asserts correct rendering of suffix and validation errors for non-numeric, zero, or negative inputs.

3. **Form Integration** (`frontend/src/components/match/CreateMatchForm.tsx`):
   - Replaced plain input for stake amount with the new `StakeAmountInput` component.

4. **Updated Snapshot** (`frontend/src/test/__snapshots__/match.test.tsx.snap`):
   - Aligned the form markup snapshot with the new input elements.

5. **Fixed Pre-existing Test Failures** (`useBalance.test.ts`, `useMatch.test.ts`):
   - Fixed the `Horizon.Server` constructor mock implementation to avoid instantiation errors.
   - Refactored polling interval tests to use Vitest fake timers with explicit `act` and `vi.advanceTimersByTimeAsync` calls to prevent 5000ms test timeouts.

## Verification
- Ran the full frontend test suite locally:
  ```bash
  npm test