### PR TITLE
Add automated doc-code conformance gate for escrow/oracle contracts

### DIFF
--- a/.github/workflows/doc-conformance.yml
+++ b/.github/workflows/doc-conformance.yml
@@ -1,0 +1,44 @@
+name: Doc Conformance
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+
+jobs:
+  conformance-check:
+    name: Check Doc-Code Conformance
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Run conformance checker
+        run: bash scripts/check_doc_conformance.sh
+
+  conformance-self-test:
+    name: Conformance Checker Self-Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Run positive/negative control tests
+        run: bash scripts/test_doc_conformance.sh
+
+  require-doc-update:
+    name: Require Doc Update on Contract Change
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Verify contract-surface changes include a doc update
+        run: |
+          bash scripts/require_doc_update.sh \
+            "origin/${{ github.event.pull_request.base.ref }}" \
+            "${{ github.sha }}"

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
 # Build artifacts
 target/
 
+# Python bytecode (scripts/doc_conformance)
+__pycache__/
+*.pyc
+
 # Environment secrets
 .env
 

--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,21 @@
 SHELL := /bin/bash
 .DEFAULT_GOAL := help
 
-.PHONY: help build test lint fmt deploy-testnet frontend-dev frontend-test
+.PHONY: help build test lint fmt deploy-testnet frontend-dev frontend-test doc-conformance doc-conformance-test
 
 help:
 	@echo "Usage: make <target>"
 	@echo ""
 	@echo "Targets:"
-	@echo "  build            Build Soroban contracts"
-	@echo "  test             Run Rust tests"
-	@echo "  lint             Run Rust lints via cargo clippy"
-	@echo "  fmt              Format Rust code"
-	@echo "  deploy-testnet   Deploy contracts to Stellar testnet"
-	@echo "  frontend-dev     Start the frontend development server"
-	@echo "  frontend-test    Run frontend tests"
+	@echo "  build                 Build Soroban contracts"
+	@echo "  test                  Run Rust tests"
+	@echo "  lint                  Run Rust lints via cargo clippy"
+	@echo "  fmt                   Format Rust code"
+	@echo "  deploy-testnet        Deploy contracts to Stellar testnet"
+	@echo "  frontend-dev          Start the frontend development server"
+	@echo "  frontend-test         Run frontend tests"
+	@echo "  doc-conformance       Check docs against contract source (see docs/doc-conformance.md)"
+	@echo "  doc-conformance-test  Run the doc-conformance checker's own self-tests"
 
 build:
 	bash scripts/build.sh
@@ -35,3 +37,9 @@ frontend-dev:
 
 frontend-test:
 	cd frontend && npm ci && npm test
+
+doc-conformance:
+	bash scripts/check_doc_conformance.sh
+
+doc-conformance-test:
+	bash scripts/test_doc_conformance.sh

--- a/contracts/escrow/formal_spec.json
+++ b/contracts/escrow/formal_spec.json
@@ -104,15 +104,16 @@
       "authorization": "player1",
       "preconditions": [
         "same as create_match",
-        "token_b != token",
-        "conversion_rate > 0"
+        "token_b != token_a",
+        "rate > 0",
+        "rate within ±5% of the oracle contract's stored get_rate(token_a, token_b) (or its inverse), where a rate is available"
       ],
       "state_transition": "N/A → Pending (new match)",
       "mutations": [
-        "Match(id) created with state=Pending, conversion_rate, token_b set",
+        "Match(id) created with state=Pending, conversion_rate=rate, token_b set, conversion_rate_ledger=current ledger",
         "all mutations as create_match"
       ],
-      "errors": ["same as create_match + InvalidConversionRate"]
+      "errors": ["same as create_match + ConversionRateOutOfBounds (rate outside the oracle-validated ±5% tolerance; note the similarly-named InvalidConversionRate error variant in errors.rs is currently unused dead code, not returned by this function)"]
     },
     {
       "name": "deposit",
@@ -157,7 +158,8 @@
         "match removed from ActiveMatches index"
       ],
       "errors": [
-        "ContractPaused", "Unauthorized", "MatchNotFound", "InvalidState", "NotFunded"
+        "ContractPaused", "Unauthorized", "MatchNotFound", "InvalidState", "NotFunded",
+        "ConversionRateStalePriceSource (multi-token matches only; execute_payout rejects a conversion_rate validated too long ago)"
       ]
     },
     {
@@ -260,7 +262,7 @@
         "PendingWinner and ResultDeadline entries cleaned up",
         "BalanceSnapshot recorded with reason=Finalized"
       ],
-      "errors": ["MatchNotFound", "MatchNotInPendingResult", "DisputePeriodNotElapsed"]
+      "errors": ["MatchNotFound", "MatchNotInPendingResult", "DisputePeriodNotElapsed", "ConversionRateStalePriceSource (multi-token matches only; execute_payout rejects a conversion_rate validated too long ago)"]
     },
     {
       "name": "dispute_oracle_result",
@@ -309,14 +311,14 @@
         "dispute.state == Active",
         "current_ledger >= dispute.voting_deadline"
       ],
-      "state_transition": "PendingResult → Completed (if result upheld) or PendingResult → Cancelled (if overturned)",
+      "state_transition": "PendingResult → Completed (always; an overturned vote settles as a Draw refund but match.state still becomes Completed, not Cancelled)",
       "mutations": [
-        "dispute.state = ResolvedUpheld (if uphold_votes > overturn_votes) or ResolvedOverturned (if overturn_votes > uphold_votes)",
+        "dispute.state = ResolvedUpheld (if no_votes >= yes_votes) or ResolvedOverturned (if yes_votes > no_votes) — tally uses Dispute.yes_votes/no_votes as mutated by vote_on_dispute; Dispute.uphold_votes/overturn_votes are unused legacy fields",
         "if upheld: execute_payout with stored PendingWinner, match.state = Completed",
-        "if overturned: refund both players, match.state = Cancelled",
+        "if overturned: execute_payout with Winner::Draw (refund both players), match.state = Completed",
         "BalanceSnapshot recorded with reason=Finalized"
       ],
-      "errors": ["DisputeNotFound", "VotingPeriodNotElapsed", "DisputeAlreadyResolved"]
+      "errors": ["DisputeNotFound", "VotingPeriodNotElapsed", "DisputeAlreadyResolved", "ConversionRateStalePriceSource (multi-token matches only; execute_payout rejects a conversion_rate validated too long ago)"]
     },
     {
       "name": "claim_vested_payout",
@@ -375,7 +377,7 @@
     "claim_vested_payout": ["player1_claimed", "player2_claimed"],
     "finalize_match": ["state", "completed_ledger"],
     "dispute_oracle_result": ["state (persisted as PendingResult)"],
-    "resolve_dispute_by_vote": ["state (either Completed or Cancelled)"]
+    "resolve_dispute_by_vote": ["state (always Completed; see entry_points[].state_transition for the overturned-vote nuance)"]
   },
   "critical_invariants": [
     {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -129,15 +129,85 @@ Returned by `get_match(match_id)`. All fields below are stable and safe to read.
 | `player1`          | `Address`       | Match creator (first player). |
 | `player2`          | `Address`       | Invited opponent (second player). |
 | `stake_amount`     | `i128`          | Amount each player stakes, in the token's smallest unit. |
-| `token`            | `Address`       | Token contract address used for staking (XLM or USDC). |
+| `token`            | `Address`       | Token contract address used for staking (any allowlisted Stellar Asset Contract, e.g. XLM or USDC — see [Token Support](security.md#smart-contract-limitations)). |
 | `game_id`          | `String`        | External game ID from the chess platform. |
 | `platform`         | `Platform`      | Chess platform: `Lichess` or `ChessDotCom`. |
 | `state`            | `MatchState`    | Current lifecycle state (see below). |
 | `winner`           | `Winner`        | Match outcome once completed; defaults to `Draw` until set. |
 | `created_ledger`   | `u32`           | Ledger sequence at match creation. |
 | `completed_ledger` | `Option<u32>`   | Ledger sequence at completion or cancellation, if applicable. |
+| `vested_at`        | `Option<u64>`   | Unix timestamp at which a completed payout's vesting period ends, if the protocol config has a non-zero `vesting_duration_seconds`. `None` when vesting does not apply. |
+| `player1_claimed`  | `bool`          | Whether `player1` has claimed their vested payout via `claim_vested_payout`. |
+| `player2_claimed`  | `bool`          | Whether `player2` has claimed their vested payout via `claim_vested_payout`. |
+| `conversion_rate`  | `Option<i128>`  | For multi-token matches created via `create_match_with_conversion`: the oracle-validated `token`→`token_b` conversion rate. `None` for single-token matches. |
+| `token_b`          | `Option<Address>` | For multi-token matches: the second token, in which `player2`'s side of the payout is settled. `None` for single-token matches. |
+| `conversion_rate_ledger` | `Option<u32>` | Ledger sequence at which `conversion_rate` was validated against the oracle price. Used to reject stale rates at payout time. |
+| `paused_ledger`    | `Option<u32>`   | Ledger sequence at which `pause_match` was last called; cleared by `resume_match`. `None` when the match is not currently paused. |
+| `total_pause_duration` | `u32`       | Cumulative number of ledgers the match has spent paused across all pause/resume cycles. |
 
 > **Internal fields** — `player1_deposited` and `player2_deposited` are internal bookkeeping. Use `is_funded(match_id)` to check whether a match is fully funded.
+
+### `PlayerTier` Enum
+
+Stake-size tiers used to gate `create_match`/`deposit` (both players must satisfy the tier bounds for the match's `stake_amount`) and returned by `tier_from_match_count`.
+
+| Variant | Meaning |
+|---------|---------|
+| `Bronze` | Default tier; lowest stake bounds (`min_tier_stake`/`max_tier_stake`). |
+| `Silver` | Unlocked after enough completed matches; wider stake bounds than `Bronze`. |
+| `Gold` | Wider stake bounds than `Silver`. |
+| `Platinum` | Highest tier; no upper stake bound (`max_tier_stake` returns `i128::MAX`). |
+
+A player's tier is derived from their completed-match count (`tier_from_match_count`), not stored directly on `Match` or a player record.
+
+### `DisputeState` Enum
+
+| Variant | Meaning |
+|---------|---------|
+| `Active` | Dispute raised via `dispute_oracle_result`; voting window open. |
+| `Upheld` | Reserved for future use; not currently assigned by `resolve_dispute_by_vote` (see `ResolvedUpheld`). |
+| `Overturned` | Reserved for future use; not currently assigned by `resolve_dispute_by_vote` (see `ResolvedOverturned`). |
+| `ResolvedUpheld` | Voting concluded; majority upheld the oracle's original result. |
+| `ResolvedOverturned` | Voting concluded; majority overturned the oracle's result (settled as a `Draw` refund — the match itself still transitions to `Completed`, not `Cancelled`). |
+
+### `Dispute` Struct
+
+Returned by `get_dispute(dispute_id)`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | `u64` | Unique dispute identifier. |
+| `match_id` | `u64` | The match this dispute contests. |
+| `disputer` | `Address` | Player (`player1` or `player2`) who raised the dispute. |
+| `created_ledger` | `u32` | Ledger sequence when the dispute was raised. |
+| `voting_deadline` | `u32` | Ledger sequence after which `resolve_dispute_by_vote` becomes callable. |
+| `state` | `DisputeState` | Current dispute state. |
+| `evidence_hash` | `String` | Caller-supplied hash referencing off-chain evidence for the dispute. |
+| `uphold_votes` | `u32` | Unused by current voting logic; retained on the struct but not mutated by `vote_on_dispute` (see `yes_votes`/`no_votes`). |
+| `overturn_votes` | `u32` | Unused by current voting logic; retained on the struct but not mutated by `vote_on_dispute` (see `yes_votes`/`no_votes`). |
+| `yes_votes` | `u32` | Token-balance-weighted votes to overturn, accumulated by `vote_on_dispute`. |
+| `no_votes` | `u32` | Token-balance-weighted votes to uphold, accumulated by `vote_on_dispute`. |
+
+### `ProtocolConfig` Struct
+
+Set via `set_protocol_config`, read via `get_protocol_config`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `vesting_duration_seconds` | `u64` | Seconds a completed payout must vest before `claim_vested_payout` releases it. `0` disables vesting (payout is immediate at `submit_result`/`finalize_match`/`resolve_dispute_by_vote` time). |
+| `cancellation_fee_basis_points` | `u32` | Basis-point fee deducted on cancellation, if configured. |
+| `treasury` | `Address` | Recipient address for cancellation fees. |
+
+### `PlayerBalanceSnapshot` Struct
+
+An internal per-player storage record — not returned directly by any function — underlying `get_balance_at_timestamp(player, timestamp) -> i128`, which walks these snapshots newest-first and returns the aggregate balance value from the first snapshot at or before `timestamp` (or `0` if none). A point-in-time record of a player's aggregate escrow balance across all of that player's deposit-eligible, non-terminal matches, recorded in a fixed-size per-player ring buffer (`MAX_PLAYER_SNAPSHOTS = 32`) on every deposit, payout, refund, or timeout.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `player` | `Address` | The player this snapshot belongs to. |
+| `index` | `u64` | Monotonically increasing position in the player's snapshot history; storage slot is `index % MAX_PLAYER_SNAPSHOTS`. |
+| `ledger` | `u64` | Ledger sequence (widened to `u64`) at snapshot time. |
+| `balance` | `i128` | Aggregate escrow balance attributable to the player at this point in time. |
 
 ### `MatchState` Enum
 
@@ -168,10 +238,14 @@ The contract uses a 6-state machine (formally verified at `/contracts/escrow/for
 
 | Variant     | Meaning |
 |-------------|---------|
-| `Created`   | Snapshot taken when match was created. |
+| `Created`   | Snapshot taken when match was created (`create_match` / `create_match_with_conversion`). |
 | `Deposit`   | Snapshot taken after a player deposited. |
-| `Completed` | Snapshot taken when match completed with payout. |
-| `Cancelled` | Snapshot taken when match was cancelled. |
+| `Paused`    | Snapshot taken when `pause_match` is called. |
+| `Resumed`   | Snapshot taken when `resume_match` is called. |
+| `Completed` | Snapshot taken when `submit_result` executes an immediate payout (`dispute_period == 0`). |
+| `Cancelled` | Snapshot taken when a match is cancelled (`cancel_match` or `expire_match`). |
+| `ResultSubmitted` | Snapshot taken when `submit_result` records a `PendingResult` (`dispute_period > 0`), before any payout. |
+| `Finalized` | Snapshot taken when `finalize_match` or `resolve_dispute_by_vote` executes the deferred payout. |
 
 ### `BalanceSnapshot` Struct
 
@@ -204,38 +278,96 @@ The ring buffer has a fixed capacity of `MAX_SNAPSHOTS_PER_MATCH = 8` slots per 
 
 ### Contract Functions
 
+This section lists the complete public function surface of `EscrowContract` (`contracts/escrow/src/lib.rs`). Every `pub fn` in the contract's `#[contractimpl]` block appears in exactly one table below.
+
+#### Admin & Lifecycle
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `initialize` | `(oracle: Address, admin: Address)` | One-time setup; stores the oracle and admin addresses. Panics (does not return `Error`) if called a second time — see [Panic vs Error Behavior](security.md#panic-vs-error-behavior). |
+| `is_initialized` | `() -> bool` | Returns whether `initialize` has been called. |
+| `pause` | `()` | Admin-only. Halts `create_match`, `deposit`, and `submit_result` contract-wide. See [Pause Mechanism](security.md#pause-mechanism). |
+| `unpause` | `()` | Admin-only. Reverses `pause`. |
+| `is_paused` | `() -> bool` | Returns the current contract-wide pause state. |
+| `get_admin` | `() -> Address` | Returns the stored admin address. |
+| `propose_admin` | `(new_admin: Address)` | Admin-only. First step of the two-step admin transfer; stores a pending admin. |
+| `accept_admin` | `()` | Called by the pending admin to complete a `propose_admin` transfer. |
+| `transfer_admin` | `(new_admin: Address)` | Admin-only. One-step admin transfer (no accept step), distinct from the `propose_admin`/`accept_admin` pair. |
+| `update_oracle` | `(new_oracle: Address)` | Admin-only. Rotates the trusted oracle address. Emits an `admin`/`oracle_up` event. |
+| `get_oracle` | `() -> Address` | Returns the stored oracle address. |
+| `set_protocol_config` | `(config: ProtocolConfig)` | Admin-only. Sets vesting duration, cancellation fee, and treasury address (see `ProtocolConfig` below). |
+| `get_protocol_config` | `() -> ProtocolConfig` | Returns the current protocol configuration. |
+| `set_match_timeout` | `(timeout: u32)` | Admin-only. Sets the pending-match expiration timeout, in ledgers. Must be within `[MIN_MATCH_TIMEOUT_LEDGERS, MAX_MATCH_TIMEOUT_LEDGERS]` = `[17,280, 1,555,200]` or returns `Error::InvalidTimeout`. See [Known Limitations](security.md#smart-contract-limitations). |
+| `get_match_timeout` | `() -> u32` | Returns the currently effective match timeout (configured value, or `DEFAULT_MATCH_TIMEOUT_LEDGERS` = 518,400 if never set). |
+
+#### Token Allowlist
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `add_allowed_token` | `(token: Address)` | Admin-only. Adds `token` to the allowlist and enables allowlist enforcement. |
+| `remove_allowed_token` | `(token: Address)` | Admin-only. Removes `token` from the allowlist. |
+| `is_token_allowed` | `(token: Address) -> bool` | Returns whether `token` is accepted (always `true` if enforcement is not yet enabled). |
+| `is_allowlist_enforced` | `() -> bool` | Returns whether allowlist enforcement has been turned on. |
+| `get_allowed_tokens` | `() -> Vec<Address>` | Returns all currently allowlisted tokens. |
+
 #### Match Management
 
 | Function | Signature | Description |
 |----------|-----------|-------------|
-| `create_match` | `(player1: Address, player2: Address, stake_amount: i128, token: Address, game_id: String, platform: Platform) -> u64` | Creates a new match and returns its ID. |
+| `create_match` | `(player1: Address, player2: Address, stake_amount: i128, token: Address, game_id: String, platform: Platform) -> u64` | Creates a new single-token match and returns its ID. |
+| `create_match_with_conversion` | `(player1: Address, player2: Address, stake_amount: i128, token_a: Address, token_b: Address, rate: i128, game_id: String, platform: Platform) -> u64` | Creates a multi-token match: `player1` stakes `token_a`, `player2` stakes the equivalent in `token_b` at `rate`, validated against the oracle contract's `get_rate` within a ±5% tolerance (see [oracle.md](oracle.md#contract-function-reference) and [Roadmap v1.0.1](roadmap.md#v101--multi-token-conversion-rate-hardening-complete)). |
 | `get_match` | `(match_id: u64) -> Match` | Returns the current state of a match. |
-| `cancel_match` | `(match_id: u64)` | Cancels a match and refunds any deposits. |
+| `cancel_match` | `(match_id: u64, caller: Address)` | Cancels a `Pending` match and refunds any deposits (minus the configured cancellation fee, if any). |
+| `expire_match` | `(match_id: u64)` | Anyone may call once a `Pending` match's timeout has elapsed since `created_ledger`; cancels and refunds like `cancel_match`. |
+| `pause_match` | `(match_id: u64, caller: Address)` | Either player may pause an `Active` or `PendingResult` match. |
+| `resume_match` | `(match_id: u64, caller: Address)` | Either player may resume a `Paused` match, restoring its prior state and accumulating `total_pause_duration`. |
 
 #### Escrow
 
 | Function | Signature | Description |
 |----------|-----------|-------------|
-| `deposit` | `(match_id: u64)` | Deposits the caller's stake into escrow. |
+| `deposit` | `(match_id: u64, player: Address)` | Deposits the caller's stake into escrow. |
 | `get_escrow_balance` | `(match_id: u64) -> i128` | Returns the total escrowed balance for a match. |
 | `is_funded` | `(match_id: u64) -> bool` | Returns `true` when both players have deposited. |
+| `get_depositor_count` | `(match_id: u64) -> u32` | Returns how many of the two players (0, 1, or 2) have deposited. |
+| `claim_vested_payout` | `(match_id: u64, player: Address)` | For matches settled under a non-zero `vesting_duration_seconds`: releases `player`'s share once the vesting period (tracked via `vested_at`) has elapsed. Returns `Error::Overflow` on timestamp arithmetic overflow. |
 
-#### Oracle & Payouts
+#### Oracle, Payouts & Disputes
 
 | Function | Signature | Description |
 |----------|-----------|-------------|
+| `submit_result` | `(match_id: u64, winner: Winner)` | Oracle submits the verified match result. If `dispute_period == 0`, payout (or draw refund) executes atomically in the same call. If `dispute_period > 0`, the match moves to `PendingResult` and payout is deferred to `finalize_match` or `resolve_dispute_by_vote`. |
+| `submit_result_with_oracle_record` | `(match_id: u64, winner: Winner, game_id: String) -> Result<(), Error>` | Same as `submit_result`, additionally storing `game_id` under `DataKey::OracleRecord(match_id)` as an audit-trail cross-reference to the oracle contract's `ResultEntry`. |
+| `finalize_match` | `(match_id: u64)` | Anyone may call once a `PendingResult` match's dispute deadline has elapsed with no active dispute; executes the deferred payout. |
+| `dispute_oracle_result` | `(match_id: u64, disputer: Address, evidence_hash: String) -> u64` | Either player may raise a dispute on a `PendingResult` match before the dispute deadline, opening a voting window. Returns the new dispute ID. |
+| `vote_on_dispute` | `(dispute_id: u64, voter: Address, vote: bool)` | Any address holding a positive balance of the match's stake token may cast one token-balance-weighted vote (`true` = overturn) before `voting_deadline`. |
+| `resolve_dispute_by_vote` | `(dispute_id: u64)` | Anyone may call once the voting deadline has elapsed; tallies `yes_votes`/`no_votes` and executes payout — upheld pays the original winner, overturned pays out a `Draw` refund. The match state becomes `Completed` in both outcomes (see `DisputeState` below). |
+| `set_dispute_period` | `(period: u32)` | Admin-only. Sets the dispute window (in ledgers) applied to future `submit_result` calls. `0` disables the dispute flow (immediate payout). |
+| `get_dispute_period` | `(&Env) -> u32` | Returns the currently configured dispute period. |
+| `get_dispute` | `(dispute_id: u64) -> Dispute` | Returns the stored dispute record. |
+| `get_match_dispute_id` | `(match_id: u64) -> u64` | Returns the dispute ID associated with a match, if one has been raised. |
 
-| `submit_result` | `(match_id: u64, winner: Winner)` | Oracle submits the verified match result. Payout (or draw refund) is executed atomically in the same transaction — there are no separate `verify_result` or `execute_payout` functions. |
+#### Player Tiers
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `tier_from_match_count` | `(player: Address) -> PlayerTier` | Derives a player's current tier from their completed-match count. |
+| `min_tier_stake` | `(tier: PlayerTier) -> i128` | Returns the minimum `stake_amount` permitted for a given tier. |
+| `max_tier_stake` | `(tier: PlayerTier) -> i128` | Returns the maximum `stake_amount` permitted for a given tier (`i128::MAX` for `Platinum`, i.e. unbounded). |
 
 #### Read Indexes
 
 | Function | Signature | Description |
 |----------|-----------|-------------|
+| `get_match_count` | `() -> u64` | Returns the total number of matches ever created. |
 | `get_player_matches` | `(player: Address) -> Vec<u64>` | Returns all match IDs (past and present) for a player. |
+| `get_player_matches_paginated` | `(player: Address, offset: u32, limit: u32) -> Vec<u64>` | Paginated version of `get_player_matches`. |
 | `get_pending_matches` | `() -> Vec<Match>` | Returns pending matches currently in `Pending` state, awaiting deposit completion. |
 | `get_active_matches` | `() -> Vec<Match>` | Returns active matches currently in `Active` state, fully funded and ready for result submission. |
+| `get_live_matches` | `() -> Vec<Match>` | **Currently an alias for `get_active_matches`** — despite the name, it does not include `Pending`, `PendingResult`, or `Paused` matches. Treat as equivalent to `get_active_matches` until/unless the implementation diverges. |
 | `get_pending_matches_paginated` | `(player: Address, offset: u32, limit: u32) -> Vec<Match>` | Paginated version of `get_pending_matches`. |
 | `get_active_matches_paginated` | `(offset: u32, limit: u32) -> Vec<Match>` | Paginated version of `get_active_matches`. |
+| `get_live_matches_paginated` | `(offset: u32, limit: u32) -> Vec<Match>` | Alias for `get_active_matches_paginated` (see `get_live_matches` note above). |
 
 #### Balance Snapshot Queries
 
@@ -243,6 +375,7 @@ The ring buffer has a fixed capacity of `MAX_SNAPSHOTS_PER_MATCH = 8` slots per 
 |----------|-----------|-------------|
 | `get_balance_snapshots` | `(caller: Address, match_id: u64) -> Vec<BalanceSnapshot>` | Returns all retained snapshots for a match. Admin sees exact amounts; players see redacted amounts. |
 | `get_latest_snapshot` | `(caller: Address, match_id: u64) -> BalanceSnapshot` | Returns the most recent snapshot for a match. Same access rules as `get_balance_snapshots`. |
+| `get_balance_at_timestamp` | `(player: Address, timestamp: u64) -> i128` | Returns `player`'s aggregate escrow balance as of the most recent `PlayerBalanceSnapshot` at or before `timestamp` (see `PlayerBalanceSnapshot` below), or `0` if none exists. |
 
 ## Index Behavior, TTL Caveats, and Pagination
 

--- a/docs/doc-conformance.md
+++ b/docs/doc-conformance.md
@@ -1,0 +1,184 @@
+# Doc-Code Conformance Checking
+
+This document describes the mechanism that prevents documentation from
+silently drifting away from the escrow and oracle contracts' actual public
+interface — the recurring failure mode that motivated
+[issue #1067](https://github.com/StellarCheckMate/Checkmate-Escrow/issues/1067):
+`docs/security.md` claiming a hardcoded ~24-hour match timeout when
+`set_match_timeout` has supported a configurable `[17,280, 1,555,200]`-ledger
+range since before that claim was written, `docs/architecture.md` omitting
+struct fields and contract functions that had shipped, and `docs/roadmap.md`
+claiming a feature had landed complete while its settlement path was still
+unsound.
+
+## What this is (and isn't)
+
+This is a **presence-and-consistency checker**, not a correctness prover. It
+answers "does every fact I can mechanically extract from source have a
+matching mention in the docs, and does every doc claim I can't extract
+automatically still match what it cited?" It does **not** verify that a
+doc's prose *correctly describes* a function's behavior — that's a human
+review responsibility this tool supports but doesn't replace.
+
+Formal correctness properties of the state machine itself (reachability,
+invariants like "no double payout") are a separate, complementary effort —
+see `contracts/escrow/formal_spec.json` and the related state-machine-
+verification work. This checker treats that file as **cross-referenced
+ground truth for `MatchState` variants and entry points**, not something it
+duplicates: see [Cross-reference with formal_spec.json](#cross-reference-with-formal_specjson)
+below. When the two disagree, that disagreement is itself a finding — see
+the worked example in that section.
+
+## Running it locally
+
+```bash
+make doc-conformance        # or: bash scripts/check_doc_conformance.sh
+make doc-conformance-test   # or: bash scripts/test_doc_conformance.sh
+```
+
+The checker exits non-zero if any error-level finding is produced. Pass
+`--json` to `scripts/doc_conformance/check.py` for machine-readable output.
+
+## What's checked automatically
+
+Facts are extracted from source by `scripts/doc_conformance/extract_facts.py`
+(regex/scanning — no `syn`/AST dependency, since CI only guarantees a plain
+`python3`) and diffed against docs by `scripts/doc_conformance/check.py`:
+
+| Check | Source of truth | Doc(s) checked |
+|---|---|---|
+| `match-states` | `MatchState` enum variants (`contracts/escrow/src/types.rs`) | `docs/architecture.md` — each variant must appear (as `` `Variant` ``) at least twice, matching the pattern of a states table + a transitions table. |
+| `match-fields` | `Match` struct fields (`types.rs`) | `docs/architecture.md`'s `### \`Match\` Struct` section — every field needs a row (or, for `player1_deposited`/`player2_deposited`, the documented internal-field callout). |
+| `function-coverage` | Every `pub fn` in `EscrowContract`'s and `OracleContract`'s `impl` blocks | `docs/architecture.md` (escrow) and `docs/oracle.md` + `docs/architecture.md` combined (oracle) — every function name needs at least one `` `fn_name` `` code-span mention somewhere. |
+| `timeout-bounds` | `MIN_MATCH_TIMEOUT_LEDGERS` / `MAX_MATCH_TIMEOUT_LEDGERS` (`contracts/escrow/src/lib.rs`) | `docs/security.md` must mention both bounds, and must not contain a "fixed/hardcoded timeout" or "~24 hour" style claim. |
+| `token-support` | — | `docs/security.md` must not contain a "No Native Token Support" style claim (the contract supports allowlisted SAC tokens including multi-token matches via `create_match_with_conversion`). |
+| `formal-spec` | `contracts/escrow/formal_spec.json` | Cross-checked against the same `MatchState` variants and the escrow contract's function set — see below. |
+| `annotations` | Cited source line's current content | Any doc carrying a `doc-conformance` annotation (see below) — the cited line must still hash to what was recorded. |
+
+## The annotation convention
+
+Some doc claims aren't mechanically extractable as a single fact (e.g. "the
+admin-oversight bullet list in the Oracle Compromise section is still
+accurate"). For these, cite the exact source location backing the claim
+with a structured HTML comment immediately above it:
+
+```html
+<!-- doc-conformance: verified path=contracts/escrow/src/lib.rs line=41 sha256=0c23a067e8485bb2d30c198995a18b78f9591bc66506f988f1e1399cab01f590 -->
+```
+
+The checker re-reads `path:line` and compares its stripped content against
+the recorded `sha256`. If the cited line has since changed — even in a way
+that's still true, like a comment edit — the hash won't match and the
+checker fails with a clear pointer to re-verify the claim and update the
+annotation. This deliberately trades some false positives (a harmlessly
+reworded comment triggers a required-but-cheap re-check) for the property
+that **a silently drifted claim can never pass CI indefinitely**.
+
+To compute a new/updated hash locally:
+
+```bash
+python3 -c "
+import hashlib
+line = open('contracts/escrow/src/lib.rs').read().splitlines()[LINE_NUMBER - 1]
+print(hashlib.sha256(line.strip().encode()).hexdigest())
+"
+```
+
+## Cross-reference with formal_spec.json
+
+Rather than re-deriving a second state-transition model (which would just
+create a second thing to keep in sync), this checker treats
+`contracts/escrow/formal_spec.json` — the artifact produced by the related
+state-machine-verification effort — as ground truth for `MatchState`
+variants and entry-point names, and checks it *against the contract source*
+the same way it checks the docs:
+
+- Every `MatchState` variant in `types.rs` must appear in the spec's
+  `match_states`, and vice versa (a spec state that no longer exists in
+  code is exactly as stale as a doc claim that no longer exists in code).
+- Every `entry_points[].name` in the spec must be a real public function on
+  `EscrowContract`.
+
+This isn't hypothetical: running this cross-check while building this gate
+caught that `formal_spec.json`'s `resolve_dispute_by_vote` entry claimed an
+overturned dispute vote transitions the match to `Cancelled`. The actual
+code (`contracts/escrow/src/lib.rs`, `resolve_dispute_by_vote`) always sets
+`match.state = Completed` — an overturned vote pays out a `Draw` refund
+through the normal `Completed` path, it does not cancel the match. That
+entry has been corrected as part of this change. `docs/architecture.md`'s
+transition table already described the real behavior correctly, which is
+exactly the kind of divergence between two "authoritative" artifacts this
+cross-check exists to catch before it's a third, contradictory source of
+truth.
+
+## Required CI gate
+
+Three jobs run in `.github/workflows/doc-conformance.yml`:
+
+1. **`conformance-check`** — runs the checker against the repo's current
+   state on every push/PR. This is the "docs must currently be accurate"
+   gate.
+2. **`conformance-self-test`** — runs `scripts/doc_conformance/tests/` (see
+   below), so a change to the checker itself that silently breaks its
+   ability to detect drift is caught the same way a change that breaks the
+   docs is.
+3. **`require-doc-update`** (PRs only) — `scripts/require_doc_update.sh`
+   fails if a PR modifies `contracts/escrow/src/lib.rs`,
+   `contracts/escrow/src/types.rs`, or `contracts/oracle/src/lib.rs` without
+   also touching at least one of `docs/architecture.md`, `docs/security.md`,
+   `docs/roadmap.md`, `docs/oracle.md`, `docs/doc-conformance.md`, or
+   `contracts/escrow/formal_spec.json`. This is a coarse presence check (did
+   *a* doc file change at all), not a substitute for job 1 — it exists so a
+   PR can't skip documentation entirely, and job 1 exists so what gets
+   written is actually correct.
+
+## Test suite (positive controls)
+
+`scripts/doc_conformance/tests/test_check.py` runs the checker against a
+small synthetic fixture repo (`tests/fixtures/good_repo/` — not this
+repo's real docs/contracts, so these tests stay fast and don't need
+updating every time the real docs change). `TestGoodRepoPasses` is the
+negative control: the clean fixture must produce zero findings.
+`TestPositiveControls` has one test per check category, each applying
+exactly one deliberate mutation (delete a state's second doc mention, add
+an undocumented struct field, add an undocumented function, reintroduce a
+"hardcoded timeout" claim, reintroduce a "no native token" claim, stale an
+annotation's cited line, and diverge `formal_spec.json` from source in two
+different ways) and asserting the checker's `run()` reports a
+matching-category error. Run with:
+
+```bash
+make doc-conformance-test
+```
+
+## Known limitations
+
+- **Regex-based extraction, not an AST.** `extract_facts.py` scans for
+  `impl NAME { ... }`, `enum NAME { ... }`, `struct NAME { ... }`, and
+  `pub fn` blocks with brace/paren counting. It will misparse source that
+  uses unusual formatting it wasn't written against (e.g. a struct/enum
+  defined via macro rather than literal `struct`/`enum` syntax). If a check
+  errors with a "not found" `ValueError` rather than a normal finding,
+  that's this limitation surfacing — treat it as "the checker needs an
+  update to follow the refactor," not as green.
+- **Function coverage only checks the name is mentioned**, not that its
+  documented signature/description matches. A doc row for `deposit` with a
+  stale parameter list still satisfies `function-coverage`; only the
+  annotation mechanism (cited line + hash) catches that class of drift, and
+  only where an annotation was actually added.
+- **`match-states` requiring "at least twice"** is a heuristic proxy for
+  "appears in both a states table and a transitions table," not a
+  structural parse of Markdown tables. A doc that mentions a state twice in
+  unrelated prose would pass; this trade-off was chosen to avoid coupling
+  the checker to today's exact Markdown table layout.
+- **The oracle contract's `set_rate`/`get_rate`/`swap` functions** predate
+  full doc-comment coverage in source (see the note in `docs/oracle.md`).
+  They pass `function-coverage` because they're named in the doc's function
+  reference table, but their error-handling documentation there is
+  advisory, not sourced from `# Errors` doc comments like the rest of the
+  contract.
+- **`require_doc_update.sh` is presence-only.** It cannot tell a genuine
+  doc update from a one-character whitespace touch to a gated file; that
+  gap is intentional (a stricter check would need to understand diff
+  *semantics*, which is exactly the harder problem `conformance-check`
+  handles for the specific fact classes above, not this gate).

--- a/docs/oracle.md
+++ b/docs/oracle.md
@@ -407,13 +407,104 @@ On-chain persistent storage has a finite TTL (~30 days). In normal operation res
 
 ## has_result vs has_result_admin
 
-(Existing contract documentation continues unchanged.)
+Both functions answer "has a result been submitted for this `match_id`?", but differ in access control:
+
+| Function | Auth Required | Use Case |
+|---|---|---|
+| `has_result(match_id) -> bool` | None (public) | General-purpose polling by indexers, frontends, or the escrow contract's integrators. |
+| `has_result_admin(match_id) -> Result<bool, Error>` | Admin (`require_auth`) | Private-tournament contexts where even the *existence* of a submitted result should not be observable by third parties before an official announcement. Returns `Error::Unauthorized` if the contract is uninitialized or the caller is not the admin. |
+
+Both read the same underlying `DataKey::Result(match_id)` storage entry; `has_result_admin` adds an authorization gate in front of the identical lookup.
 
 ---
 
 ## Data Structures
 
-(Existing contract documentation continues unchanged.)
+The oracle contract's public `#[contracttype]` types, defined in `contracts/oracle/src/types.rs`:
+
+### `ResultEntry`
+
+Returned by `get_result(match_id)`.
+
+| Field | Type | Description |
+|---|---|---|
+| `game_id` | `String` | External game ID from the chess platform. |
+| `platform` | `Platform` | `Lichess` or `ChessDotCom`. |
+| `result` | `Winner` | `Player1`, `Player2`, or `Draw`. |
+| `submitted_ledger` | `u32` | Ledger sequence at submission time. |
+| `submitter` | `Address` | Admin address that submitted the result. |
+
+### `BatchResultEntry`
+
+One entry within the `entries` vector passed to `submit_batch_results`.
+
+| Field | Type | Description |
+|---|---|---|
+| `match_id` | `u64` | Match this entry's result applies to. |
+| `game_id` | `String` | External game ID from the chess platform. |
+| `platform` | `Platform` | `Lichess` or `ChessDotCom`. |
+| `result` | `Winner` | `Player1`, `Player2`, or `Draw`. |
+
+### `OracleRegistration`
+
+Stored per oracle address via `register_oracle_with_stake`; read and mutated by `slash_oracle`.
+
+| Field | Type | Description |
+|---|---|---|
+| `oracle_address` | `Address` | The registered oracle's address. |
+| `oracle_stake` | `i128` | Token stake currently backing this oracle; reduced by `slash_oracle`. |
+| `token` | `Address` | Token contract the stake was posted in. |
+
+### `RateLimitConfig`
+
+Returned by `get_oracle_rate_limits`; set by `set_oracle_rate_limits`.
+
+| Field | Type | Description |
+|---|---|---|
+| `hourly_limit` | `u32` | Max submissions accepted per rolling hour. Defaults to 100 if never set. |
+| `daily_limit` | `u32` | Max submissions accepted per rolling day. Defaults to 1,000 if never set. |
+
+### `RateLimitStatus`
+
+Returned by `get_oracle_rate_limit_status`. The on-chain analogue of HTTP rate-limit response headers.
+
+| Field | Type | Description |
+|---|---|---|
+| `hourly_used` | `u32` | Estimated submissions counted in the current hourly sliding window. |
+| `hourly_limit` | `u32` | Configured (or default) hourly limit. |
+| `hourly_remaining` | `u32` | `hourly_limit - hourly_used`, saturating at 0. |
+| `daily_used` | `u32` | Estimated submissions counted in the current daily sliding window. |
+| `daily_limit` | `u32` | Configured (or default) daily limit. |
+| `daily_remaining` | `u32` | `daily_limit - daily_used`, saturating at 0. |
+
+## Contract Function Reference
+
+The complete public function surface of `OracleContract` (`contracts/oracle/src/lib.rs`). Functions above with dedicated sections are cross-referenced rather than re-described.
+
+| Function | Signature | Description |
+|---|---|---|
+| `initialize` | `(admin: Address)` | One-time setup; stores the admin address. Panics-free — returns `Error::AlreadyInitialized` on a second call. |
+| `is_initialized` | `() -> bool` | Returns whether `initialize` has been called. |
+| `register_oracle_with_stake` | `(oracle_address: Address, stake_amount: i128, token: Address)` | Transfers `stake_amount` of `token` from `oracle_address` into the contract as a slashable bond, recorded in `OracleRegistration`. |
+| `slash_oracle` | `(oracle_address: Address, slash_amount: i128)` | Admin-only. Deducts `slash_amount` from a registered oracle's stake and transfers it to the admin. |
+| `submit_result` | `(match_id: u64, game_id: String, platform: Platform, result: Winner)` | See [Submitting a Result](#submitting-a-result). Admin-authorized, rate-limited, one result per `match_id`. |
+| `submit_batch_results` | `(entries: Vec<BatchResultEntry>)` | All-or-nothing submission of up to `MAX_BATCH_SIZE` (100) results in one call; each entry counts toward the submitting admin's rate limit. |
+| `get_result` | `(match_id: u64) -> ResultEntry` | Returns the stored result, or `Error::ResultNotFound`. Extends the entry's TTL on read. |
+| `has_result` | `(match_id: u64) -> bool` | Public existence check. See [has_result vs has_result_admin](#has_result-vs-has_result_admin). |
+| `has_result_admin` | `(match_id: u64) -> Result<bool, Error>` | Admin-gated existence check. See [has_result vs has_result_admin](#has_result-vs-has_result_admin). |
+| `delete_result` | `(match_id: u64)` | Admin-only, irreversible. See [Result Deletion Policy](#result-deletion-policy-delete_result). |
+| `get_admin` | `() -> Address` | Returns the stored admin address, or `Error::Unauthorized` if uninitialized. |
+| `update_admin` | `(new_admin: Address)` | Rotates the admin address. Requires current admin auth. |
+| `pause` | `()` | Admin-only. Blocks `submit_result` and `submit_batch_results` while paused (`delete_result` is also blocked; see [Security: Oracle Contract Pause](security.md#oracle-contract-pause)). |
+| `unpause` | `()` | Admin-only. Reverses `pause`. |
+| `set_oracle_rate_limits` | `(oracle: Address, hourly_limit: u32, daily_limit: u32)` | Admin-only. Overrides the default hourly/daily submission caps for one oracle address. Pass `0` for either field to reset that field to the contract default. |
+| `get_oracle_rate_limits` | `(oracle: Address) -> RateLimitConfig` | Returns the effective (override or default) rate-limit configuration for `oracle`. |
+| `get_oracle_rate_limit_status` | `(oracle: Address) -> RateLimitStatus` | Returns `oracle`'s current sliding-window usage and remaining quota. |
+| `set_rate` | `(token_a: Address, token_b: Address, rate: i128)` | Admin-only. Stores a fixed-point exchange rate (scaled `1e7`) between `token_a` and `token_b`, used by `swap` and by the escrow contract's multi-token conversion-rate validation (see [Roadmap v1.0.1](roadmap.md#v101--multi-token-conversion-rate-hardening-complete)). |
+| `get_rate` | `(token_a: Address, token_b: Address) -> i128` | Returns the rate previously stored by `set_rate` for the ordered pair, or `Error::ResultNotFound` if none has been set. |
+| `swap` | `(token_in: Address, token_out: Address, amount_in: i128, recipient: Address)` | Converts `amount_in` of `token_in` to `token_out` using whichever direction of a stored rate exists, and transfers the result to `recipient` from the contract's own balance. Does not pull `token_in` from the caller — callers must fund the contract with `token_in` separately. |
+
+> **Note:** `set_rate`, `get_rate`, and `swap` predate formal documentation and currently carry no `# Errors` doc comments in source (unlike the rest of the contract's public functions). They are included here for conformance-checker coverage; treat their error behavior (both return `Error::ResultNotFound`/`Error::InvalidRateLimit`/`Error::Unauthorized` in the cases shown in `contracts/oracle/src/lib.rs:710-789`) as subject to change without the same stability guarantee as the rest of this reference.
 
 ---
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -184,10 +184,14 @@ Both contracts implement emergency pause functionality for rapid response to sec
 
 ## Known Limitations
 
+<!-- doc-conformance: verified path=contracts/escrow/src/lib.rs line=41 sha256=0c23a067e8485bb2d30c198995a18b78f9591bc66506f988f1e1399cab01f590 -->
+<!-- doc-conformance: verified path=contracts/escrow/src/lib.rs line=44 sha256=bbaa55f15d653c0614ce3d2f144a8394ca8a5b59215f0a4d279ed2e9d99e7a15 -->
+<!-- doc-conformance: verified path=contracts/escrow/src/lib.rs line=47 sha256=fb036554951d87299457f6fd6dd78dd8c6e3b884d5b7785c2f8fc7834225f9a5 -->
+
 ### Smart Contract Limitations
 
-1. **No Native Token Support**: Only supports Stellar assets (XLM, USDC), not native tokens
-2. **Fixed Timeout**: Match expiration timeout is hardcoded (~24 hours)
+1. **Token Support Is Allowlist-Gated, Not "Native"**: The contract accepts any Stellar Asset Contract (SAC) token — including XLM's wrapped SAC and Soroban-native token contracts such as USDC — subject to an optional admin-managed allowlist (`add_allowed_token` / `is_token_allowed`). There is no separate "native XLM" fast-path distinct from the generic token interface; every token, including XLM, is moved via the standard `token::Client` transfer interface. A `create_match_with_conversion` path additionally supports two-token ("multi-token") matches where each player stakes a different token at an oracle-validated conversion rate — see [Roadmap v1.0.1](roadmap.md#v101--multi-token-conversion-rate-hardening-complete) for the settlement-correctness history of that feature.
+2. **Configurable Timeout, Not Fixed**: Match expiration is **not** hardcoded. `set_match_timeout` (admin-only) accepts any value in `[MIN_MATCH_TIMEOUT_LEDGERS, MAX_MATCH_TIMEOUT_LEDGERS]` = `[17,280, 1,555,200]` ledgers (approximately 1 day to 90 days at 5s/ledger). If never set, `DEFAULT_MATCH_TIMEOUT_LEDGERS` (518,400 ledgers, ~30 days) applies. See `contracts/escrow/src/lib.rs:41-47` and `set_match_timeout` (`contracts/escrow/src/lib.rs:1329`).
 3. **No Partial Withdrawals**: Players cannot withdraw partial stakes
 4. **Single Oracle**: Only one oracle address per escrow contract
 

--- a/scripts/check_doc_conformance.sh
+++ b/scripts/check_doc_conformance.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Runs the doc-code conformance checker (scripts/doc_conformance/check.py).
+# See docs/doc-conformance.md for what this validates and why.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+python3 "$REPO_ROOT/scripts/doc_conformance/check.py" --repo-root "$REPO_ROOT" "$@"

--- a/scripts/doc_conformance/check.py
+++ b/scripts/doc_conformance/check.py
@@ -1,0 +1,369 @@
+#!/usr/bin/env python3
+"""Doc-code conformance checker for Checkmate-Escrow.
+
+Derives verifiable facts from `contracts/escrow/src/{lib,types}.rs` and
+`contracts/oracle/src/lib.rs`, then diffs them against claims embedded in
+`docs/security.md`, `docs/architecture.md`, `docs/oracle.md`, and
+`contracts/escrow/formal_spec.json`. See `docs/doc-conformance.md` for the
+full explanation of what is and isn't checked, and the annotation
+convention used for claims that can't be fully automated.
+
+Usage:
+    python3 scripts/doc_conformance/check.py [--repo-root PATH] [--json]
+
+Exit code is non-zero if any error-level finding is produced.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from extract_facts import ContractFacts, load_contract_facts  # noqa: E402
+
+ANNOTATION_RE = re.compile(
+    r"<!--\s*doc-conformance:\s*verified\s+path=(?P<path>\S+)\s+line=(?P<line>\d+)\s+"
+    r"sha256=(?P<hash>[0-9a-f]{64})\s*-->"
+)
+
+
+@dataclass
+class Finding:
+    severity: str  # "error" | "warn"
+    check: str
+    message: str
+
+
+def line_hash(line: str) -> str:
+    return hashlib.sha256(line.strip().encode("utf-8")).hexdigest()
+
+
+def check_match_states(facts: ContractFacts, arch_text: str) -> list[Finding]:
+    findings = []
+    for state in facts.match_states:
+        token = f"`{state}`"
+        occurrences = arch_text.count(token)
+        # Expect the variant to appear in both the state table and the
+        # transition table (>= 2), not just a passing prose mention.
+        if occurrences < 2:
+            findings.append(
+                Finding(
+                    "error",
+                    "match-states",
+                    f"MatchState variant '{state}' appears only {occurrences}x as "
+                    f"`{state}` in docs/architecture.md (expected >= 2: state table "
+                    "+ transition table). Contract has "
+                    f"{len(facts.match_states)} states: {facts.match_states}.",
+                )
+            )
+    return findings
+
+
+def check_match_struct_fields(facts: ContractFacts, arch_text: str) -> list[Finding]:
+    findings = []
+    m = re.search(
+        r"### `Match` Struct(?P<body>.*?)(?=\n### )", arch_text, re.DOTALL
+    )
+    if not m:
+        return [
+            Finding(
+                "error",
+                "match-fields",
+                "docs/architecture.md has no '### `Match` Struct' section to check "
+                "fields against.",
+            )
+        ]
+    body = m.group("body")
+    for f_name in facts.match_fields:
+        if f_name in ("player1_deposited", "player2_deposited"):
+            # Documented as intentionally-internal via a callout, not a table row.
+            if f_name not in body:
+                findings.append(
+                    Finding(
+                        "error",
+                        "match-fields",
+                        f"Match field '{f_name}' is not mentioned anywhere in the "
+                        "`Match` Struct section (expected at least the internal-field "
+                        "callout).",
+                    )
+                )
+            continue
+        if f"`{f_name}`" not in body:
+            findings.append(
+                Finding(
+                    "error",
+                    "match-fields",
+                    f"Match field '{f_name}' (contracts/escrow/src/types.rs) has no "
+                    "row in docs/architecture.md's `Match` Struct table.",
+                )
+            )
+    return findings
+
+
+def check_function_coverage(
+    fns: dict, doc_text: str, *, doc_name: str, contract_name: str
+) -> list[Finding]:
+    findings = []
+    for name in fns:
+        if f"`{name}`" not in doc_text:
+            findings.append(
+                Finding(
+                    "error",
+                    "function-coverage",
+                    f"{contract_name} function '{name}' has no `{name}` code-span "
+                    f"reference anywhere in {doc_name}.",
+                )
+            )
+    return findings
+
+
+def check_timeout_bounds(facts: ContractFacts, security_text: str) -> list[Finding]:
+    findings = []
+
+    def fmt(n: int) -> str:
+        return f"{n:,}"
+
+    if fmt(facts.timeout_min) not in security_text:
+        findings.append(
+            Finding(
+                "error",
+                "timeout-bounds",
+                f"MIN_MATCH_TIMEOUT_LEDGERS ({fmt(facts.timeout_min)}) is not "
+                "mentioned in docs/security.md.",
+            )
+        )
+    if fmt(facts.timeout_max) not in security_text:
+        findings.append(
+            Finding(
+                "error",
+                "timeout-bounds",
+                f"MAX_MATCH_TIMEOUT_LEDGERS ({fmt(facts.timeout_max)}) is not "
+                "mentioned in docs/security.md.",
+            )
+        )
+
+    stale_patterns = [
+        r"fixed\s+timeout",
+        r"hardcoded[^.]{0,40}timeout",
+        r"timeout[^.]{0,40}hardcoded",
+        r"~?24[\s-]hour",
+    ]
+    for pat in stale_patterns:
+        if re.search(pat, security_text, re.IGNORECASE):
+            findings.append(
+                Finding(
+                    "error",
+                    "timeout-bounds",
+                    f"docs/security.md contains a stale fixed/hardcoded-timeout "
+                    f"claim matching /{pat}/i. Match timeout is admin-configurable "
+                    "via set_match_timeout — see contracts/escrow/src/lib.rs "
+                    "MIN_MATCH_TIMEOUT_LEDGERS/MAX_MATCH_TIMEOUT_LEDGERS.",
+                )
+            )
+    return findings
+
+
+def check_native_token_claim(security_text: str) -> list[Finding]:
+    if re.search(r"no native token support", security_text, re.IGNORECASE):
+        return [
+            Finding(
+                "error",
+                "token-support",
+                "docs/security.md still contains a 'No Native Token Support' style "
+                "claim. The contract supports multi-token matches via "
+                "create_match_with_conversion (contracts/escrow/src/lib.rs) — this "
+                "claim is stale.",
+            )
+        ]
+    return []
+
+
+def check_annotations(repo_root: Path, doc_paths: list[Path]) -> list[Finding]:
+    findings = []
+    for doc_path in doc_paths:
+        text = doc_path.read_text()
+        for m in ANNOTATION_RE.finditer(text):
+            cited_path = repo_root / m.group("path")
+            cited_line_no = int(m.group("line"))
+            expected_hash = m.group("hash")
+            rel_doc = doc_path.relative_to(repo_root)
+            if not cited_path.is_file():
+                findings.append(
+                    Finding(
+                        "error",
+                        "annotations",
+                        f"{rel_doc}: annotation cites missing file "
+                        f"'{m.group('path')}'.",
+                    )
+                )
+                continue
+            lines = cited_path.read_text().splitlines()
+            if not (1 <= cited_line_no <= len(lines)):
+                findings.append(
+                    Finding(
+                        "error",
+                        "annotations",
+                        f"{rel_doc}: annotation cites {m.group('path')}:"
+                        f"{cited_line_no}, which is out of range "
+                        f"(file has {len(lines)} lines).",
+                    )
+                )
+                continue
+            actual_hash = line_hash(lines[cited_line_no - 1])
+            if actual_hash != expected_hash:
+                findings.append(
+                    Finding(
+                        "error",
+                        "annotations",
+                        f"{rel_doc}: content at {m.group('path')}:{cited_line_no} "
+                        "has changed since this annotation was verified "
+                        f"(expected sha256={expected_hash}, got {actual_hash}). "
+                        "Re-verify the doc claim and update the annotation's hash.",
+                    )
+                )
+    return findings
+
+
+def check_formal_spec_cross_reference(
+    facts: ContractFacts, repo_root: Path
+) -> list[Finding]:
+    findings = []
+    spec_path = repo_root / "contracts/escrow/formal_spec.json"
+    if not spec_path.is_file():
+        return [
+            Finding(
+                "error",
+                "formal-spec",
+                "contracts/escrow/formal_spec.json not found; the state-machine "
+                "cross-reference check (see the related state-machine-"
+                "verification effort) cannot run.",
+            )
+        ]
+    try:
+        spec = json.loads(spec_path.read_text())
+    except json.JSONDecodeError as e:
+        return [
+            Finding(
+                "error", "formal-spec", f"formal_spec.json is not valid JSON: {e}"
+            )
+        ]
+
+    spec_states = {s["state"] for s in spec.get("match_states", [])}
+    code_states = set(facts.match_states)
+    missing_in_spec = code_states - spec_states
+    extra_in_spec = spec_states - code_states
+    if missing_in_spec:
+        findings.append(
+            Finding(
+                "error",
+                "formal-spec",
+                f"MatchState variant(s) {sorted(missing_in_spec)} exist in "
+                "contracts/escrow/src/types.rs but are missing from "
+                "formal_spec.json's match_states.",
+            )
+        )
+    if extra_in_spec:
+        findings.append(
+            Finding(
+                "error",
+                "formal-spec",
+                f"formal_spec.json's match_states lists {sorted(extra_in_spec)}, "
+                "which no longer exist as MatchState variants in "
+                "contracts/escrow/src/types.rs.",
+            )
+        )
+
+    for ep in spec.get("entry_points", []):
+        name = ep.get("name")
+        if name and name not in facts.escrow_fns:
+            findings.append(
+                Finding(
+                    "error",
+                    "formal-spec",
+                    f"formal_spec.json entry_points references '{name}', which is "
+                    "not a public function on EscrowContract.",
+                )
+            )
+    return findings
+
+
+def run(repo_root: Path) -> list[Finding]:
+    facts = load_contract_facts(repo_root)
+
+    architecture_path = repo_root / "docs/architecture.md"
+    security_path = repo_root / "docs/security.md"
+    oracle_path = repo_root / "docs/oracle.md"
+
+    architecture_text = architecture_path.read_text()
+    security_text = security_path.read_text()
+    oracle_text = oracle_path.read_text()
+
+    findings: list[Finding] = []
+    findings += check_match_states(facts, architecture_text)
+    findings += check_match_struct_fields(facts, architecture_text)
+    findings += check_function_coverage(
+        facts.escrow_fns,
+        architecture_text,
+        doc_name="docs/architecture.md",
+        contract_name="EscrowContract",
+    )
+    findings += check_function_coverage(
+        facts.oracle_fns,
+        oracle_text + architecture_text,
+        doc_name="docs/oracle.md (or docs/architecture.md)",
+        contract_name="OracleContract",
+    )
+    findings += check_timeout_bounds(facts, security_text)
+    findings += check_native_token_claim(security_text)
+    findings += check_annotations(
+        repo_root,
+        [architecture_path, security_path, oracle_path, repo_root / "docs/roadmap.md"],
+    )
+    findings += check_formal_spec_cross_reference(facts, repo_root)
+    return findings
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=Path(__file__).resolve().parents[2],
+        help="Repository root (default: inferred from this script's location).",
+    )
+    parser.add_argument(
+        "--json", action="store_true", help="Emit findings as JSON instead of text."
+    )
+    args = parser.parse_args()
+
+    findings = run(args.repo_root)
+    errors = [f for f in findings if f.severity == "error"]
+
+    if args.json:
+        print(
+            json.dumps(
+                [f.__dict__ for f in findings],
+                indent=2,
+            )
+        )
+    else:
+        if not findings:
+            print("doc-conformance: OK — no drift detected.")
+        for f in findings:
+            print(f"[{f.severity.upper()}] ({f.check}) {f.message}")
+        print(
+            f"\ndoc-conformance: {len(errors)} error(s), "
+            f"{len(findings) - len(errors)} warning(s)."
+        )
+
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/doc_conformance/extract_facts.py
+++ b/scripts/doc_conformance/extract_facts.py
@@ -1,0 +1,179 @@
+"""Extract machine-checkable facts from the escrow/oracle contract source.
+
+This module intentionally uses lightweight regex/scanning instead of a full
+Rust parser (no `syn` dependency is available to a plain `python3` CI step).
+It is deliberately narrow: it extracts only the handful of fact classes the
+doc-conformance checker (`check.py`) needs — enum variants, struct fields,
+public function signatures, and named integer constants — from the specific
+files this repo's docs make claims about.
+
+If contract source is refactored in a way this scanner can't follow (e.g. a
+function signature spanning unusual formatting), `check.py` will surface a
+missing-fact error rather than silently skipping the check.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+@dataclass
+class FnSig:
+    name: str
+    params: str
+    returns: str
+
+
+@dataclass
+class ContractFacts:
+    match_states: list[str] = field(default_factory=list)
+    match_fields: list[str] = field(default_factory=list)
+    dispute_state_variants: list[str] = field(default_factory=list)
+    dispute_fields: list[str] = field(default_factory=list)
+    snapshot_reason_variants: list[str] = field(default_factory=list)
+    player_tier_variants: list[str] = field(default_factory=list)
+    escrow_fns: dict[str, FnSig] = field(default_factory=dict)
+    oracle_fns: dict[str, FnSig] = field(default_factory=dict)
+    timeout_min: int | None = None
+    timeout_max: int | None = None
+    timeout_default_expr: str | None = None
+
+
+def _strip_line_comments(src: str) -> str:
+    # Good enough for this codebase: no `//` appears inside string/char
+    # literals in the const/enum/struct/fn regions we scan.
+    return re.sub(r"//[^\n]*", "", src)
+
+
+def extract_enum_variants(src: str, enum_name: str) -> list[str]:
+    src = _strip_line_comments(src)
+    m = re.search(rf"\benum\s+{re.escape(enum_name)}\s*\{{", src)
+    if not m:
+        raise ValueError(f"enum {enum_name} not found")
+    start = m.end()
+    depth = 1
+    i = start
+    while depth > 0:
+        if src[i] == "{":
+            depth += 1
+        elif src[i] == "}":
+            depth -= 1
+        i += 1
+    body = src[start : i - 1]
+    variants = []
+    for raw_line in body.split(","):
+        line = raw_line.strip()
+        if not line:
+            continue
+        ident = re.match(r"([A-Za-z_][A-Za-z0-9_]*)", line)
+        if ident:
+            variants.append(ident.group(1))
+    return variants
+
+
+def extract_struct_fields(src: str, struct_name: str) -> list[str]:
+    src = _strip_line_comments(src)
+    m = re.search(rf"\bstruct\s+{re.escape(struct_name)}\s*\{{", src)
+    if not m:
+        raise ValueError(f"struct {struct_name} not found")
+    start = m.end()
+    depth = 1
+    i = start
+    while depth > 0:
+        if src[i] == "{":
+            depth += 1
+        elif src[i] == "}":
+            depth -= 1
+        i += 1
+    body = src[start : i - 1]
+    fields = []
+    for raw_line in body.split(","):
+        line = raw_line.strip()
+        if not line:
+            continue
+        m2 = re.match(r"pub\s+([A-Za-z_][A-Za-z0-9_]*)\s*:", line)
+        if m2:
+            fields.append(m2.group(1))
+    return fields
+
+
+def extract_pub_fns(src: str, *, impl_only: bool = True) -> dict[str, FnSig]:
+    """Extract `pub fn name(params) -> ret` signatures.
+
+    When `impl_only` is True, restricts extraction to the body of the first
+    `impl ... { ... }` block found (the contract's `#[contractimpl] impl`),
+    so free functions / test helpers elsewhere in the file are excluded.
+    """
+    src = _strip_line_comments(src)
+
+    if impl_only:
+        m = re.search(r"\bimpl\s+\w+\s*\{", src)
+        if not m:
+            raise ValueError("no impl block found")
+        start = m.end()
+        depth = 1
+        i = start
+        while depth > 0:
+            if src[i] == "{":
+                depth += 1
+            elif src[i] == "}":
+                depth -= 1
+            i += 1
+        src = src[start : i - 1]
+
+    fns: dict[str, FnSig] = {}
+    for m in re.finditer(r"pub fn\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(", src):
+        name = m.group(1)
+        paren_start = m.end() - 1
+        depth = 0
+        i = paren_start
+        while True:
+            if src[i] == "(":
+                depth += 1
+            elif src[i] == ")":
+                depth -= 1
+                if depth == 0:
+                    break
+            i += 1
+        params = src[paren_start + 1 : i]
+        rest = src[i + 1 :]
+        brace_idx = rest.index("{")
+        header_tail = rest[:brace_idx]
+        returns = ""
+        if "->" in header_tail:
+            returns = header_tail.split("->", 1)[1].strip()
+        fns[name] = FnSig(name=name, params=params.strip(), returns=returns)
+    return fns
+
+
+def extract_u32_const(src: str, const_name: str) -> int:
+    src = _strip_line_comments(src)
+    m = re.search(
+        rf"const\s+{re.escape(const_name)}\s*:\s*u32\s*=\s*([0-9_]+)\s*;", src
+    )
+    if not m:
+        raise ValueError(f"const {const_name} not found (or not a literal u32)")
+    return int(m.group(1).replace("_", ""))
+
+
+def load_contract_facts(repo_root: Path) -> ContractFacts:
+    escrow_lib = (repo_root / "contracts/escrow/src/lib.rs").read_text()
+    escrow_types = (repo_root / "contracts/escrow/src/types.rs").read_text()
+    oracle_lib = (repo_root / "contracts/oracle/src/lib.rs").read_text()
+
+    facts = ContractFacts()
+    facts.match_states = extract_enum_variants(escrow_types, "MatchState")
+    facts.match_fields = extract_struct_fields(escrow_types, "Match")
+    facts.dispute_state_variants = extract_enum_variants(escrow_types, "DisputeState")
+    facts.dispute_fields = extract_struct_fields(escrow_types, "Dispute")
+    facts.snapshot_reason_variants = extract_enum_variants(
+        escrow_types, "SnapshotReason"
+    )
+    facts.player_tier_variants = extract_enum_variants(escrow_types, "PlayerTier")
+    facts.escrow_fns = extract_pub_fns(escrow_lib)
+    facts.oracle_fns = extract_pub_fns(oracle_lib)
+    facts.timeout_min = extract_u32_const(escrow_lib, "MIN_MATCH_TIMEOUT_LEDGERS")
+    facts.timeout_max = extract_u32_const(escrow_lib, "MAX_MATCH_TIMEOUT_LEDGERS")
+    return facts

--- a/scripts/doc_conformance/tests/fixtures/good_repo/contracts/escrow/formal_spec.json
+++ b/scripts/doc_conformance/tests/fixtures/good_repo/contracts/escrow/formal_spec.json
@@ -1,0 +1,15 @@
+{
+  "contract": "EscrowContract",
+  "version": "1.0",
+  "match_states": [
+    {"state": "Pending", "reachable_from": ["*"], "terminal": false},
+    {"state": "Active", "reachable_from": ["Pending"], "terminal": false},
+    {"state": "Completed", "reachable_from": ["Active"], "terminal": true},
+    {"state": "Cancelled", "reachable_from": ["Pending"], "terminal": true}
+  ],
+  "entry_points": [
+    {"name": "create_match", "state_transition": "N/A -> Pending"},
+    {"name": "get_match", "state_transition": "none"},
+    {"name": "set_match_timeout", "state_transition": "none"}
+  ]
+}

--- a/scripts/doc_conformance/tests/fixtures/good_repo/contracts/escrow/src/lib.rs
+++ b/scripts/doc_conformance/tests/fixtures/good_repo/contracts/escrow/src/lib.rs
@@ -1,0 +1,29 @@
+#![no_std]
+
+pub mod types;
+
+use types::{Match, MatchState};
+use soroban_sdk::{Address, Env};
+
+/// Minimum match timeout: 1 day (17,280 ledgers at 5s/ledger).
+pub const MIN_MATCH_TIMEOUT_LEDGERS: u32 = 17_280;
+
+/// Maximum match timeout: 90 days (1,555,200 ledgers at 5s/ledger).
+pub const MAX_MATCH_TIMEOUT_LEDGERS: u32 = 1_555_200;
+
+#[contract]
+pub struct EscrowContract;
+
+impl EscrowContract {
+    pub fn create_match(env: Env, player1: Address, player2: Address, stake_amount: i128) -> u64 {
+        0
+    }
+
+    pub fn get_match(env: Env, match_id: u64) -> Match {
+        unimplemented!()
+    }
+
+    pub fn set_match_timeout(env: Env, timeout: u32) -> Result<(), u32> {
+        Ok(())
+    }
+}

--- a/scripts/doc_conformance/tests/fixtures/good_repo/contracts/escrow/src/types.rs
+++ b/scripts/doc_conformance/tests/fixtures/good_repo/contracts/escrow/src/types.rs
@@ -1,0 +1,53 @@
+use soroban_sdk::{contracttype, Address, String};
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum MatchState {
+    Pending,
+    Active,
+    Completed,
+    Cancelled,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum DisputeState {
+    Active,
+    ResolvedUpheld,
+    ResolvedOverturned,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum SnapshotReason {
+    Created,
+    Completed,
+    Cancelled,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum PlayerTier {
+    Bronze,
+    Silver,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct Match {
+    pub id: u64,
+    pub player1: Address,
+    pub player2: Address,
+    pub stake_amount: i128,
+    pub state: MatchState,
+    pub player1_deposited: bool,
+    pub player2_deposited: bool,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct Dispute {
+    pub id: u64,
+    pub match_id: u64,
+    pub state: DisputeState,
+}

--- a/scripts/doc_conformance/tests/fixtures/good_repo/contracts/oracle/src/lib.rs
+++ b/scripts/doc_conformance/tests/fixtures/good_repo/contracts/oracle/src/lib.rs
@@ -1,0 +1,16 @@
+#![no_std]
+
+use soroban_sdk::{Address, Env};
+
+#[contract]
+pub struct OracleContract;
+
+impl OracleContract {
+    pub fn submit_result(env: Env, match_id: u64) -> Result<(), u32> {
+        Ok(())
+    }
+
+    pub fn get_result(env: Env, match_id: u64) -> u32 {
+        0
+    }
+}

--- a/scripts/doc_conformance/tests/fixtures/good_repo/docs/architecture.md
+++ b/scripts/doc_conformance/tests/fixtures/good_repo/docs/architecture.md
@@ -1,0 +1,39 @@
+# Architecture (fixture)
+
+## Match States
+
+| State | Terminal |
+|-------|----------|
+| `Pending` | No |
+| `Active` | No |
+| `Completed` | Yes |
+| `Cancelled` | Yes |
+
+## Transition Table
+
+| From | To | Entry Point |
+|------|----|--------------|
+| N/A | `Pending` | `create_match` |
+| `Pending` | `Active` | `deposit` |
+| `Active` | `Completed` | `submit_result` |
+| `Pending` | `Cancelled` | `cancel_match` |
+
+### `Match` Struct
+
+| Field | Type | Description |
+|-------|------|--------------|
+| `id` | `u64` | Match id. |
+| `player1` | `Address` | Player 1. |
+| `player2` | `Address` | Player 2. |
+| `stake_amount` | `i128` | Stake. |
+| `state` | `MatchState` | State. |
+
+> Internal fields — `player1_deposited` and `player2_deposited` are internal bookkeeping.
+
+### Contract Functions
+
+| Function | Signature | Description |
+|----------|-----------|--------------|
+| `create_match` | `(...)` | Creates a match. |
+| `get_match` | `(...)` | Gets a match. |
+| `set_match_timeout` | `(...)` | Sets timeout. |

--- a/scripts/doc_conformance/tests/fixtures/good_repo/docs/oracle.md
+++ b/scripts/doc_conformance/tests/fixtures/good_repo/docs/oracle.md
@@ -1,0 +1,6 @@
+# Oracle (fixture)
+
+| Function | Description |
+|----------|-------------|
+| `submit_result` | Submits a result. |
+| `get_result` | Gets a result. |

--- a/scripts/doc_conformance/tests/fixtures/good_repo/docs/roadmap.md
+++ b/scripts/doc_conformance/tests/fixtures/good_repo/docs/roadmap.md
@@ -1,0 +1,3 @@
+# Roadmap (fixture)
+
+Nothing to see here.

--- a/scripts/doc_conformance/tests/fixtures/good_repo/docs/security.md
+++ b/scripts/doc_conformance/tests/fixtures/good_repo/docs/security.md
@@ -1,0 +1,7 @@
+# Security (fixture)
+
+<!-- doc-conformance: verified path=contracts/escrow/src/lib.rs line=9 sha256=bbaa55f15d653c0614ce3d2f144a8394ca8a5b59215f0a4d279ed2e9d99e7a15 -->
+
+Match timeout is configurable in the range 17,280 to 1,555,200 ledgers via `set_match_timeout`.
+
+Multi-token matches are supported via `create_match_with_conversion`.

--- a/scripts/doc_conformance/tests/test_check.py
+++ b/scripts/doc_conformance/tests/test_check.py
@@ -1,0 +1,230 @@
+"""Self-tests for the doc-conformance checker.
+
+Run with:
+    python3 -m unittest discover -s scripts/doc_conformance/tests -v
+
+Uses a small synthetic fixture repo (fixtures/good_repo) rather than this
+repo's real docs/contracts, so these tests stay fast, hermetic, and stable
+regardless of future edits to the real docs. `test_good_repo_passes` is the
+negative control (baseline must be clean); every `test_drift_*` is a
+positive control proving the checker actually flags a deliberately
+introduced class of drift, per the requirement in issue #1067 that the
+conformance checker be proven to catch drift, not just assumed to.
+"""
+
+from __future__ import annotations
+
+import shutil
+import sys
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+import check  # noqa: E402
+
+FIXTURES = Path(__file__).resolve().parent / "fixtures"
+GOOD_REPO = FIXTURES / "good_repo"
+
+
+class DriftFixture:
+    """Copies fixtures/good_repo into a temp dir, optionally mutated."""
+
+    def __init__(self, mutate=None):
+        self._tmp = TemporaryDirectory()
+        self.root = Path(self._tmp.name) / "repo"
+        shutil.copytree(GOOD_REPO, self.root)
+        if mutate:
+            mutate(self.root)
+
+    def cleanup(self):
+        self._tmp.cleanup()
+
+    def errors(self):
+        return [f for f in check.run(self.root) if f.severity == "error"]
+
+
+def _replace(path: Path, old: str, new: str):
+    text = path.read_text()
+    assert old in text, f"fixture setup error: {old!r} not found in {path}"
+    path.write_text(text.replace(old, new))
+
+
+class TestGoodRepoPasses(unittest.TestCase):
+    """Negative control: the clean fixture must produce zero error findings."""
+
+    def test_no_errors(self):
+        fx = DriftFixture()
+        try:
+            errors = fx.errors()
+            self.assertEqual(
+                errors, [], f"expected no errors on clean fixture, got: {errors}"
+            )
+        finally:
+            fx.cleanup()
+
+
+class TestPositiveControls(unittest.TestCase):
+    """Each test introduces exactly one class of drift and asserts it's caught."""
+
+    def test_missing_match_state_variant_detected(self):
+        def mutate(root: Path):
+            # Drop `Cancelled` down to a single mention in architecture.md,
+            # simulating a doc that never got updated after a new terminal
+            # state was reviewed into the contract.
+            _replace(
+                root / "docs/architecture.md",
+                "| `Pending` | `Cancelled` | `cancel_match` |\n",
+                "",
+            )
+
+        fx = DriftFixture(mutate)
+        try:
+            errors = fx.errors()
+            self.assertTrue(
+                any(e.check == "match-states" and "Cancelled" in e.message for e in errors),
+                f"expected a match-states finding about Cancelled, got: {errors}",
+            )
+        finally:
+            fx.cleanup()
+
+    def test_undocumented_match_field_detected(self):
+        def mutate(root: Path):
+            # Add a new field to the Match struct without touching docs —
+            # this is exactly the "field added, docs not updated" drift
+            # class described in issue #1067.
+            _replace(
+                root / "contracts/escrow/src/types.rs",
+                "    pub state: MatchState,\n",
+                "    pub state: MatchState,\n    pub token_b: Option<Address>,\n",
+            )
+
+        fx = DriftFixture(mutate)
+        try:
+            errors = fx.errors()
+            self.assertTrue(
+                any(e.check == "match-fields" and "token_b" in e.message for e in errors),
+                f"expected a match-fields finding about token_b, got: {errors}",
+            )
+        finally:
+            fx.cleanup()
+
+    def test_undocumented_new_function_detected(self):
+        def mutate(root: Path):
+            _replace(
+                root / "contracts/escrow/src/lib.rs",
+                "    pub fn set_match_timeout(env: Env, timeout: u32) -> Result<(), u32> {\n        Ok(())\n    }\n",
+                "    pub fn set_match_timeout(env: Env, timeout: u32) -> Result<(), u32> {\n        Ok(())\n    }\n\n"
+                "    pub fn undocumented_new_fn(env: Env) -> u32 {\n        0\n    }\n",
+            )
+
+        fx = DriftFixture(mutate)
+        try:
+            errors = fx.errors()
+            self.assertTrue(
+                any(
+                    e.check == "function-coverage" and "undocumented_new_fn" in e.message
+                    for e in errors
+                ),
+                f"expected a function-coverage finding, got: {errors}",
+            )
+        finally:
+            fx.cleanup()
+
+    def test_stale_hardcoded_timeout_claim_detected(self):
+        def mutate(root: Path):
+            _replace(
+                root / "docs/security.md",
+                "Match timeout is configurable in the range 17,280 to 1,555,200 ledgers via `set_match_timeout`.",
+                "Match expiration timeout is hardcoded (~24 hours).",
+            )
+
+        fx = DriftFixture(mutate)
+        try:
+            errors = fx.errors()
+            self.assertTrue(
+                any(e.check == "timeout-bounds" for e in errors),
+                f"expected a timeout-bounds finding, got: {errors}",
+            )
+        finally:
+            fx.cleanup()
+
+    def test_stale_no_native_token_claim_detected(self):
+        def mutate(root: Path):
+            _replace(
+                root / "docs/security.md",
+                "Multi-token matches are supported via `create_match_with_conversion`.",
+                "No Native Token Support: only XLM and USDC are supported.",
+            )
+
+        fx = DriftFixture(mutate)
+        try:
+            errors = fx.errors()
+            self.assertTrue(
+                any(e.check == "token-support" for e in errors),
+                f"expected a token-support finding, got: {errors}",
+            )
+        finally:
+            fx.cleanup()
+
+    def test_stale_annotation_hash_detected(self):
+        def mutate(root: Path):
+            # Change the annotated source line's value without re-verifying
+            # the doc claim — the annotation's recorded hash goes stale.
+            _replace(
+                root / "contracts/escrow/src/lib.rs",
+                "pub const MIN_MATCH_TIMEOUT_LEDGERS: u32 = 17_280;",
+                "pub const MIN_MATCH_TIMEOUT_LEDGERS: u32 = 8_640;",
+            )
+
+        fx = DriftFixture(mutate)
+        try:
+            errors = fx.errors()
+            self.assertTrue(
+                any(e.check == "annotations" for e in errors),
+                f"expected an annotations finding, got: {errors}",
+            )
+        finally:
+            fx.cleanup()
+
+    def test_formal_spec_state_drift_detected(self):
+        def mutate(root: Path):
+            _replace(
+                root / "contracts/escrow/formal_spec.json",
+                '{"state": "Cancelled", "reachable_from": ["Pending"], "terminal": true}',
+                '{"state": "Cancelled", "reachable_from": ["Pending"], "terminal": true},\n'
+                '    {"state": "Paused", "reachable_from": ["Active"], "terminal": false}',
+            )
+
+        fx = DriftFixture(mutate)
+        try:
+            errors = fx.errors()
+            self.assertTrue(
+                any(e.check == "formal-spec" and "Paused" in e.message for e in errors),
+                f"expected a formal-spec finding about Paused, got: {errors}",
+            )
+        finally:
+            fx.cleanup()
+
+    def test_formal_spec_unknown_entry_point_detected(self):
+        def mutate(root: Path):
+            _replace(
+                root / "contracts/escrow/formal_spec.json",
+                '{"name": "get_match", "state_transition": "none"}',
+                '{"name": "get_match", "state_transition": "none"},\n'
+                '    {"name": "nonexistent_fn", "state_transition": "none"}',
+            )
+
+        fx = DriftFixture(mutate)
+        try:
+            errors = fx.errors()
+            self.assertTrue(
+                any(e.check == "formal-spec" and "nonexistent_fn" in e.message for e in errors),
+                f"expected a formal-spec finding about nonexistent_fn, got: {errors}",
+            )
+        finally:
+            fx.cleanup()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/require_doc_update.sh
+++ b/scripts/require_doc_update.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Fails if a PR modifies the escrow/oracle contracts' public-interface files
+# without also touching one of the doc-conformance-relevant files. This is
+# the "required CI gate" from issue #1067: it does not check that the docs
+# were updated *correctly* (that's scripts/check_doc_conformance.sh's job),
+# only that a PR touching contract surface didn't skip docs entirely.
+#
+# Usage: require_doc_update.sh <base-ref> <head-ref>
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+  echo "Usage: $0 <base-ref> <head-ref>" >&2
+  exit 2
+fi
+
+BASE_REF="$1"
+HEAD_REF="$2"
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+# Contract files whose public-interface changes must come with a doc update.
+GATED_FILES=(
+  "contracts/escrow/src/lib.rs"
+  "contracts/escrow/src/types.rs"
+  "contracts/oracle/src/lib.rs"
+)
+
+# Any of these counts as "a corresponding doc-conformance update".
+DOC_FILES=(
+  "docs/architecture.md"
+  "docs/security.md"
+  "docs/roadmap.md"
+  "docs/oracle.md"
+  "docs/doc-conformance.md"
+  "contracts/escrow/formal_spec.json"
+)
+
+CHANGED="$(git diff --name-only "$BASE_REF" "$HEAD_REF")"
+
+touches_contract=false
+for f in "${GATED_FILES[@]}"; do
+  if grep -qxF "$f" <<< "$CHANGED"; then
+    touches_contract=true
+    echo "Contract surface changed: $f"
+  fi
+done
+
+if [[ "$touches_contract" == false ]]; then
+  echo "No gated contract files changed; doc-update gate does not apply."
+  exit 0
+fi
+
+touches_docs=false
+for f in "${DOC_FILES[@]}"; do
+  if grep -qxF "$f" <<< "$CHANGED"; then
+    touches_docs=true
+    echo "Doc-conformance file updated: $f"
+  fi
+done
+
+if [[ "$touches_docs" == false ]]; then
+  cat >&2 <<'EOF'
+
+ERROR: This PR modifies a contract's public-interface file
+(contracts/escrow/src/lib.rs, contracts/escrow/src/types.rs, or
+contracts/oracle/src/lib.rs) without touching any doc-conformance file
+(docs/architecture.md, docs/security.md, docs/roadmap.md, docs/oracle.md,
+docs/doc-conformance.md, or contracts/escrow/formal_spec.json).
+
+If your change adds/removes/renames a public function, a MatchState
+variant, a Match/Dispute field, or a configurable-parameter bound, update
+the relevant doc(s) in the same PR. If your change genuinely has no
+doc-visible effect (e.g. an internal refactor with no interface change),
+touch docs/doc-conformance.md with a one-line note explaining why, or ask
+a maintainer to bypass this gate.
+
+See docs/doc-conformance.md for details.
+EOF
+  exit 1
+fi
+
+echo "OK: contract surface change is accompanied by a doc update."

--- a/scripts/test_doc_conformance.sh
+++ b/scripts/test_doc_conformance.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Runs the doc-conformance checker's own self-tests (positive + negative
+# controls proving it actually flags deliberately introduced drift).
+# See docs/doc-conformance.md.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+python3 -m unittest discover -s "$REPO_ROOT/scripts/doc_conformance/tests" -v


### PR DESCRIPTION
Add automated doc-code conformance gate for escrow/oracle contracts

  Closes #1067

  ## Summary
  - Fixed stale claims in docs/security.md (hardcoded ~24h timeout, no
    native token support) to match the real configurable timeout range
    and multi-token support.
  - Expanded docs/architecture.md and docs/oracle.md to cover fields and
    functions that existed in the contracts but were undocumented
    (tiers, disputes, protocol config, balance snapshots, rate limiting,
    conversion rate functions, etc).
  - Fixed a real bug in contracts/escrow/formal_spec.json found while
    cross-referencing it against source: resolve_dispute_by_vote was
    documented as transitioning to Cancelled on an overturned vote; the
    contract always transitions to Completed.
  - Added scripts/doc_conformance/: extracts facts directly from contract
    source (MatchState variants, struct fields, function signatures,
    timeout bounds) and diffs them against the docs. Supports a
    `verified path=... line=... sha256=...` annotation convention for
    claims that can't be auto-extracted.
  - Added a test suite (scripts/doc_conformance/tests/) with 8 positive
    controls proving the checker catches each class of drift, plus a
    negative control on clean docs.
    runs the checker, runs its self-tests, and fails PRs touching
    contracts/escrow/src/{lib,types}.rs or contracts/oracle/src/lib.rs
    without a corresponding doc update.
  - Added docs/doc-conformance.md documenting the system and its
    limitations.
    