### PR TITLE
Add tests verifying deposit and submit_result blocked while contract …

### DIFF
--- a/contracts/escrow/src/tests/admin.rs
+++ b/contracts/escrow/src/tests/admin.rs
@@ -50,6 +50,56 @@ fn test_admin_unpause_allows_create_match() {
 }
 
 #[test]
+fn test_admin_unpause_allows_deposit_after_paused() {
+    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let id = client.create_match(
+        &player1,
+        &player2,
+        &100,
+        &token,
+        &String::from_str(&env, "unpaused_deposit_game"),
+        &Platform::Lichess,
+    );
+
+    client.pause();
+    let result = client.try_deposit(&id, &player1);
+    assert_eq!(result, Err(Ok(Error::ContractPaused)));
+
+    client.unpause();
+    client.deposit(&id, &player1);
+    let m = client.get_match(&id);
+    assert!(m.player1_deposited, "deposit should succeed after unpause");
+}
+
+#[test]
+fn test_admin_unpause_allows_submit_result_after_paused() {
+    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let id = client.create_match(
+        &player1,
+        &player2,
+        &100,
+        &token,
+        &String::from_str(&env, "unpaused_submit_game"),
+        &Platform::Lichess,
+    );
+    client.deposit(&id, &player1);
+    client.deposit(&id, &player2);
+
+    client.pause();
+    let result = client.try_submit_result(&id, &Winner::Player1);
+    assert_eq!(result, Err(Ok(Error::ContractPaused)));
+
+    client.unpause();
+    client.submit_result(&id, &Winner::Player1);
+    let m = client.get_match(&id);
+    assert_eq!(m.state, MatchState::Completed);
+}
+
+#[test]
 fn test_paused_contract_rejects_deposit() {
     let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
     let client = EscrowContractClient::new(&env, &contract_id);


### PR DESCRIPTION
…paused and allowed after unpause

## Summary

Provide a short description of the change and the problem it fixes.

## Related Issue

Link the issue number or task this PR addresses.

## What changed
- Contracts:
- Tests:
- Docs:
- Events / API / storage:

## Verification
- What did you run to verify this change?
  - `cargo test -p escrow`
  - `cargo test -p oracle`
  - `cargo fmt`
  - `cargo clippy`

## Checklist
- [ ] I added or updated tests covering this change.
- [ ] I updated documentation or confirmed no docs update is needed.
- [ ] I confirmed any event/API/storage changes are documented and backward-compatible.
- [ ] I manually verified the contract or CLI behavior where applicable.
- [ ] I linked this PR to the related issue.
- [ ] I included notes on any TTL or storage assumptions affecting contract state.

## Notes

Add any additional details, risks, or follow-up tasks here.


Closes #909
