### PR TITLE
Feature/stake vesting

### DIFF
--- a/contracts/escrow/src/errors.rs
+++ b/contracts/escrow/src/errors.rs
@@ -24,4 +24,6 @@ pub enum Error {
     MatchAlreadyActive = 19,
     InvalidTimeout = 20,
     SnapshotNotFound = 21,
+    VestingNotExpired = 22,
+    AlreadyClaimed = 23,
 }

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -5,7 +5,7 @@ pub mod types;
 
 use errors::Error;
 use soroban_sdk::{contract, contractimpl, symbol_short, token, Address, Env, String, Symbol, Vec};
-use types::{BalanceSnapshot, DataKey, Match, MatchState, Platform, SnapshotReason, Winner};
+use types::{BalanceSnapshot, DataKey, Match, MatchState, Platform, ProtocolConfig, SnapshotReason, Winner};
 
 /// ~30 days at 5s/ledger. Used as the default TTL and expiration threshold.
 const MATCH_TTL_LEDGERS: u32 = 518_400;
@@ -344,6 +344,10 @@ impl EscrowContract {
             player2_deposited: false,
             created_ledger: env.ledger().sequence(),
             completed_ledger: None,
+            winner: None,
+            vested_at: None,
+            player1_claimed: false,
+            player2_claimed: false,
         };
 
         env.storage().persistent().set(&DataKey::Match(id), &m);
@@ -481,7 +485,7 @@ impl EscrowContract {
         Ok(())
     }
 
-    /// Oracle submits the verified match result and triggers payout.
+    /// Oracle submits the verified match result and triggers payout vesting.
     pub fn submit_result(
         env: Env,
         match_id: u64,
@@ -517,22 +521,13 @@ impl EscrowContract {
             return Err(Error::NotFunded);
         }
 
-        let client = token::Client::new(&env, &m.token);
-        let pot = m.stake_amount.checked_mul(2).ok_or(Error::Overflow)?;
-
-        match winner {
-            Winner::Player1 => client.transfer(&env.current_contract_address(), &m.player1, &pot),
-            Winner::Player2 => client.transfer(&env.current_contract_address(), &m.player2, &pot),
-            Winner::Draw => {
-                client.transfer(&env.current_contract_address(), &m.player1, &m.stake_amount);
-                client.transfer(&env.current_contract_address(), &m.player2, &m.stake_amount);
-            }
-        }
-
         Self::remove_active_match(&env, match_id);
 
         m.state = MatchState::Completed;
         m.completed_ledger = Some(env.ledger().sequence());
+        m.winner = Some(winner.clone());
+        m.vested_at = Some(env.ledger().timestamp());
+
         env.storage()
             .persistent()
             .set(&DataKey::Match(match_id), &m);
@@ -1319,6 +1314,127 @@ impl EscrowContract {
         env.storage().instance().has(&DataKey::Oracle)
     }
 
+    /// Return the protocol config.
+    pub fn get_protocol_config(env: Env) -> ProtocolConfig {
+        Self::get_config(&env)
+    }
+
+    /// Update the protocol config — admin only.
+    pub fn update_protocol_config(env: Env, config: ProtocolConfig) -> Result<(), Error> {
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(Error::Unauthorized)?;
+        admin.require_auth();
+
+        env.storage().instance().set(&DataKey::ProtocolConfig, &config);
+        env.events().publish(
+            (Symbol::new(&env, "admin"), symbol_short!("config")),
+            config.vesting_duration_seconds,
+        );
+        Ok(())
+    }
+
+    /// Claim a vested match payout. Callable by players after the vesting period ends.
+    pub fn claim_vested_payout(env: Env, match_id: u64, player: Address) -> Result<(), Error> {
+        extend_instance_ttl(&env);
+        player.require_auth();
+
+        let mut m: Match = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Match(match_id))
+            .ok_or(Error::MatchNotFound)?;
+
+        if m.state != MatchState::Completed {
+            return Err(Error::InvalidState);
+        }
+
+        let vested_at = m.vested_at.ok_or(Error::InvalidState)?;
+        let config = Self::get_config(&env);
+        if env.ledger().timestamp() < vested_at.checked_add(config.vesting_duration_seconds).ok_or(Error::Overflow)? {
+            return Err(Error::VestingNotExpired);
+        }
+
+        let is_p1 = player == m.player1;
+        let is_p2 = player == m.player2;
+
+        if !is_p1 && !is_p2 {
+            return Err(Error::Unauthorized);
+        }
+
+        let winner = m.winner.as_ref().ok_or(Error::InvalidState)?;
+        let client = token::Client::new(&env, &m.token);
+        let amount_claimed;
+
+        if is_p1 {
+            if m.player1_claimed {
+                return Err(Error::AlreadyClaimed);
+            }
+
+            match winner {
+                Winner::Player1 => {
+                    let pot = m.stake_amount.checked_mul(2).ok_or(Error::Overflow)?;
+                    client.transfer(&env.current_contract_address(), &m.player1, &pot);
+                    amount_claimed = pot;
+                }
+                Winner::Draw => {
+                    client.transfer(&env.current_contract_address(), &m.player1, &m.stake_amount);
+                    amount_claimed = m.stake_amount;
+                }
+                Winner::Player2 => {
+                    return Err(Error::Unauthorized);
+                }
+            }
+            m.player1_claimed = true;
+        } else {
+            if m.player2_claimed {
+                return Err(Error::AlreadyClaimed);
+            }
+
+            match winner {
+                Winner::Player2 => {
+                    let pot = m.stake_amount.checked_mul(2).ok_or(Error::Overflow)?;
+                    client.transfer(&env.current_contract_address(), &m.player2, &pot);
+                    amount_claimed = pot;
+                }
+                Winner::Draw => {
+                    client.transfer(&env.current_contract_address(), &m.player2, &m.stake_amount);
+                    amount_claimed = m.stake_amount;
+                }
+                Winner::Player1 => {
+                    return Err(Error::Unauthorized);
+                }
+            }
+            m.player2_claimed = true;
+        }
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Match(match_id), &m);
+        env.storage().persistent().extend_ttl(
+            &DataKey::Match(match_id),
+            MATCH_TTL_LEDGERS,
+            MATCH_TTL_LEDGERS,
+        );
+
+        env.events().publish(
+            (Symbol::new(&env, "match"), symbol_short!("claim")),
+            (match_id, player, amount_claimed, m.token.clone()),
+        );
+
+        Ok(())
+    }
+
+}
+
+impl EscrowContract {
+    fn get_config(env: &Env) -> ProtocolConfig {
+        env.storage().instance().get(&DataKey::ProtocolConfig).unwrap_or(ProtocolConfig {
+            vesting_duration_seconds: 259_200, // 3 days
+        })
+    }
 }
 
 #[cfg(test)]

--- a/contracts/escrow/src/tests/helpers.rs
+++ b/contracts/escrow/src/tests/helpers.rs
@@ -87,6 +87,18 @@ pub fn run_full_match(
     let id = create_default_match(client, env, player1, player2, token, game_id);
     fund_match(client, id, player1, player2);
     client.submit_result(&id, winner);
+    match winner {
+        Winner::Player1 => {
+            client.claim_vested_payout(&id, player1);
+        }
+        Winner::Player2 => {
+            client.claim_vested_payout(&id, player2);
+        }
+        Winner::Draw => {
+            client.claim_vested_payout(&id, player1);
+            client.claim_vested_payout(&id, player2);
+        }
+    }
     id
 }
 

--- a/contracts/escrow/src/tests/invariants.rs
+++ b/contracts/escrow/src/tests/invariants.rs
@@ -17,7 +17,9 @@ fn test_balance_conservation_after_player1_wins() {
 
     let total_before = tc.balance(&player1) + tc.balance(&player2) + tc.balance(&contract_id);
 
-    EscrowContractClient::new(&env, &contract_id).submit_result(&match_id, &Winner::Player1);
+    let client = EscrowContractClient::new(&env, &contract_id);
+    client.submit_result(&match_id, &Winner::Player1);
+    client.claim_vested_payout(&match_id, &player1);
 
     let total_after = tc.balance(&player1) + tc.balance(&player2) + tc.balance(&contract_id);
     assert_eq!(
@@ -35,7 +37,9 @@ fn test_balance_conservation_after_player2_wins() {
 
     let total_before = tc.balance(&player1) + tc.balance(&player2) + tc.balance(&contract_id);
 
-    EscrowContractClient::new(&env, &contract_id).submit_result(&match_id, &Winner::Player2);
+    let client = EscrowContractClient::new(&env, &contract_id);
+    client.submit_result(&match_id, &Winner::Player2);
+    client.claim_vested_payout(&match_id, &player2);
 
     let total_after = tc.balance(&player1) + tc.balance(&player2) + tc.balance(&contract_id);
     assert_eq!(
@@ -53,7 +57,10 @@ fn test_balance_conservation_after_draw() {
 
     let total_before = tc.balance(&player1) + tc.balance(&player2) + tc.balance(&contract_id);
 
-    EscrowContractClient::new(&env, &contract_id).submit_result(&match_id, &Winner::Draw);
+    let client = EscrowContractClient::new(&env, &contract_id);
+    client.submit_result(&match_id, &Winner::Draw);
+    client.claim_vested_payout(&match_id, &player1);
+    client.claim_vested_payout(&match_id, &player2);
 
     let total_after = tc.balance(&player1) + tc.balance(&player2) + tc.balance(&contract_id);
     assert_eq!(

--- a/contracts/escrow/src/tests/lifecycle.rs
+++ b/contracts/escrow/src/tests/lifecycle.rs
@@ -377,6 +377,7 @@ fn test_full_match_lifecycle_winner_and_draw_scenarios() {
     assert_eq!(client.get_escrow_balance(&winner_match_id), 200);
 
     client.submit_result(&winner_match_id, &Winner::Player1);
+    client.claim_vested_payout(&winner_match_id, &player1);
     let winner_match = client.get_match(&winner_match_id);
     assert_eq!(winner_match.state, MatchState::Completed);
     assert_eq!(token_client.balance(&player1), 1100);
@@ -413,6 +414,8 @@ fn test_full_match_lifecycle_winner_and_draw_scenarios() {
     assert_eq!(client.get_escrow_balance(&draw_match_id), 150);
 
     client.submit_result(&draw_match_id, &Winner::Draw);
+    client.claim_vested_payout(&draw_match_id, &player3);
+    client.claim_vested_payout(&draw_match_id, &player4);
     let draw_match = client.get_match(&draw_match_id);
     assert_eq!(draw_match.state, MatchState::Completed);
     assert_eq!(token_client.balance(&player3), 1000);
@@ -448,6 +451,7 @@ fn test_full_match_lifecycle() {
     assert_eq!(client.get_escrow_balance(&id), 200);
 
     client.submit_result(&id, &Winner::Player1);
+    client.claim_vested_payout(&id, &player1);
     assert_eq!(client.get_match(&id).state, MatchState::Completed);
     assert_eq!(token_client.balance(&player1), 1100);
     assert_eq!(token_client.balance(&player2), 900);
@@ -472,6 +476,7 @@ fn test_payout_winner() {
     client.deposit(&id, &player1);
     client.deposit(&id, &player2);
     client.submit_result(&id, &Winner::Player1);
+    client.claim_vested_payout(&id, &player1);
 
     assert_eq!(token_client.balance(&player1), 1100);
     assert_eq!(client.get_match(&id).state, MatchState::Completed);
@@ -496,6 +501,8 @@ fn test_draw_refund() {
     client.deposit(&id, &player1);
     client.deposit(&id, &player2);
     client.submit_result(&id, &Winner::Draw);
+    client.claim_vested_payout(&id, &player1);
+    client.claim_vested_payout(&id, &player2);
 
     assert_eq!(token_client.balance(&player1), 1000);
     assert_eq!(token_client.balance(&player2), 1000);
@@ -522,6 +529,8 @@ fn test_draw_refund_balances() {
     client.deposit(&id, &player1);
     client.deposit(&id, &player2);
     client.submit_result(&id, &Winner::Draw);
+    client.claim_vested_payout(&id, &player1);
+    client.claim_vested_payout(&id, &player2);
 
     assert_eq!(token_client.balance(&player1), player1_balance_before);
     assert_eq!(token_client.balance(&player2), player2_balance_before);
@@ -1784,4 +1793,128 @@ fn test_create_match_empty_game_id_rejected() {
         &Platform::Lichess,
     );
     assert_eq!(result, Err(Ok(Error::InvalidGameId)));
+}
+
+#[test]
+fn test_default_vesting_duration_seconds() {
+    let test_env = Env::default();
+    let contract_addr = test_env.register_contract(None, EscrowContract);
+    let test_client = EscrowContractClient::new(&test_env, &contract_addr);
+
+    let config = test_client.get_protocol_config();
+    assert_eq!(config.vesting_duration_seconds, 259_200); // 3 days
+}
+
+#[test]
+fn test_update_protocol_config() {
+    let (env, contract_id, _oracle, _player1, _player2, _token, admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    client.update_protocol_config(&ProtocolConfig {
+        vesting_duration_seconds: 600,
+    });
+
+    let config = client.get_protocol_config();
+    assert_eq!(config.vesting_duration_seconds, 600);
+}
+
+#[test]
+fn test_vesting_enforced() {
+    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+    let token_client = TokenClient::new(&env, &token);
+
+    // Set vesting duration to 1 hour (3600 seconds)
+    client.update_protocol_config(&ProtocolConfig {
+        vesting_duration_seconds: 3600,
+    });
+
+    let id = client.create_match(
+        &player1,
+        &player2,
+        &100,
+        &token,
+        &String::from_str(&env, "vesting_enforce_game"),
+        &Platform::Lichess,
+    );
+
+    client.deposit(&id, &player1);
+    client.deposit(&id, &player2);
+
+    // Submit result
+    client.submit_result(&id, &Winner::Player1);
+
+    // Try to claim immediately - should fail
+    let claim_res = client.try_claim_vested_payout(&id, &player1);
+    assert_eq!(claim_res, Err(Ok(Error::VestingNotExpired)));
+
+    // Advance time by 3599 seconds - should still fail
+    env.ledger().with_mut(|info| {
+        info.timestamp = info.timestamp.saturating_add(3599);
+    });
+    let claim_res = client.try_claim_vested_payout(&id, &player1);
+    assert_eq!(claim_res, Err(Ok(Error::VestingNotExpired)));
+
+    // Advance time by 1 more second (total 3600) - should succeed
+    env.ledger().with_mut(|info| {
+        info.timestamp = info.timestamp.saturating_add(1);
+    });
+    let claim_res = client.claim_vested_payout(&id, &player1);
+    assert_eq!(claim_res, ());
+
+    assert_eq!(token_client.balance(&player1), 1100);
+}
+
+#[test]
+fn test_cannot_double_claim() {
+    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let id = client.create_match(
+        &player1,
+        &player2,
+        &100,
+        &token,
+        &String::from_str(&env, "double_claim_game"),
+        &Platform::Lichess,
+    );
+
+    client.deposit(&id, &player1);
+    client.deposit(&id, &player2);
+    client.submit_result(&id, &Winner::Player1);
+
+    // First claim - succeeds (vesting is 0 by default in setup)
+    client.claim_vested_payout(&id, &player1);
+
+    // Second claim - fails
+    let claim_res = client.try_claim_vested_payout(&id, &player1);
+    assert_eq!(claim_res, Err(Ok(Error::AlreadyClaimed)));
+}
+
+#[test]
+fn test_claim_unauthorized_parties() {
+    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+    let outsider = Address::generate(&env);
+
+    let id = client.create_match(
+        &player1,
+        &player2,
+        &100,
+        &token,
+        &String::from_str(&env, "outsider_claim_game"),
+        &Platform::Lichess,
+    );
+
+    client.deposit(&id, &player1);
+    client.deposit(&id, &player2);
+    client.submit_result(&id, &Winner::Player1);
+
+    // Outsider trying to claim - fails
+    let claim_res = client.try_claim_vested_payout(&id, &outsider);
+    assert_eq!(claim_res, Err(Ok(Error::Unauthorized)));
+
+    // Player 2 trying to claim (P1 won, so P2 payout is 0) - fails
+    let claim_res = client.try_claim_vested_payout(&id, &player2);
+    assert_eq!(claim_res, Err(Ok(Error::Unauthorized)));
 }

--- a/contracts/escrow/src/tests/mod.rs
+++ b/contracts/escrow/src/tests/mod.rs
@@ -43,6 +43,9 @@ pub fn setup() -> (Env, Address, Address, Address, Address, Address, Address) {
     let contract_id = env.register_contract(None, EscrowContract);
     let client = EscrowContractClient::new(&env, &contract_id);
     client.initialize(&oracle, &admin);
+    client.update_protocol_config(&ProtocolConfig {
+        vesting_duration_seconds: 0,
+    });
 
     (
         env,

--- a/contracts/escrow/src/types.rs
+++ b/contracts/escrow/src/types.rs
@@ -25,6 +25,12 @@ pub enum Winner {
 }
 
 #[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ProtocolConfig {
+    pub vesting_duration_seconds: u64,
+}
+
+#[contracttype]
 #[derive(Clone, Debug, PartialEq)]
 pub struct Match {
     pub id: u64,
@@ -41,6 +47,10 @@ pub struct Match {
     pub created_ledger: u32,
     /// Ledger sequence number when match reached terminal state (Completed or Cancelled).
     pub completed_ledger: Option<u32>,
+    pub winner: Option<Winner>,
+    pub vested_at: Option<u64>,
+    pub player1_claimed: bool,
+    pub player2_claimed: bool,
 }
 
 #[contracttype]
@@ -65,6 +75,7 @@ pub enum DataKey {
     Snapshot(u64, u32),
     /// Total number of snapshots ever recorded for a match (monotonic, never reset).
     SnapshotCount(u64),
+    ProtocolConfig,
 }
 
 /// The lifecycle event that triggered a balance snapshot.

--- a/frontend/src/components/StakeAmountInput.test.tsx
+++ b/frontend/src/components/StakeAmountInput.test.tsx
@@ -1,0 +1,43 @@
+import { vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { StakeAmountInput } from './StakeAmountInput';
+
+describe('StakeAmountInput', () => {
+  const onChange = vi.fn();
+
+  test('renders token symbol suffix', () => {
+    render(
+      <StakeAmountInput tokenSymbol="ETH" value="" onChange={onChange} min={0} />
+    );
+    expect(screen.getByText('ETH')).toBeInTheDocument();
+  });
+
+  test('shows error for non‑numeric input', () => {
+    render(
+      <StakeAmountInput tokenSymbol="ETH" value="abc" onChange={onChange} min={0} />
+    );
+    expect(screen.getByRole('alert')).toHaveTextContent('Amount must be a number');
+  });
+
+  test('shows error for zero or negative input', () => {
+    const { rerender } = render(
+      <StakeAmountInput tokenSymbol="ETH" value="0" onChange={onChange} min={0} />
+    );
+    expect(screen.getByRole('alert')).toHaveTextContent('Amount must be greater than 0');
+
+    rerender(
+      <StakeAmountInput tokenSymbol="ETH" value="-5" onChange={onChange} min={0} />
+    );
+    expect(screen.getByRole('alert')).toHaveTextContent('Amount must be greater than 0');
+  });
+
+  test('calls onChange when user edits input', () => {
+    render(
+      <StakeAmountInput tokenSymbol="ETH" value="" onChange={onChange} min={0} />
+    );
+    const input = screen.getByRole('textbox');
+    fireEvent.change(input, { target: { value: '10' } });
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/components/StakeAmountInput.tsx
+++ b/frontend/src/components/StakeAmountInput.tsx
@@ -1,0 +1,77 @@
+import React, { useId } from 'react';
+
+type StakeAmountInputProps = {
+  /** HTML id for the input element – needed for label association */
+  id?: string;
+  /** Symbol of the token to display as a suffix */
+  tokenSymbol: string;
+  /** Current string value of the input */
+  value: string;
+  /** Change handler */
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  /** Minimum allowed amount (default 0) */
+  min?: number;
+};
+
+/**
+ * Input component for entering a staking amount.
+ * Displays the token symbol as a suffix and performs inline validation.
+ * Uses a plain text input (type="text") so it works with the test suite's
+ * `getByRole('textbox')` query while still allowing numeric validation.
+ */
+export const StakeAmountInput: React.FC<StakeAmountInputProps> = ({
+  id,
+  tokenSymbol,
+  value,
+  onChange,
+  min = 0,
+}) => {
+  const errorId = useId();
+  const numericValue = Number(value);
+  const isValidNumber = !isNaN(numericValue) && value.trim() !== '';
+  const hasError = value !== '' && (!isValidNumber || numericValue <= min);
+  const errorMessage =
+    !isValidNumber
+      ? 'Amount must be a number'
+      : numericValue <= min
+      ? `Amount must be greater than ${min}`
+      : '';
+
+  return (
+    <div style={{ position: 'relative', display: 'inline-block', width: '100%' }}>
+      <input
+        id={id}
+        type="text"
+        inputMode="decimal"
+        value={value}
+        onChange={onChange}
+        min={min}
+        aria-describedby={hasError ? errorId : undefined}
+        style={{
+          width: '100%',
+          paddingRight: `${tokenSymbol.length + 2}ch`, // extra space for suffix
+          boxSizing: 'border-box',
+        }}
+      />
+      <span
+        style={{
+          position: 'absolute',
+          right: '8px',
+          top: '50%',
+          transform: 'translateY(-50%)',
+          pointerEvents: 'none',
+          color: '#555',
+          fontWeight: 'bold',
+        }}
+        aria-hidden="true"
+      >
+        {tokenSymbol}
+      </span>
+      {hasError && (
+        <span id={errorId} role="alert" style={{ color: 'red', fontSize: '0.875rem' }}>
+          {errorMessage}
+        </span>
+      )}
+    </div>
+  );
+};

--- a/frontend/src/components/match/CreateMatchForm.tsx
+++ b/frontend/src/components/match/CreateMatchForm.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { StakeAmountInput } from '../StakeAmountInput';
 
 export interface CreateMatchData {
   player2: string;
@@ -50,8 +51,13 @@ export function CreateMatchForm({ onSubmit }: CreateMatchFormProps) {
       </div>
       <div>
         <label htmlFor="stakeAmount">Stake Amount</label>
-        <input id="stakeAmount" type="number" min="0" value={form.stakeAmount} onChange={set('stakeAmount')} />
-        {errors.stakeAmount && <span role="alert">{errors.stakeAmount}</span>}
+        <StakeAmountInput
+          id="stakeAmount"
+          tokenSymbol={form.token || "TOKEN"}
+          value={form.stakeAmount}
+          onChange={set('stakeAmount')}
+          min={0}
+        />
       </div>
       <div>
         <label htmlFor="token">Token Address</label>

--- a/frontend/src/test/useBalance.test.ts
+++ b/frontend/src/test/useBalance.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { renderHook, waitFor } from '@testing-library/react';
+import { renderHook, act, waitFor } from '@testing-library/react';
 import { useBalance } from '../hooks/useBalance';
 
 const mockLoadAccount = vi.fn();
@@ -10,7 +10,9 @@ vi.mock('@stellar/stellar-sdk', async (importOriginal) => {
     ...actual,
     Horizon: {
       ...actual.Horizon,
-      Server: vi.fn().mockImplementation(() => ({ loadAccount: mockLoadAccount })),
+      Server: vi.fn().mockImplementation(function (this: any) {
+        this.loadAccount = mockLoadAccount;
+      }),
     },
   };
 });
@@ -30,12 +32,16 @@ describe('useBalance', () => {
     vi.useFakeTimers();
 
     const { unmount } = renderHook(() => useBalance('GABC123'));
+    
+    // Let React run effects and resolve the mock loadAccount
+    await act(async () => {});
 
-    // Wait for the initial fetch
-    await waitFor(() => expect(mockLoadAccount).toHaveBeenCalledTimes(1));
+    expect(mockLoadAccount).toHaveBeenCalledTimes(1);
 
     // Advance time by 10 seconds to trigger the interval
-    await vi.advanceTimersByTimeAsync(10_000);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10_000);
+    });
 
     expect(mockLoadAccount).toHaveBeenCalledTimes(2);
 

--- a/frontend/src/test/useMatch.test.ts
+++ b/frontend/src/test/useMatch.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { renderHook, waitFor } from '@testing-library/react';
+import { renderHook, act } from '@testing-library/react';
 import { useMatch } from '../hooks/useMatch';
 
 describe('useMatch', () => {
@@ -33,15 +33,18 @@ describe('useMatch', () => {
     vi.stubGlobal('fetch', fetchMock);
 
     const { result } = renderHook(() => useMatch(1));
-
-    await waitFor(() => expect(result.current.match).toEqual(matchResponse.data));
+ 
+    await act(async () => {});
+    expect(result.current.match).toEqual(matchResponse.data);
     expect(result.current.loading).toBe(false);
     expect(result.current.error).toBeNull();
     expect(fetchMock).toHaveBeenCalledWith('http://localhost:8080/match/1');
-
-    vi.advanceTimersByTime(10_000);
-
-    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+ 
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10_000);
+    });
+ 
+    expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
   it('sets error when matchId is null', () => {


### PR DESCRIPTION
this pr closes #950 

Description
Implements Stake Vesting (a configurable time delay) for completed match payouts to prevent accidental token loss and allow a dispute period.

Key Changes
Vesting Config: Added ProtocolConfig with a default 3-day vesting duration (vesting_duration_seconds).
Deferred Payout: Modified submit_result to log the result (winner, vested_at) but defer immediate token transfers.
Claims: Added claim_vested_payout to verify authorization, enforce the vesting period, prevent double-claiming, and disburse stakes.
Admin Controls: Added get_protocol_config and update_protocol_config (admin-only).
Testing: Added unit tests covering default config, config updates, vesting enforcement, double-claim rejection, and unauthorized claim protection.