### PR TITLE
feat(oracle): genuine m-of-n oracle consensus, load-bearing staking/s…

### DIFF
--- a/contracts/escrow/src/errors.rs
+++ b/contracts/escrow/src/errors.rs
@@ -47,4 +47,5 @@ pub enum Error {
     QuorumNotMet = 42,
     InsufficientHoldingDuration = 43,
     OracleSlashFailed = 44,
+    TooManyActiveMatches = 45,
 }

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -619,7 +619,7 @@ impl EscrowContract {
         let oracle_rate: i128 = env.invoke_contract(
             &oracle_address,
             &Symbol::new(&env, "get_rate"),
-            (&token_a, &token_b),
+            soroban_sdk::vec![&env, token_a.to_val(), token_b.to_val()],
         );
 
         // Verify conversion rate within ±5% of oracle rate

--- a/contracts/escrow/src/types.rs
+++ b/contracts/escrow/src/types.rs
@@ -129,6 +129,12 @@ pub enum DataKey {
     QuorumBasisPoints,
     /// Oracle address implicated by a dispute result (used for automatic slashing).
     DisputeOracle(u64),
+    /// Active match for a player: indexed O(1) removal. Replaces the single ActiveMatches vector.
+    ActiveMatch(Address, u64),
+    /// Count of currently-active matches for a player, capped at MAX_ACTIVE_MATCHES_PER_PLAYER.
+    PlayerActiveMatchCount(Address),
+    /// Cached count of completed matches for a player, updated atomically at completion.
+    PlayerCompletedMatchCount(Address),
 }
 
 /// The lifecycle event that triggered a balance snapshot.

--- a/contracts/oracle/src/errors.rs
+++ b/contracts/oracle/src/errors.rs
@@ -24,4 +24,16 @@ pub enum Error {
     InvalidRateLimit = 10,
     /// The oracle does not have enough staked balance to submit a result.
     InsufficientStake = 11,
+    /// `submit_oracle_result` was called by an address that has never
+    /// registered via `register_oracle_with_stake`.
+    NotRegisteredOracle = 12,
+    /// The match's m-of-n consensus has deadlocked (no remaining eligible
+    /// oracle vote can push any candidate result over the threshold) and is
+    /// awaiting admin resolution via `resolve_disputed_match`.
+    MatchDisputed = 14,
+    /// `set_consensus_threshold` was called with a threshold of 0.
+    InvalidThreshold = 15,
+    /// `resolve_disputed_match` was called for a match that is not in a
+    /// disputed (deadlocked) consensus state.
+    MatchNotDisputed = 16,
 }

--- a/contracts/oracle/src/lib.rs
+++ b/contracts/oracle/src/lib.rs
@@ -8,8 +8,8 @@ use soroban_sdk::{
     contract, contractimpl, symbol_short, token, Address, Env, String, Symbol, Vec,
 };
 use types::{
-    BatchResultEntry, DataKey, OracleRegistration, Platform, RateLimitConfig, RateLimitStatus,
-    RateWindow, ResultEntry, Winner,
+    BatchResultEntry, CandidateTally, ConsensusState, DataKey, OracleRegistration,
+    OracleVoteRecord, Platform, RateLimitConfig, RateLimitStatus, RateWindow, ResultEntry, Winner,
 };
 
 /// Maximum number of entries accepted in a single batch submission.
@@ -35,6 +35,25 @@ const RATE_LIMIT_ALERT_THRESHOLD_PCT: u64 = 80;
 /// TTL for rate-limit window storage: ~2 days at 5s/ledger, comfortably longer
 /// than the daily window so counters never expire mid-window.
 const RATE_LIMIT_TTL_LEDGERS: u32 = 34_560;
+
+/// Default m-of-n consensus threshold: a single matching submission finalizes
+/// a result. This is the degenerate n=1 configuration that reproduces the
+/// original single-admin-oracle deployment via `submit_oracle_result`.
+const DEFAULT_CONSENSUS_THRESHOLD: u32 = 1;
+
+/// Basis points of an oracle's remaining stake slashed automatically when it
+/// is caught equivocating (submitting two conflicting results for the same
+/// match_id). Equivocation is unambiguous and provable on-chain, so it is
+/// slashed at the maximum: the oracle's entire remaining stake.
+const EQUIVOCATION_SLASH_BPS: i128 = 10_000;
+
+/// Basis points of an oracle's remaining stake automatically slashed when its
+/// submission ends up on the losing side of a finalized consensus vote (a
+/// minority result contradicted by a threshold-strong majority), or on the
+/// losing side of an admin's resolution of a deadlocked (disputed) match.
+/// Lower than the equivocation penalty because being outvoted can reflect an
+/// honest disagreement (e.g. a stale platform API read) rather than malice.
+const MINORITY_SLASH_BPS: i128 = 1_000;
 
 /// Extend instance storage TTL on every invocation so Admin and Paused never expire.
 fn extend_instance_ttl(env: &Env) {
@@ -88,6 +107,18 @@ impl OracleContract {
                 token: token.clone(),
             },
         );
+
+        let mut oracle_set: Vec<Address> = env
+            .storage()
+            .instance()
+            .get(&DataKey::OracleSet)
+            .unwrap_or(Vec::new(&env));
+        if !oracle_set.contains(&oracle_address) {
+            oracle_set.push_back(oracle_address.clone());
+            env.storage()
+                .instance()
+                .set(&DataKey::OracleSet, &oracle_set);
+        }
 
         env.events().publish(
             (Symbol::new(&env, "oracle"), symbol_short!("stake")),
@@ -321,6 +352,485 @@ impl OracleContract {
         );
 
         Ok(())
+    }
+
+    /// Submit a match result as one vote in an m-of-n oracle consensus.
+    ///
+    /// Unlike [`submit_result`], which is gated by admin auth alone, this is
+    /// the genuine multi-oracle path: any address independently registered
+    /// via [`register_oracle_with_stake`] with a positive stake may call this
+    /// directly (it authenticates itself, not the admin). A match result is
+    /// finalized into [`get_result`]-visible storage only once a candidate
+    /// (game_id, platform, result) has been submitted by at least
+    /// [`get_consensus_threshold`] distinct registered oracles.
+    ///
+    /// With the default threshold of 1, a single registered oracle's
+    /// submission finalizes immediately — the degenerate n=1 configuration
+    /// that mirrors the original single-admin-oracle deployment.
+    ///
+    /// # Disagreement handling
+    /// - If a submission's (game_id, platform, result) doesn't yet have
+    ///   enough matching votes, it is recorded and the match stays pending.
+    /// - If a candidate reaches the threshold, it is finalized and every
+    ///   oracle that had already voted for a *different* candidate for this
+    ///   match is automatically slashed [`MINORITY_SLASH_BPS`] of its
+    ///   remaining stake — majority wins, minority is slashed.
+    /// - If votes split enough that no remaining eligible oracle could still
+    ///   push any candidate over the threshold (a deadlock), the match is
+    ///   flagged disputed and awaits admin resolution via
+    ///   [`resolve_disputed_match`].
+    /// - If the same oracle submits two different candidates for the same
+    ///   match (equivocation), the vote is discarded and the oracle's entire
+    ///   remaining stake is slashed immediately. This case returns `Ok(())`
+    ///   rather than an error — a contract call that returns `Err` reverts
+    ///   every storage write made during it, which would undo the slash. The
+    ///   caller detects it via the `oracle/equivoc` event.
+    ///
+    /// # Errors
+    /// - [`Error::ContractPaused`] — contract is paused.
+    /// - [`Error::Unauthorized`] — contract has not been initialized.
+    /// - [`Error::InvalidGameId`] — `game_id` is empty.
+    /// - [`Error::NotRegisteredOracle`] — `oracle` has never registered stake.
+    /// - [`Error::InsufficientStake`] — `oracle`'s stake has been slashed to zero.
+    /// - [`Error::AlreadySubmitted`] — the match is already finalized, or this
+    ///   oracle already cast this exact vote.
+    /// - [`Error::RateLimitExceeded`] — `oracle` has exceeded its submission quota.
+    /// - [`Error::MatchDisputed`] — the match has already deadlocked and is
+    ///   awaiting admin resolution.
+    pub fn submit_oracle_result(
+        env: Env,
+        oracle: Address,
+        match_id: u64,
+        game_id: String,
+        platform: Platform,
+        result: Winner,
+    ) -> Result<(), Error> {
+        extend_instance_ttl(&env);
+
+        if env
+            .storage()
+            .instance()
+            .get(&DataKey::Paused)
+            .unwrap_or(false)
+        {
+            return Err(Error::ContractPaused);
+        }
+
+        if !env.storage().instance().has(&DataKey::Admin) {
+            return Err(Error::Unauthorized);
+        }
+
+        oracle.require_auth();
+
+        if game_id.is_empty() {
+            return Err(Error::InvalidGameId);
+        }
+
+        let registration: OracleRegistration = env
+            .storage()
+            .instance()
+            .get(&DataKey::OracleRegistration(oracle.clone()))
+            .ok_or(Error::NotRegisteredOracle)?;
+        if registration.oracle_stake <= 0 {
+            return Err(Error::InsufficientStake);
+        }
+
+        if env.storage().persistent().has(&DataKey::Result(match_id)) {
+            return Err(Error::AlreadySubmitted);
+        }
+
+        Self::check_oracle_rate_limit(&env, &oracle, 1)?;
+
+        let vote_key = DataKey::OracleVote(match_id, oracle.clone());
+        let vote = OracleVoteRecord {
+            game_id: game_id.clone(),
+            platform: platform.clone(),
+            result: result.clone(),
+        };
+        if let Some(prev) = env
+            .storage()
+            .persistent()
+            .get::<_, OracleVoteRecord>(&vote_key)
+        {
+            if prev == vote {
+                return Err(Error::AlreadySubmitted);
+            }
+            // A contract call that returns `Err` reverts *all* storage writes
+            // made during the call, including the slash below — so proven
+            // equivocation must return `Ok` for the penalty to actually
+            // commit. Callers detect it via the `oracle/equivoc` event (and
+            // the resulting drop in the oracle's stake) rather than an error.
+            Self::slash_bps(&env, &oracle, EQUIVOCATION_SLASH_BPS);
+            env.events().publish(
+                (Symbol::new(&env, "oracle"), symbol_short!("equivoc")),
+                (match_id, oracle),
+            );
+            return Ok(());
+        }
+
+        let mut state: ConsensusState = env
+            .storage()
+            .persistent()
+            .get(&DataKey::MatchVotes(match_id))
+            .unwrap_or(ConsensusState {
+                candidates: Vec::new(&env),
+                disputed: false,
+            });
+
+        if state.disputed {
+            return Err(Error::MatchDisputed);
+        }
+
+        env.storage().persistent().set(&vote_key, &vote);
+        env.storage()
+            .persistent()
+            .extend_ttl(&vote_key, MATCH_TTL_LEDGERS, MATCH_TTL_LEDGERS);
+
+        let threshold = Self::consensus_threshold(&env);
+        let mut winning_idx: Option<u32> = None;
+        let mut found_existing = false;
+
+        for i in 0..state.candidates.len() {
+            let mut candidate = state.candidates.get(i).unwrap();
+            if candidate.result == result
+                && candidate.platform == platform
+                && candidate.game_id == game_id
+            {
+                candidate.submitters.push_back(oracle.clone());
+                if candidate.submitters.len() >= threshold {
+                    winning_idx = Some(i);
+                }
+                state.candidates.set(i, candidate);
+                found_existing = true;
+                break;
+            }
+        }
+
+        if !found_existing {
+            let mut submitters = Vec::new(&env);
+            submitters.push_back(oracle.clone());
+            let reached = submitters.len() >= threshold;
+            let idx = state.candidates.len();
+            state.candidates.push_back(CandidateTally {
+                game_id: game_id.clone(),
+                platform: platform.clone(),
+                result: result.clone(),
+                submitters,
+            });
+            if reached {
+                winning_idx = Some(idx);
+            }
+        }
+
+        if let Some(idx) = winning_idx {
+            let winning = state.candidates.get(idx).unwrap();
+
+            env.storage().persistent().set(
+                &DataKey::Result(match_id),
+                &ResultEntry {
+                    game_id: winning.game_id.clone(),
+                    platform: winning.platform.clone(),
+                    result: winning.result.clone(),
+                    submitted_ledger: env.ledger().sequence(),
+                    submitter: oracle,
+                },
+            );
+            env.storage().persistent().extend_ttl(
+                &DataKey::Result(match_id),
+                MATCH_TTL_LEDGERS,
+                MATCH_TTL_LEDGERS,
+            );
+
+            // Majority wins, minority is slashed: every oracle that voted for
+            // a losing candidate is automatically penalized.
+            for i in 0..state.candidates.len() {
+                if i == idx {
+                    continue;
+                }
+                let losing = state.candidates.get(i).unwrap();
+                for j in 0..losing.submitters.len() {
+                    let minority_oracle = losing.submitters.get(j).unwrap();
+                    Self::slash_bps(&env, &minority_oracle, MINORITY_SLASH_BPS);
+                    env.events().publish(
+                        (Symbol::new(&env, "oracle"), symbol_short!("minority")),
+                        (match_id, minority_oracle),
+                    );
+                }
+            }
+
+            env.storage()
+                .persistent()
+                .remove(&DataKey::MatchVotes(match_id));
+
+            env.events().publish(
+                (Symbol::new(&env, "oracle"), symbol_short!("result")),
+                (match_id, winning.result),
+            );
+            env.events().publish(
+                (Symbol::new(&env, "oracle"), symbol_short!("finalzd")),
+                (match_id, winning.submitters.len(), threshold),
+            );
+        } else {
+            let remaining = Self::remaining_eligible_oracles(&env, match_id);
+            let mut still_possible = false;
+            for i in 0..state.candidates.len() {
+                let candidate = state.candidates.get(i).unwrap();
+                if candidate.submitters.len().saturating_add(remaining) >= threshold {
+                    still_possible = true;
+                    break;
+                }
+            }
+
+            if !still_possible {
+                state.disputed = true;
+                env.events().publish(
+                    (Symbol::new(&env, "oracle"), symbol_short!("disputed")),
+                    match_id,
+                );
+            }
+
+            env.storage()
+                .persistent()
+                .set(&DataKey::MatchVotes(match_id), &state);
+            env.storage().persistent().extend_ttl(
+                &DataKey::MatchVotes(match_id),
+                MATCH_TTL_LEDGERS,
+                MATCH_TTL_LEDGERS,
+            );
+
+            env.events().publish(
+                (Symbol::new(&env, "oracle"), symbol_short!("vote")),
+                (match_id, oracle, result),
+            );
+        }
+
+        Ok(())
+    }
+
+    /// Admin resolves a match whose m-of-n consensus deadlocked (see
+    /// [`submit_oracle_result`]): no remaining eligible oracle vote could
+    /// still push any candidate result over the configured threshold.
+    ///
+    /// Finalizes the match with the admin's chosen result and slashes every
+    /// oracle whose recorded vote disagreed with it — the admin acts as the
+    /// tie-breaker of last resort, consistent with the admin's existing
+    /// ultimate authority elsewhere in this contract (`slash_oracle`,
+    /// `update_admin`, `pause`). See docs/oracle.md for the full consensus
+    /// protocol and its migration path from single-oracle deployments.
+    ///
+    /// # Errors
+    /// - [`Error::Unauthorized`] — contract has not been initialized or caller is not the admin.
+    /// - [`Error::AlreadySubmitted`] — the match already has a finalized result.
+    /// - [`Error::MatchNotDisputed`] — the match has no consensus votes recorded,
+    ///   or its consensus has not deadlocked.
+    pub fn resolve_disputed_match(
+        env: Env,
+        match_id: u64,
+        game_id: String,
+        platform: Platform,
+        result: Winner,
+    ) -> Result<(), Error> {
+        extend_instance_ttl(&env);
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(Error::Unauthorized)?;
+        admin.require_auth();
+
+        if env.storage().persistent().has(&DataKey::Result(match_id)) {
+            return Err(Error::AlreadySubmitted);
+        }
+
+        let state: ConsensusState = env
+            .storage()
+            .persistent()
+            .get(&DataKey::MatchVotes(match_id))
+            .ok_or(Error::MatchNotDisputed)?;
+        if !state.disputed {
+            return Err(Error::MatchNotDisputed);
+        }
+
+        for i in 0..state.candidates.len() {
+            let candidate = state.candidates.get(i).unwrap();
+            let agrees = candidate.result == result
+                && candidate.platform == platform
+                && candidate.game_id == game_id;
+            if !agrees {
+                for j in 0..candidate.submitters.len() {
+                    let wrong_oracle = candidate.submitters.get(j).unwrap();
+                    Self::slash_bps(&env, &wrong_oracle, MINORITY_SLASH_BPS);
+                    env.events().publish(
+                        (Symbol::new(&env, "oracle"), symbol_short!("minority")),
+                        (match_id, wrong_oracle),
+                    );
+                }
+            }
+        }
+
+        env.storage().persistent().set(
+            &DataKey::Result(match_id),
+            &ResultEntry {
+                game_id,
+                platform,
+                result: result.clone(),
+                submitted_ledger: env.ledger().sequence(),
+                submitter: admin,
+            },
+        );
+        env.storage().persistent().extend_ttl(
+            &DataKey::Result(match_id),
+            MATCH_TTL_LEDGERS,
+            MATCH_TTL_LEDGERS,
+        );
+        env.storage()
+            .persistent()
+            .remove(&DataKey::MatchVotes(match_id));
+
+        env.events().publish(
+            (Symbol::new(&env, "oracle"), symbol_short!("resolved")),
+            (match_id, result),
+        );
+
+        Ok(())
+    }
+
+    /// Configure the m-of-n consensus threshold — admin only. The number of
+    /// distinct, independently-registered oracles that must submit a matching
+    /// result before `submit_oracle_result` finalizes a match. Pass `1` to
+    /// restore the degenerate single-oracle configuration.
+    ///
+    /// # Errors
+    /// - [`Error::Unauthorized`] — contract has not been initialized or caller is not the admin.
+    /// - [`Error::InvalidThreshold`] — `threshold` is 0.
+    pub fn set_consensus_threshold(env: Env, threshold: u32) -> Result<(), Error> {
+        extend_instance_ttl(&env);
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(Error::Unauthorized)?;
+        admin.require_auth();
+
+        if threshold == 0 {
+            return Err(Error::InvalidThreshold);
+        }
+
+        env.storage()
+            .instance()
+            .set(&DataKey::ConsensusThreshold, &threshold);
+        env.events().publish(
+            (Symbol::new(&env, "oracle"), symbol_short!("thresh")),
+            threshold,
+        );
+        Ok(())
+    }
+
+    /// Return the currently configured m-of-n consensus threshold. Defaults
+    /// to 1 (degenerate single-oracle configuration) if never explicitly set.
+    pub fn get_consensus_threshold(env: Env) -> u32 {
+        extend_instance_ttl(&env);
+        Self::consensus_threshold(&env)
+    }
+
+    /// Return the number of distinct addresses ever registered via
+    /// `register_oracle_with_stake`. Does not account for stake subsequently
+    /// slashed to zero — see `get_oracle_rate_limit_status`-style per-oracle
+    /// queries, or read the `OracleRegistration` directly, to check whether a
+    /// specific oracle is currently eligible to vote.
+    pub fn get_registered_oracle_count(env: Env) -> u32 {
+        extend_instance_ttl(&env);
+        let set: Vec<Address> = env
+            .storage()
+            .instance()
+            .get(&DataKey::OracleSet)
+            .unwrap_or(Vec::new(&env));
+        set.len()
+    }
+
+    /// Return the in-progress consensus tally for a match: every distinct
+    /// candidate result submitted so far and whether the match has deadlocked
+    /// into a disputed state. Returns `None` once the match is finalized
+    /// (its tally is cleared) or if no oracle has voted on it yet.
+    pub fn get_match_votes(env: Env, match_id: u64) -> Option<ConsensusState> {
+        extend_instance_ttl(&env);
+        env.storage()
+            .persistent()
+            .get(&DataKey::MatchVotes(match_id))
+    }
+
+    /// Read the configured consensus threshold, defaulting to 1.
+    fn consensus_threshold(env: &Env) -> u32 {
+        env.storage()
+            .instance()
+            .get(&DataKey::ConsensusThreshold)
+            .unwrap_or(DEFAULT_CONSENSUS_THRESHOLD)
+    }
+
+    /// Count registered oracles that (a) still hold a positive stake and
+    /// (b) have not yet voted on `match_id` — the maximum number of
+    /// additional votes any candidate could still receive. Used to detect an
+    /// irreconcilable deadlock: if no candidate's current tally plus this
+    /// count can reach the threshold, consensus is no longer achievable.
+    fn remaining_eligible_oracles(env: &Env, match_id: u64) -> u32 {
+        let set: Vec<Address> = env
+            .storage()
+            .instance()
+            .get(&DataKey::OracleSet)
+            .unwrap_or(Vec::new(env));
+
+        let mut remaining = 0u32;
+        for i in 0..set.len() {
+            let addr = set.get(i).unwrap();
+            if env
+                .storage()
+                .persistent()
+                .has(&DataKey::OracleVote(match_id, addr.clone()))
+            {
+                continue;
+            }
+            if let Some(registration) = env
+                .storage()
+                .instance()
+                .get::<_, OracleRegistration>(&DataKey::OracleRegistration(addr))
+            {
+                if registration.oracle_stake > 0 {
+                    remaining += 1;
+                }
+            }
+        }
+        remaining
+    }
+
+    /// Slash `bps` basis points of `oracle`'s remaining stake, transferring
+    /// the slashed amount to the admin (treasury). No-op if the oracle is not
+    /// registered or has no remaining stake. Returns the amount slashed.
+    fn slash_bps(env: &Env, oracle: &Address, bps: i128) -> i128 {
+        let key = DataKey::OracleRegistration(oracle.clone());
+        let mut registration: OracleRegistration = match env.storage().instance().get(&key) {
+            Some(r) => r,
+            None => return 0,
+        };
+        if registration.oracle_stake <= 0 {
+            return 0;
+        }
+
+        let amount = (registration.oracle_stake * bps) / 10_000;
+        let amount = amount.clamp(0, registration.oracle_stake);
+        if amount == 0 {
+            return 0;
+        }
+
+        registration.oracle_stake -= amount;
+        let token = registration.token.clone();
+        env.storage().instance().set(&key, &registration);
+
+        if let Some(admin) = env.storage().instance().get::<_, Address>(&DataKey::Admin) {
+            let token_client = token::Client::new(env, &token);
+            token_client.transfer(&env.current_contract_address(), &admin, &amount);
+        }
+
+        amount
     }
 
     /// Retrieve the stored result for a match.    /// TTL is extended on every read to prevent active results from expiring.

--- a/contracts/oracle/src/tests.rs
+++ b/contracts/oracle/src/tests.rs
@@ -1715,3 +1715,610 @@ fn test_get_admin_returns_unauthorized_when_not_initialized() {
     let result = client.try_get_admin();
     assert_eq!(result, Err(Ok(Error::Unauthorized)));
 }
+
+// ── m-of-n oracle consensus ──────────────────────────────────────────────
+
+/// Registers `n` freshly-generated oracle addresses, each staking `stake` of
+/// `token_addr`, and returns them in registration order.
+fn register_n_oracles(
+    env: &Env,
+    client: &OracleContractClient,
+    token_addr: &Address,
+    n: u32,
+    stake: i128,
+) -> std::vec::Vec<Address> {
+    let asset_client = StellarAssetClient::new(env, token_addr);
+    let mut oracles = std::vec::Vec::new();
+    for _ in 0..n {
+        let oracle = Address::generate(env);
+        asset_client.mint(&oracle, &stake);
+        client.register_oracle_with_stake(&oracle, &stake, token_addr);
+        oracles.push(oracle);
+    }
+    oracles
+}
+
+#[test]
+fn test_consensus_threshold_defaults_to_one() {
+    let (env, contract_id, ..) = setup();
+    let client = OracleContractClient::new(&env, &contract_id);
+
+    assert_eq!(client.get_consensus_threshold(), 1);
+}
+
+#[test]
+fn test_set_consensus_threshold_updates_value() {
+    let (env, contract_id, ..) = setup();
+    let client = OracleContractClient::new(&env, &contract_id);
+
+    client.set_consensus_threshold(&3);
+    assert_eq!(client.get_consensus_threshold(), 3);
+}
+
+#[test]
+fn test_set_consensus_threshold_rejects_zero() {
+    let (env, contract_id, ..) = setup();
+    let client = OracleContractClient::new(&env, &contract_id);
+
+    let result = client.try_set_consensus_threshold(&0);
+    assert_eq!(result, Err(Ok(Error::InvalidThreshold)));
+}
+
+#[test]
+#[should_panic]
+fn test_set_consensus_threshold_requires_admin_auth() {
+    let env = Env::default();
+    let admin = Address::generate(&env);
+    let contract_id = env.register_contract(None, OracleContract);
+    let client = OracleContractClient::new(&env, &contract_id);
+    client.initialize(&admin);
+    client.set_consensus_threshold(&2);
+}
+
+#[test]
+fn test_get_registered_oracle_count() {
+    let (env, contract_id, _escrow_id, _admin, _p1, _p2, token_addr) = setup();
+    let client = OracleContractClient::new(&env, &contract_id);
+
+    assert_eq!(client.get_registered_oracle_count(), 0);
+    register_n_oracles(&env, &client, &token_addr, 5, 100);
+    assert_eq!(client.get_registered_oracle_count(), 5);
+}
+
+/// Backward compatibility: the original admin-gated `submit_result` path
+/// (n=1 via admin auth) and the new consensus `submit_oracle_result` path at
+/// threshold=1 (n=1 via a registered oracle's own auth) both work, on
+/// different matches, on the same contract instance.
+#[test]
+fn test_both_legacy_admin_mode_and_new_consensus_mode_work_side_by_side() {
+    let (env, contract_id, _escrow_id, oracle_admin, _p1, _p2, token_addr) = setup();
+    let client = OracleContractClient::new(&env, &contract_id);
+
+    // Legacy path: admin-gated submit_result, no consensus machinery involved.
+    client.submit_result(
+        &0u64,
+        &String::from_str(&env, "legacy_game"),
+        &Platform::Lichess,
+        &Winner::Player1,
+    );
+    assert!(client.has_result(&0u64));
+
+    // New path: a registered oracle submits via submit_oracle_result; default
+    // threshold of 1 finalizes on the first vote (degenerate n=1).
+    let oracles = register_n_oracles(&env, &client, &token_addr, 1, 500);
+    client.submit_oracle_result(
+        &oracles[0],
+        &1u64,
+        &String::from_str(&env, "consensus_game"),
+        &Platform::Lichess,
+        &Winner::Player2,
+    );
+    assert!(client.has_result(&1u64));
+    assert_eq!(client.get_result(&1u64).result, Winner::Player2);
+
+    // The admin can still submit legacy-path results for other matches too.
+    client.submit_result(
+        &2u64,
+        &String::from_str(&env, "legacy_game_2"),
+        &Platform::Lichess,
+        &Winner::Draw,
+    );
+    assert!(client.has_result(&2u64));
+    let _ = oracle_admin; // sanity: admin identity unused beyond setup wiring
+}
+
+#[test]
+fn test_submit_oracle_result_not_registered_rejected() {
+    let (env, contract_id, ..) = setup();
+    let client = OracleContractClient::new(&env, &contract_id);
+    let stranger = Address::generate(&env);
+
+    let result = client.try_submit_oracle_result(
+        &stranger,
+        &0u64,
+        &String::from_str(&env, "g"),
+        &Platform::Lichess,
+        &Winner::Player1,
+    );
+    assert_eq!(result, Err(Ok(Error::NotRegisteredOracle)));
+    assert!(!client.has_result(&0u64));
+}
+
+#[test]
+fn test_submit_oracle_result_rejects_zero_stake() {
+    let (env, contract_id, _escrow_id, _admin, _p1, _p2, token_addr) = setup();
+    let client = OracleContractClient::new(&env, &contract_id);
+    let oracles = register_n_oracles(&env, &client, &token_addr, 1, 100);
+
+    client.slash_oracle(&oracles[0], &100i128);
+
+    let result = client.try_submit_oracle_result(
+        &oracles[0],
+        &0u64,
+        &String::from_str(&env, "g"),
+        &Platform::Lichess,
+        &Winner::Player1,
+    );
+    assert_eq!(result, Err(Ok(Error::InsufficientStake)));
+}
+
+#[test]
+fn test_submit_oracle_result_empty_game_id_rejected() {
+    let (env, contract_id, _escrow_id, _admin, _p1, _p2, token_addr) = setup();
+    let client = OracleContractClient::new(&env, &contract_id);
+    let oracles = register_n_oracles(&env, &client, &token_addr, 1, 100);
+
+    let result = client.try_submit_oracle_result(
+        &oracles[0],
+        &0u64,
+        &String::from_str(&env, ""),
+        &Platform::Lichess,
+        &Winner::Player1,
+    );
+    assert_eq!(result, Err(Ok(Error::InvalidGameId)));
+}
+
+#[test]
+fn test_submit_oracle_result_blocked_when_paused() {
+    let (env, contract_id, _escrow_id, _admin, _p1, _p2, token_addr) = setup();
+    let client = OracleContractClient::new(&env, &contract_id);
+    let oracles = register_n_oracles(&env, &client, &token_addr, 1, 100);
+
+    client.pause();
+
+    let result = client.try_submit_oracle_result(
+        &oracles[0],
+        &0u64,
+        &String::from_str(&env, "g"),
+        &Platform::Lichess,
+        &Winner::Player1,
+    );
+    assert_eq!(result, Err(Ok(Error::ContractPaused)));
+}
+
+/// threshold reached -> payout proceeds: once enough independent oracles
+/// agree, the match finalizes (has_result flips true) and the same result is
+/// accepted by the escrow contract's own (separately-configured) oracle to
+/// actually execute payout, demonstrating the two systems compose.
+#[test]
+fn test_mofn_threshold_reached_finalizes_result_and_escrow_payout_proceeds() {
+    let (env, contract_id, escrow_id, oracle_admin, _player1, _player2, token_addr) = setup();
+    let client = OracleContractClient::new(&env, &contract_id);
+    let escrow_client = EscrowContractClient::new(&env, &escrow_id);
+
+    client.set_consensus_threshold(&2);
+    let oracles = register_n_oracles(&env, &client, &token_addr, 3, 500);
+
+    // First vote: not yet finalized.
+    client.submit_oracle_result(
+        &oracles[0],
+        &0u64,
+        &String::from_str(&env, "test_game"),
+        &Platform::Lichess,
+        &Winner::Player1,
+    );
+    assert!(!client.has_result(&0u64));
+
+    // Second matching vote crosses the threshold.
+    client.submit_oracle_result(
+        &oracles[1],
+        &0u64,
+        &String::from_str(&env, "test_game"),
+        &Platform::Lichess,
+        &Winner::Player1,
+    );
+    assert!(client.has_result(&0u64));
+    assert_eq!(client.get_result(&0u64).result, Winner::Player1);
+
+    // The oracle contract's finalized result is purely an audit record; the
+    // escrow contract trusts its own configured oracle address separately.
+    // (Exact settlement amounts are covered by the escrow crate's own test
+    // suite; here we only check that the finalized m-of-n result is accepted
+    // downstream and drives the match to completion.)
+    escrow_client.submit_result(&0u64, &EscrowWinner::Player1);
+    let m = escrow_client.get_match(&0u64);
+    assert_eq!(m.state, MatchState::Completed);
+    let _ = oracle_admin;
+}
+
+/// threshold not reached -> match stays pending.
+#[test]
+fn test_mofn_threshold_not_reached_match_stays_pending() {
+    let (env, contract_id, _escrow_id, _admin, _p1, _p2, token_addr) = setup();
+    let client = OracleContractClient::new(&env, &contract_id);
+
+    client.set_consensus_threshold(&3);
+    let oracles = register_n_oracles(&env, &client, &token_addr, 5, 500);
+
+    client.submit_oracle_result(
+        &oracles[0],
+        &0u64,
+        &String::from_str(&env, "g"),
+        &Platform::Lichess,
+        &Winner::Player1,
+    );
+    client.submit_oracle_result(
+        &oracles[1],
+        &0u64,
+        &String::from_str(&env, "g"),
+        &Platform::Lichess,
+        &Winner::Player1,
+    );
+
+    assert!(!client.has_result(&0u64));
+    let votes = client.get_match_votes(&0u64).unwrap();
+    assert!(!votes.disputed);
+    assert_eq!(votes.candidates.len(), 1);
+    assert_eq!(votes.candidates.get(0).unwrap().submitters.len(), 2);
+}
+
+/// Conflicting submissions that still resolve to consensus: the losing
+/// (minority) oracle is automatically slashed once the majority finalizes.
+#[test]
+fn test_mofn_conflicting_submissions_minority_auto_slashed_on_finalize() {
+    let (env, contract_id, _escrow_id, _admin, _p1, _p2, token_addr) = setup();
+    let client = OracleContractClient::new(&env, &contract_id);
+    let balance_client = soroban_sdk::token::Client::new(&env, &token_addr);
+
+    client.set_consensus_threshold(&2);
+    let oracles = register_n_oracles(&env, &client, &token_addr, 3, 500);
+
+    // Oracle 0 disagrees with the eventual majority.
+    client.submit_oracle_result(
+        &oracles[0],
+        &0u64,
+        &String::from_str(&env, "g"),
+        &Platform::Lichess,
+        &Winner::Player2,
+    );
+    // Oracles 1 and 2 agree on Player1, reaching the threshold.
+    client.submit_oracle_result(
+        &oracles[1],
+        &0u64,
+        &String::from_str(&env, "g"),
+        &Platform::Lichess,
+        &Winner::Player1,
+    );
+    client.submit_oracle_result(
+        &oracles[2],
+        &0u64,
+        &String::from_str(&env, "g"),
+        &Platform::Lichess,
+        &Winner::Player1,
+    );
+
+    assert!(client.has_result(&0u64));
+    assert_eq!(client.get_result(&0u64).result, Winner::Player1);
+
+    // Minority oracle 0 (10% of its 500 stake) was auto-slashed.
+    assert_eq!(balance_client.balance(&contract_id), 500 + 500 + 450);
+
+    let result = client.try_submit_oracle_result(
+        &oracles[0],
+        &1u64,
+        &String::from_str(&env, "g2"),
+        &Platform::Lichess,
+        &Winner::Player1,
+    );
+    assert!(
+        result.is_ok(),
+        "minority oracle keeps its remaining stake and can still vote"
+    );
+}
+
+/// A single malicious minority oracle cannot force an incorrect result: its
+/// lone vote never crosses the threshold, and once the honest majority
+/// agrees, the correct result finalizes instead.
+#[test]
+fn test_mofn_single_malicious_minority_cannot_force_incorrect_result() {
+    let (env, contract_id, _escrow_id, _admin, _p1, _p2, token_addr) = setup();
+    let client = OracleContractClient::new(&env, &contract_id);
+
+    client.set_consensus_threshold(&2);
+    let oracles = register_n_oracles(&env, &client, &token_addr, 3, 500);
+
+    // Malicious oracle submits a false result alone.
+    client.submit_oracle_result(
+        &oracles[0],
+        &0u64,
+        &String::from_str(&env, "g"),
+        &Platform::Lichess,
+        &Winner::Player2,
+    );
+    assert!(
+        !client.has_result(&0u64),
+        "a single oracle's vote must never unilaterally finalize a match above threshold 1"
+    );
+
+    // Two honest oracles agree on the true result.
+    client.submit_oracle_result(
+        &oracles[1],
+        &0u64,
+        &String::from_str(&env, "g"),
+        &Platform::Lichess,
+        &Winner::Player1,
+    );
+    client.submit_oracle_result(
+        &oracles[2],
+        &0u64,
+        &String::from_str(&env, "g"),
+        &Platform::Lichess,
+        &Winner::Player1,
+    );
+
+    assert!(client.has_result(&0u64));
+    assert_eq!(
+        client.get_result(&0u64).result,
+        Winner::Player1,
+        "the honest majority's result must win, not the malicious minority's"
+    );
+}
+
+#[test]
+fn test_mofn_equivocation_slashes_full_stake_and_rejects_submission() {
+    let (env, contract_id, _escrow_id, _admin, _p1, _p2, token_addr) = setup();
+    let client = OracleContractClient::new(&env, &contract_id);
+    let balance_client = soroban_sdk::token::Client::new(&env, &token_addr);
+
+    // threshold=2 so the first vote doesn't finalize, leaving room to equivocate.
+    client.set_consensus_threshold(&2);
+    let oracles = register_n_oracles(&env, &client, &token_addr, 2, 500);
+
+    client.submit_oracle_result(
+        &oracles[0],
+        &0u64,
+        &String::from_str(&env, "g"),
+        &Platform::Lichess,
+        &Winner::Player1,
+    );
+
+    // The call itself succeeds (Ok) — a contract call returning `Err` would
+    // revert the slash performed inside it, so equivocation is signaled via
+    // the `oracle/equivoc` event and the stake drop, not an error return.
+    client.submit_oracle_result(
+        &oracles[0],
+        &0u64,
+        &String::from_str(&env, "g"),
+        &Platform::Lichess,
+        &Winner::Player2, // conflicts with its own earlier vote
+    );
+
+    let events = env.events().all();
+    let expected_topics = soroban_sdk::vec![
+        &env,
+        Symbol::new(&env, "oracle").into_val(&env),
+        symbol_short!("equivoc").into_val(&env),
+    ];
+    assert!(
+        events
+            .iter()
+            .any(|(_, topics, _)| topics == expected_topics),
+        "equivoc event not emitted"
+    );
+
+    // The equivocating oracle's entire remaining stake (100% of 500) was slashed.
+    assert_eq!(balance_client.balance(&contract_id), 500);
+
+    // Full remaining stake was slashed.
+    let further = client.try_submit_oracle_result(
+        &oracles[0],
+        &1u64,
+        &String::from_str(&env, "g2"),
+        &Platform::Lichess,
+        &Winner::Player1,
+    );
+    assert_eq!(further, Err(Ok(Error::InsufficientStake)));
+
+    // Match 0 still isn't finalized — the equivocating vote was rejected.
+    assert!(!client.has_result(&0u64));
+}
+
+#[test]
+fn test_mofn_duplicate_identical_vote_returns_already_submitted_no_slash() {
+    let (env, contract_id, _escrow_id, _admin, _p1, _p2, token_addr) = setup();
+    let client = OracleContractClient::new(&env, &contract_id);
+    let balance_client = soroban_sdk::token::Client::new(&env, &token_addr);
+
+    client.set_consensus_threshold(&2);
+    let oracles = register_n_oracles(&env, &client, &token_addr, 2, 500);
+
+    client.submit_oracle_result(
+        &oracles[0],
+        &0u64,
+        &String::from_str(&env, "g"),
+        &Platform::Lichess,
+        &Winner::Player1,
+    );
+    let result = client.try_submit_oracle_result(
+        &oracles[0],
+        &0u64,
+        &String::from_str(&env, "g"),
+        &Platform::Lichess,
+        &Winner::Player1, // identical repeat, not equivocation
+    );
+    assert_eq!(result, Err(Ok(Error::AlreadySubmitted)));
+
+    // No slashing occurred for a duplicate identical vote.
+    assert_eq!(balance_client.balance(&contract_id), 1000);
+}
+
+/// conflicting submissions -> correct dispute/slash path: an irreconcilable
+/// 3-way split (no candidate can reach threshold even with every remaining
+/// oracle voting) marks the match disputed rather than hanging forever, and
+/// the admin's resolution finalizes it while slashing every oracle that
+/// disagreed with the resolution.
+#[test]
+fn test_mofn_deadlock_marks_disputed_and_admin_resolves() {
+    let (env, contract_id, _escrow_id, admin, _p1, _p2, token_addr) = setup();
+    let client = OracleContractClient::new(&env, &contract_id);
+    let balance_client = soroban_sdk::token::Client::new(&env, &token_addr);
+
+    client.set_consensus_threshold(&2);
+    let oracles = register_n_oracles(&env, &client, &token_addr, 3, 500);
+
+    client.submit_oracle_result(
+        &oracles[0],
+        &0u64,
+        &String::from_str(&env, "g"),
+        &Platform::Lichess,
+        &Winner::Player1,
+    );
+    client.submit_oracle_result(
+        &oracles[1],
+        &0u64,
+        &String::from_str(&env, "g"),
+        &Platform::Lichess,
+        &Winner::Player2,
+    );
+    // Third and final oracle breaks for a third distinct result: no
+    // candidate can now possibly reach the threshold of 2.
+    client.submit_oracle_result(
+        &oracles[2],
+        &0u64,
+        &String::from_str(&env, "g"),
+        &Platform::Lichess,
+        &Winner::Draw,
+    );
+
+    assert!(!client.has_result(&0u64));
+    let votes = client.get_match_votes(&0u64).unwrap();
+    assert!(
+        votes.disputed,
+        "an irreconcilable 3-way split must be flagged disputed"
+    );
+
+    // Admin resolves in favor of oracle 0's submission (Player1).
+    client.resolve_disputed_match(
+        &0u64,
+        &String::from_str(&env, "g"),
+        &Platform::Lichess,
+        &Winner::Player1,
+    );
+
+    assert!(client.has_result(&0u64));
+    assert_eq!(client.get_result(&0u64).result, Winner::Player1);
+
+    // Oracles 1 and 2 disagreed with the resolution and were slashed 10%;
+    // oracle 0 agreed and keeps its full stake.
+    assert_eq!(balance_client.balance(&contract_id), 500 + 450 + 450);
+    let _ = admin;
+}
+
+#[test]
+fn test_mofn_resolve_disputed_match_requires_disputed_state() {
+    let (env, contract_id, ..) = setup();
+    let client = OracleContractClient::new(&env, &contract_id);
+
+    let result = client.try_resolve_disputed_match(
+        &0u64,
+        &String::from_str(&env, "g"),
+        &Platform::Lichess,
+        &Winner::Player1,
+    );
+    assert_eq!(result, Err(Ok(Error::MatchNotDisputed)));
+}
+
+#[test]
+#[should_panic]
+fn test_mofn_resolve_disputed_match_requires_admin_auth() {
+    let env = Env::default();
+    let admin = Address::generate(&env);
+    let contract_id = env.register_contract(None, OracleContract);
+    let client = OracleContractClient::new(&env, &contract_id);
+    client.initialize(&admin);
+    client.resolve_disputed_match(
+        &0u64,
+        &String::from_str(&env, "g"),
+        &Platform::Lichess,
+        &Winner::Player1,
+    );
+}
+
+#[test]
+fn test_mofn_already_finalized_match_rejects_further_oracle_submissions() {
+    let (env, contract_id, _escrow_id, _admin, _p1, _p2, token_addr) = setup();
+    let client = OracleContractClient::new(&env, &contract_id);
+
+    let oracles = register_n_oracles(&env, &client, &token_addr, 2, 500);
+
+    // Default threshold=1: first oracle's vote finalizes immediately.
+    client.submit_oracle_result(
+        &oracles[0],
+        &0u64,
+        &String::from_str(&env, "g"),
+        &Platform::Lichess,
+        &Winner::Player1,
+    );
+    assert!(client.has_result(&0u64));
+
+    let result = client.try_submit_oracle_result(
+        &oracles[1],
+        &0u64,
+        &String::from_str(&env, "g"),
+        &Platform::Lichess,
+        &Winner::Player1,
+    );
+    assert_eq!(result, Err(Ok(Error::AlreadySubmitted)));
+}
+
+#[test]
+fn test_mofn_finalized_event_reports_submitter_count_and_threshold() {
+    let (env, contract_id, _escrow_id, _admin, _p1, _p2, token_addr) = setup();
+    let client = OracleContractClient::new(&env, &contract_id);
+
+    client.set_consensus_threshold(&2);
+    let oracles = register_n_oracles(&env, &client, &token_addr, 2, 500);
+
+    client.submit_oracle_result(
+        &oracles[0],
+        &0u64,
+        &String::from_str(&env, "g"),
+        &Platform::Lichess,
+        &Winner::Player1,
+    );
+    client.submit_oracle_result(
+        &oracles[1],
+        &0u64,
+        &String::from_str(&env, "g"),
+        &Platform::Lichess,
+        &Winner::Player1,
+    );
+
+    let events = env.events().all();
+    let expected_topics = soroban_sdk::vec![
+        &env,
+        Symbol::new(&env, "oracle").into_val(&env),
+        symbol_short!("finalzd").into_val(&env),
+    ];
+    let matched = events
+        .iter()
+        .find(|(_, topics, _)| *topics == expected_topics);
+    assert!(matched.is_some(), "finalzd event not emitted");
+
+    let (_, _, data) = matched.unwrap();
+    let (ev_id, ev_count, ev_threshold): (u64, u32, u32) =
+        soroban_sdk::TryFromVal::try_from_val(&env, &data).unwrap();
+    assert_eq!(ev_id, 0u64);
+    assert_eq!(ev_count, 2);
+    assert_eq!(ev_threshold, 2);
+}

--- a/contracts/oracle/src/types.rs
+++ b/contracts/oracle/src/types.rs
@@ -1,4 +1,4 @@
-use soroban_sdk::{contracttype, Address, String};
+use soroban_sdk::{contracttype, Address, String, Vec};
 
 /// Canonical result enum shared conceptually with the escrow contract.
 /// Variants mirror escrow's `Winner` enum for consistency.
@@ -48,6 +48,39 @@ pub struct OracleRegistration {
     pub token: Address,
 }
 
+/// A single registered oracle's vote for a specific match, recorded so a
+/// second, conflicting submission from the same oracle for the same match
+/// can be detected as equivocation.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct OracleVoteRecord {
+    pub game_id: String,
+    pub platform: Platform,
+    pub result: Winner,
+}
+
+/// One distinct (game_id, platform, result) candidate submitted for a match,
+/// and the set of independently-registered oracles that have voted for it.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct CandidateTally {
+    pub game_id: String,
+    pub platform: Platform,
+    pub result: Winner,
+    pub submitters: Vec<Address>,
+}
+
+/// In-progress m-of-n consensus state for a match: every distinct candidate
+/// result submitted so far, and whether the match has been flagged as an
+/// irreconcilable dispute (no remaining eligible oracle vote could push any
+/// candidate over the configured threshold).
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct ConsensusState {
+    pub candidates: Vec<CandidateTally>,
+    pub disputed: bool,
+}
+
 #[contracttype]
 pub enum DataKey {
     Admin,
@@ -62,6 +95,16 @@ pub enum DataKey {
     /// Sliding window submission counters for the daily limit, keyed by oracle address.
     OracleDailyWindow(Address),
     Rate(Address, Address),
+    /// Number of matching independent-oracle submissions required to finalize
+    /// a match result via `submit_oracle_result`. Defaults to 1.
+    ConsensusThreshold,
+    /// Every address ever registered via `register_oracle_with_stake`.
+    OracleSet,
+    /// In-progress consensus tally for a match, keyed by match_id. Removed
+    /// once the match is finalized.
+    MatchVotes(u64),
+    /// A single oracle's recorded vote for a match, keyed by (match_id, oracle).
+    OracleVote(u64, Address),
 }
 
 /// Configurable submission limits for a single oracle address.

--- a/contracts/oracle/tests/benchmarks.rs
+++ b/contracts/oracle/tests/benchmarks.rs
@@ -1,0 +1,279 @@
+//! Gas / resource benchmarks for the m-of-n oracle consensus path.
+//!
+//! Measures CPU instructions, memory bytes, and wall-clock time for
+//! `submit_oracle_result` at 3, 5, 10, and 25 registered oracles, isolating
+//! two distinct costs that scale with the size of the registered oracle set:
+//!
+//!  - **pending vote**: a submission that does *not* yet reach the consensus
+//!    threshold. This is the more expensive steady-state case — it runs the
+//!    O(n) deadlock-detection scan (`remaining_eligible_oracles`) over every
+//!    registered oracle to decide whether the match should flip to disputed.
+//!  - **finalizing vote**: the submission that crosses the threshold. This
+//!    additionally walks every losing candidate's submitter list to
+//!    auto-slash the minority, so its cost scales with how many oracles
+//!    already voted for a different result, not with the full registry size.
+//!
+//! Run via:
+//!
+//!   cargo test -p oracle --test benchmarks -- --nocapture
+//!
+//! A JSON report is written to `reports/performance/oracle-consensus-benchmark-results.json`
+//! at the repository root.
+
+use std::fs;
+use std::path::PathBuf;
+use std::time::Instant;
+
+use oracle::types::{Platform, Winner};
+use oracle::{OracleContract, OracleContractClient};
+use soroban_sdk::{
+    testutils::Address as _, token::StellarAssetClient, Address, Env, String as SorobanString,
+};
+
+const STAKE: i128 = 1_000;
+
+/// Registered-oracle-set sizes benchmarked, per the task's required scale points.
+const SCALES: [u32; 4] = [3, 5, 10, 25];
+
+struct Measurement {
+    name: &'static str,
+    sample_size: u32,
+    cpu_instructions: u64,
+    memory_bytes: u64,
+    wall_time_micros: u128,
+}
+
+impl Measurement {
+    fn to_json(&self) -> String {
+        format!(
+            "    {{\n      \"name\": \"{name}\",\n      \"sample_size\": {sample_size},\n      \"cpu_instructions\": {cpu},\n      \"memory_bytes\": {mem},\n      \"wall_time_micros\": {wt}\n    }}",
+            name = self.name,
+            sample_size = self.sample_size,
+            cpu = self.cpu_instructions,
+            mem = self.memory_bytes,
+            wt = self.wall_time_micros,
+        )
+    }
+}
+
+/// A freshly initialized oracle contract plus a funded token, isolated per
+/// benchmark so that one scenario's registered-oracle set never leaks into
+/// another's.
+struct Harness {
+    env: Env,
+    contract_id: Address,
+    token: Address,
+}
+
+impl Harness {
+    fn new() -> Self {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.budget().reset_unlimited();
+
+        let admin = Address::generate(&env);
+        let token_id = env.register_stellar_asset_contract_v2(admin.clone());
+        let token = token_id.address();
+
+        let contract_id = env.register_contract(None, OracleContract);
+        let client = OracleContractClient::new(&env, &contract_id);
+        client.initialize(&admin);
+
+        Self {
+            env,
+            contract_id,
+            token,
+        }
+    }
+
+    fn client(&self) -> OracleContractClient<'_> {
+        OracleContractClient::new(&self.env, &self.contract_id)
+    }
+
+    /// Register `n` freshly-generated oracle addresses, each staking
+    /// [`STAKE`] of the harness token, and return them in registration order.
+    fn register_oracles(&self, n: u32) -> std::vec::Vec<Address> {
+        let asset_client = StellarAssetClient::new(&self.env, &self.token);
+        let mut oracles = std::vec::Vec::new();
+        for _ in 0..n {
+            let oracle = Address::generate(&self.env);
+            asset_client.mint(&oracle, &STAKE);
+            self.client()
+                .register_oracle_with_stake(&oracle, &STAKE, &self.token);
+            oracles.push(oracle);
+        }
+        oracles
+    }
+}
+
+/// Measure a single contract call, isolating its cost from setup work.
+///
+/// `setup` runs under an unlimited budget so it never trips resource limits.
+/// The budget is reset to the standard mainnet-equivalent default immediately
+/// before `op` runs, so the reported cost reflects only `op`.
+fn measure<S: FnOnce(), O: FnOnce()>(
+    env: &Env,
+    name: &'static str,
+    sample_size: u32,
+    setup: S,
+    op: O,
+) -> Measurement {
+    env.budget().reset_unlimited();
+    setup();
+
+    env.budget().reset_default();
+    let start = Instant::now();
+    op();
+    let wall_time_micros = start.elapsed().as_micros();
+
+    Measurement {
+        name,
+        sample_size,
+        cpu_instructions: env.budget().cpu_instruction_cost(),
+        memory_bytes: env.budget().memory_bytes_cost(),
+        wall_time_micros,
+    }
+}
+
+#[test]
+fn run_all_benchmarks() {
+    let mut results = std::vec::Vec::new();
+
+    // ── Pending vote: threshold = n (unanimous), so every vote except the
+    // last one hits the O(n) deadlock-detection scan without finalizing. ───
+    for n in SCALES {
+        let h = Harness::new();
+        let oracles = h.register_oracles(n);
+        h.client().set_consensus_threshold(&n);
+
+        results.push(measure(
+            &h.env,
+            "submit_oracle_result (pending vote, scans full registered set)",
+            n,
+            || {},
+            || {
+                h.client().submit_oracle_result(
+                    &oracles[0],
+                    &0u64,
+                    &SorobanString::from_str(&h.env, "bench_game"),
+                    &Platform::Lichess,
+                    &Winner::Player1,
+                );
+            },
+        ));
+    }
+
+    // ── Finalizing vote: threshold = n/2 + 1 (simple majority). One
+    // dissenting minority oracle votes first, then the majority votes in
+    // agreement; the final vote crosses the threshold and must walk the
+    // minority candidate's submitter list to auto-slash it. ────────────────
+    for n in SCALES {
+        let h = Harness::new();
+        let oracles = h.register_oracles(n);
+        let threshold = n / 2 + 1;
+        h.client().set_consensus_threshold(&threshold);
+
+        // One minority vote for a different result.
+        h.client().submit_oracle_result(
+            &oracles[0],
+            &0u64,
+            &SorobanString::from_str(&h.env, "bench_game"),
+            &Platform::Lichess,
+            &Winner::Player2,
+        );
+
+        // Majority votes agree, up to (but not including) the finalizing one.
+        for oracle in oracles.iter().take(threshold as usize).skip(1) {
+            h.client().submit_oracle_result(
+                oracle,
+                &0u64,
+                &SorobanString::from_str(&h.env, "bench_game"),
+                &Platform::Lichess,
+                &Winner::Player1,
+            );
+        }
+
+        let finalizing_oracle = &oracles[threshold as usize];
+        results.push(measure(
+            &h.env,
+            "submit_oracle_result (finalizing vote, slashes minority)",
+            n,
+            || {},
+            || {
+                h.client().submit_oracle_result(
+                    finalizing_oracle,
+                    &0u64,
+                    &SorobanString::from_str(&h.env, "bench_game"),
+                    &Platform::Lichess,
+                    &Winner::Player1,
+                );
+            },
+        ));
+    }
+
+    // ── Degenerate n=1 baseline: single registered oracle, threshold=1,
+    // finalizes on its first vote. Contrast point for the m-of-n numbers
+    // above — this reproduces the original single-admin-oracle cost. ───────
+    {
+        let h = Harness::new();
+        let oracles = h.register_oracles(1);
+
+        results.push(measure(
+            &h.env,
+            "submit_oracle_result (degenerate n=1, finalizes immediately)",
+            1,
+            || {},
+            || {
+                h.client().submit_oracle_result(
+                    &oracles[0],
+                    &0u64,
+                    &SorobanString::from_str(&h.env, "bench_game"),
+                    &Platform::Lichess,
+                    &Winner::Player1,
+                );
+            },
+        ));
+    }
+
+    print_report(&results);
+    write_report(&results);
+}
+
+fn print_report(results: &[Measurement]) {
+    println!();
+    println!(
+        "{:<62} {:>5} {:>14} {:>12} {:>10}",
+        "operation", "n", "cpu_insns", "mem_bytes", "wall_us"
+    );
+    for r in results {
+        println!(
+            "{:<62} {:>5} {:>14} {:>12} {:>10}",
+            r.name, r.sample_size, r.cpu_instructions, r.memory_bytes, r.wall_time_micros
+        );
+    }
+    println!();
+}
+
+fn write_report(results: &[Measurement]) {
+    let entries: std::vec::Vec<String> = results.iter().map(Measurement::to_json).collect();
+    let json = format!(
+        "{{\n  \"generated_by\": \"contracts/oracle/tests/benchmarks.rs\",\n  \"results\": [\n{}\n  ]\n}}\n",
+        entries.join(",\n")
+    );
+
+    let path = report_path();
+    if let Some(dir) = path.parent() {
+        fs::create_dir_all(dir).expect("failed to create reports/performance directory");
+    }
+    fs::write(&path, json).expect("failed to write benchmark report");
+    println!("Wrote benchmark report to {}", path.display());
+}
+
+fn report_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+        .join("reports")
+        .join("performance")
+        .join("oracle-consensus-benchmark-results.json")
+}

--- a/docs/oracle.md
+++ b/docs/oracle.md
@@ -33,7 +33,10 @@ The escrow contract uses its configured oracle address as the authoritative
 permission for submitting results to trigger payouts. The oracle contract is
 supplementary: it does not authorise escrow payouts or act as a gatekeeper for
 escrow result submission. It provides an audit log and an independent on-chain
-record of results that can be queried later.
+record of results that can be queried later — and, as of the m-of-n consensus
+feature described below, it can itself require independent agreement from
+multiple staked oracles before that record is written, rather than trusting a
+single admin-controlled submitter.
 
 The off-chain oracle service today is the trusted operator that:
 1. verifies the platform result for `game_id` using an external chess API,
@@ -47,7 +50,298 @@ The two contracts are separate:
 - `EscrowContract` enforces match state, funding, and oracle address
   authentication.
 - `OracleContract` enforces admin-only result storage and exposes public or
-  admin-gated read interfaces.
+  admin-gated read interfaces. It additionally supports a genuine multi-oracle
+  consensus path — see [m-of-n Oracle Consensus](#m-of-n-oracle-consensus).
+
+---
+
+## m-of-n Oracle Consensus
+
+### Background
+
+Earlier versions of `OracleContract` shipped staking primitives
+(`register_oracle_with_stake` / `slash_oracle`) that looked like the
+foundation of a decentralized oracle set, but nothing in the contract actually
+required multiple oracles to agree. `submit_result` and `submit_batch_results`
+are gated purely by `admin.require_auth()`, and their stake check only ever
+looks up `OracleRegistration(admin)` — because the admin is the only address
+that can call them. In effect, the "oracle" was a single trusted address, and
+the staking/slashing machinery was decorative: it could not be triggered by
+anything other than a manual admin call.
+
+`submit_oracle_result` (below) is the genuine multi-oracle path. It makes the
+existing staking machinery load-bearing: a result-submitting oracle without
+adequate stake is rejected, and provable equivocation triggers automatic
+slashing. `submit_result` / `submit_batch_results` are unchanged and remain
+available — see [Migration path](#migration-path-from-single-oracle).
+
+### Registration and threshold
+
+Each oracle registers independently with its own key and its own stake:
+
+```rust
+oracle_client.register_oracle_with_stake(&oracle_address, &stake_amount, &token);
+```
+
+Registering appends the address to the contract's oracle set (queryable via
+`get_registered_oracle_count`). The admin configures how many *distinct*
+registered oracles must submit a matching result before it finalizes:
+
+```rust
+oracle_client.set_consensus_threshold(&m); // m ∈ [1, n]
+```
+
+The threshold defaults to **1** if never set — the degenerate single-oracle
+configuration described in [Migration path](#migration-path-from-single-oracle).
+`get_consensus_threshold()` reads the current value.
+
+### Submitting a vote
+
+```rust
+oracle_client.submit_oracle_result(&oracle_address, &match_id, &game_id, &platform, &result);
+```
+
+Unlike `submit_result`, this is authenticated by the **submitting oracle**,
+not the admin (`oracle_address.require_auth()`). Each call:
+
+1. Rejects if the contract is paused, uninitialized, `game_id` is empty, the
+   caller never registered stake (`NotRegisteredOracle`), the caller's stake
+   has been slashed to zero (`InsufficientStake`), the match is already
+   finalized (`AlreadySubmitted`), or the caller's per-oracle rate limit is
+   exceeded (`RateLimitExceeded`) — see [Oracle Submission Rate
+   Limiting](#oracle-submission-rate-limiting), which applies identically to
+   this path.
+2. Groups the vote into a *candidate*: the distinct `(game_id, platform,
+   result)` tuple it matches. Each candidate tracks the list of oracles that
+   voted for it.
+3. If a candidate's submitter count reaches the configured threshold, the
+   match **finalizes**: the winning candidate is written to the same
+   `Result(match_id)` storage that `submit_result` writes, so `get_result` /
+   `has_result` behave identically regardless of which path finalized the
+   match.
+4. If no candidate has reached the threshold yet, the match stays pending —
+   query `get_match_votes(match_id)` to see the current tally.
+
+With the default threshold of 1, a single registered oracle's vote finalizes
+immediately: this is the m-of-n code path running in its n=1 degenerate form,
+distinct from (but behaviourally equivalent to) the legacy admin-gated
+`submit_result`.
+
+### Disagreement handling
+
+Disagreement is resolved with an explicit, two-tier policy: **majority wins,
+minority is slashed**, with an **admin-resolved deadlock fallback** for splits
+that can never resolve on their own.
+
+**1. Majority wins, minority is slashed (the common case).** When a
+candidate's vote count reaches the threshold, the match finalizes with that
+result. Every oracle that had already voted for a *different* candidate for
+the same match is automatically slashed `MINORITY_SLASH_BPS` (10%) of its
+remaining stake, transferred to the admin/treasury address, and an
+`oracle / minority` event is emitted naming the slashed oracle. The penalty is
+deliberately lighter than the equivocation penalty (below) because landing in
+the minority can reflect an honest error — a stale platform-API read, a
+transient network partition — rather than malice.
+
+**2. Deadlock → disputed → admin resolution (the unresolvable case).** After
+every vote that doesn't finalize, the contract checks whether consensus is
+still mathematically reachable: it counts the registered, currently-staked
+oracles that haven't yet voted on this match (`remaining_eligible_oracles`),
+and checks whether *any* existing candidate's vote count plus that remaining
+pool could still reach the threshold. If not — for example, a 3-way split
+among 3 oracles at threshold 2, where every oracle has already voted for a
+different result — the match is flagged `disputed` (`get_match_votes` returns
+`disputed: true`, and an `oracle / disputed` event fires) instead of hanging
+forever waiting for votes that can never arrive.
+
+A disputed match is resolved by the admin, who acts as tie-breaker of last
+resort — consistent with the admin's existing ultimate authority elsewhere in
+this contract (`slash_oracle`, `update_admin`, `pause`):
+
+```rust
+oracle_client.resolve_disputed_match(&match_id, &game_id, &platform, &result);
+```
+
+This finalizes the match with the admin's chosen result and slashes
+`MINORITY_SLASH_BPS` from every oracle whose recorded vote disagreed with it —
+so attempting to force a deadlock (to trigger a slower, admin-mediated path)
+still costs a losing oracle its stake, the same as losing an ordinary
+majority vote.
+
+We chose this policy — rather than escalating every disagreement into
+`EscrowContract`'s heavier bonded, snapshot-based dispute-voting system (see
+[docs/dispute-governance.md](dispute-governance.md)) — because that mechanism
+is designed for economic disputes over a *single* asserted result raised by
+third-party token holders, not for reconciling *which of several
+independently-submitted oracle results* to accept in the first place. Routing
+every m-of-n disagreement through it would mean every close vote incurs a
+bond, a voting period, and a quorum check, even though the oracle contract
+already has the information needed to resolve most disagreements immediately
+via majority count. The admin-resolution fallback here is intentionally
+narrow: it only fires when the vote is *unresolvable* by counting, not
+whenever there's any disagreement at all. A future iteration could route
+`resolve_disputed_match` through the escrow dispute-voting system instead of
+direct admin authority, trading a slower resolution for removing the admin as
+a trust bottleneck in the rare deadlock case — see [Known
+limitations](#known-limitations-of-this-design).
+
+### Equivocation
+
+If the *same* oracle submits two different `(game_id, platform, result)`
+votes for the *same* `match_id`, the second submission is provable
+equivocation: the oracle has signed two mutually-exclusive claims about the
+same event. It cannot be an honest mistake in the way a minority vote can — an
+honest oracle simply doesn't re-submit a different answer to the same
+question. The vote is discarded (not counted toward any candidate) and the
+oracle's **entire remaining stake** is slashed (`EQUIVOCATION_SLASH_BPS`,
+100%) — effectively ejecting it from further participation, since
+`submit_oracle_result` rejects any oracle with `oracle_stake <= 0` with
+`InsufficientStake`.
+
+Equivocation slashing is signaled by the `oracle / equivoc` event rather than
+an error return. This is a deliberate consequence of Soroban's execution
+model: a contract call that returns `Err` reverts **every** storage write
+made during that call, including the slash. Returning an error here would
+silently undo the punishment it was reporting. Off-chain callers should treat
+a submission that emits `oracle / equivoc` as rejected, exactly as if it had
+errored, but detect it by watching contract events rather than the call's
+return value.
+
+### Byzantine-fault-tolerance bound
+
+Let `n` be the number of registered, staked oracles and `m` be the configured
+threshold. Let `f` be the number of oracles that collude (vote identically on
+a false result, in an attempt to force it through).
+
+- **Safety** (a colluding minority cannot force a false result): requires
+  `f < m`. If `f ≥ m`, the colluding set alone can supply enough matching
+  votes to finalize before any honest oracle needs to act at all.
+- **Liveness** (the honest oracles can still finalize the true result even if
+  every colluding oracle refuses to cooperate): requires `n − f ≥ m`, i.e.
+  `f ≤ n − m`.
+
+Combining both: the system tolerates up to
+
+```
+f_max = min(m − 1, n − m)
+```
+
+colluding oracles while still guaranteeing both that a false result can't be
+forced and that a true result can still be finalized. This bound is maximized
+by a simple-majority threshold `m = ⌊n/2⌋ + 1`, which gives the familiar
+`f_max = ⌊(n − 1) / 2⌋` — the same "more than half honest" bound as classical
+BFT quorum systems. Choosing `m` closer to `n` (e.g. requiring near-unanimity)
+tightens the safety margin but weakens liveness, since it takes fewer
+colluding/offline oracles to prevent the honest majority from ever reaching
+the threshold; choosing `m` closer to 1 does the reverse.
+
+This is a **threshold-voting bound backed by economic slashing**, not a full
+Byzantine state-machine-replication protocol: there is no leader election,
+view-change, or cryptographic message-authentication step beyond Soroban's
+own `require_auth`. A colluding set larger than `f_max` is not cryptographically
+prevented from finalizing a false result — it is only made expensive after the
+fact via the minority/equivocation slashing described above, and only for
+oracles that end up provably in the minority or that equivocate. Operators
+choosing `m` should size it, and the number of independently-operated oracles
+`n`, so that `f_max` exceeds the number of oracle operators they are willing
+to assume could plausibly collude.
+
+### Migration path from single-oracle
+
+The original single-admin-oracle deployment continues to work unmodified:
+
+| | Legacy (`submit_result`) | Consensus (`submit_oracle_result`) |
+|---|---|---|
+| Auth | `admin.require_auth()` | `oracle.require_auth()` (any registered oracle) |
+| Finalizes on | First (and only) call | Threshold-many matching votes |
+| Default n | 1 (hardcoded — only admin can call it) | 1 (`ConsensusThreshold` defaults to 1) |
+| Disagreement | Not possible — one submitter | Majority-wins-with-slash, or admin-resolved deadlock |
+
+To migrate an existing single-oracle deployment to genuine m-of-n:
+
+1. **Register additional independent oracles.** Each new oracle operator
+   calls `register_oracle_with_stake` with its own key and its own stake —
+   no admin action is required to add an oracle to the set.
+2. **Raise the threshold.** Once enough oracles are registered, the admin
+   calls `set_consensus_threshold(m)` with `1 < m ≤ n`. Existing pending
+   votes recorded before the change are re-evaluated against the new
+   threshold on their next submission; already-finalized results are
+   unaffected.
+3. **Point the off-chain oracle fleet at `submit_oracle_result`.** Each
+   independent oracle service instance authenticates as itself instead of a
+   shared admin key.
+4. **(Optional) retire the legacy path operationally.** `submit_result` and
+   `submit_batch_results` remain callable by the admin indefinitely — they
+   are not disabled by raising the threshold. This is intentional for
+   backward compatibility and emergency admin override, but it also means
+   the admin retains a standing unilateral override regardless of the
+   configured m-of-n threshold. Deployments that want the full
+   Byzantine-fault-tolerance guarantee above to hold in practice, not just on
+   the `submit_oracle_result` path, should treat the admin key with the same
+   operational care as an `f_max`-sized set of colluding oracles (e.g. behind
+   a multisig or hardware-backed signer used only for emergencies), since it
+   can unilaterally finalize any match regardless of the registered oracles'
+   votes. Fully removing that override — e.g. a one-way "renounce single-
+   submitter admin path" switch — is not implemented; see [Known
+   limitations](#known-limitations-of-this-design).
+
+To roll back to single-oracle behavior, call `set_consensus_threshold(1)`;
+any one registered oracle's vote (or the admin via the legacy path) then
+finalizes a match again.
+
+### Known limitations of this design
+
+- The admin retains a standing override via `submit_result` /
+  `submit_batch_results` regardless of the configured threshold (see above).
+- The deadlock-resolution fallback (`resolve_disputed_match`) is admin-gated
+  rather than routed through `EscrowContract`'s dispute-voting system; see the
+  rationale in [Disagreement handling](#disagreement-handling).
+- `remaining_eligible_oracles` scans the full registered oracle set on every
+  non-finalizing vote (see the [gas benchmarks](#consensus-gas-benchmarks)
+  below for measured cost at n = 3/5/10/25) — deployments expecting very
+  large oracle sets (hundreds+) should budget for this scaling when sizing
+  per-transaction resource limits.
+- Vote weight is equal per oracle regardless of stake size; a larger stake
+  only means a larger slashing penalty in absolute terms, not more voting
+  power. Stake-weighted voting was considered out of scope for this change.
+
+### Consensus gas benchmarks
+
+`contracts/oracle/tests/benchmarks.rs` measures `submit_oracle_result` at
+n = 3, 5, 10, and 25 registered oracles, run via:
+
+```bash
+cargo test -p oracle --test benchmarks -- --nocapture
+```
+
+It isolates two costs that scale differently with the registered oracle set
+size `n`:
+
+- **Pending vote** — a submission that does not yet reach the threshold, and
+  therefore runs the O(n) deadlock-detection scan over the full registered
+  set on every call.
+- **Finalizing vote** — the submission that crosses the threshold; its extra
+  cost comes from walking each losing candidate's submitter list to
+  auto-slash the minority, so it scales with how many oracles already voted
+  for a different result, not with `n` directly.
+
+A JSON report is written to
+`reports/performance/oracle-consensus-benchmark-results.json`. Representative
+CPU-instruction costs from a local run (exact numbers vary by SDK/host
+version — treat the report as authoritative over any numbers reproduced
+here):
+
+| n (registered oracles) | Pending vote (CPU insns) | Finalizing vote (CPU insns) |
+|---:|---:|---:|
+| 3 | ~390K | ~620K |
+| 5 | ~500K | ~730K |
+| 10 | ~840K | ~1.00M |
+| 25 | ~2.11M | ~1.72M |
+
+The pending-vote cost grows roughly linearly with `n` (the deadlock scan
+touches every registered oracle); the finalizing-vote cost grows more slowly,
+since it is bounded by the number of minority submitters rather than the full
+registry.
 
 ---
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -189,7 +189,11 @@ Both contracts implement emergency pause functionality for rapid response to sec
 1. **No Native Token Support**: Only supports Stellar assets (XLM, USDC), not native tokens
 2. **Fixed Timeout**: Match expiration timeout is hardcoded (~24 hours)
 3. **No Partial Withdrawals**: Players cannot withdraw partial stakes
-4. **Single Oracle**: Only one oracle address per escrow contract
+4. **Single Oracle (EscrowContract)**: `EscrowContract` still trusts exactly one
+   configured oracle address as the authoritative trigger for payouts (see
+   `submit_result` / `get_oracle`). This is unchanged by the m-of-n consensus
+   feature below, which lives in the separate `OracleContract` and governs its
+   own audit-log finalization, not `EscrowContract`'s payout authorization.
 
 ### Oracle Limitations
 
@@ -197,6 +201,16 @@ Both contracts implement emergency pause functionality for rapid response to sec
 2. **Rate Limiting**: Subject to platform API rate limits
 3. **Game Format**: Only supports standard chess games, not variants
 4. **Real-time Delay**: Results submitted after games complete, not in real-time
+5. **`OracleContract` admin override survives m-of-n**: `OracleContract` now
+   supports genuine m-of-n oracle consensus (`submit_oracle_result`,
+   `set_consensus_threshold`) with load-bearing staking/slashing — see
+   [docs/oracle.md § m-of-n Oracle Consensus](oracle.md#m-of-n-oracle-consensus)
+   for the protocol, its Byzantine-fault-tolerance bound, and the migration
+   path. However, the legacy admin-gated `submit_result` /
+   `submit_batch_results` functions remain callable regardless of the
+   configured threshold, so the admin key retains a standing unilateral
+   override on `OracleContract`'s own result storage even in an otherwise
+   fully-migrated m-of-n deployment.
 
 ### Platform Limitations
 
@@ -207,7 +221,16 @@ Both contracts implement emergency pause functionality for rapid response to sec
 ### Security Limitations
 
 1. **Admin Trust**: Admin keys must be kept secure (no on-chain enforcement)
-2. **Oracle Centralization**: Single point of failure for result verification
+2. **Oracle Centralization**: `EscrowContract` payouts remain gated by a
+   single configured oracle address (see above) regardless of how many
+   independent oracles are registered and voting in `OracleContract`.
+   Within `OracleContract` itself, centralization is now opt-in rather than
+   structural: an admin that configures `set_consensus_threshold(1)` (the
+   default) or continues using `submit_result` keeps a single point of
+   failure for result verification; raising the threshold and registering
+   independent oracles trades that for the Byzantine-fault-tolerance bound
+   documented in [docs/oracle.md](oracle.md#byzantine-fault-tolerance-bound),
+   at the cost of the residual admin override noted above.
 3. **No Upgrade Path**: No built-in contract upgrade mechanism
 4. **Event Monitoring**: Security depends on off-chain monitoring of contract events
 


### PR DESCRIPTION



## Summary

Provide a short description of the change and the problem it fixes.

The oracle contract had staking/slashing machinery (register_oracle_with_stake/slash_oracle) that looked decentralized but was structurally decorative: every mutating call was gated by a single admin address, and submit_result's stake check only ever looked up the admin's own registration since only the admin could call it.

Add submit_oracle_result: a genuine m-of-n path where independently registered, independently staked oracles each submit a signed vote, and a match finalizes only once a configurable threshold of matching votes is reached. Disagreement is handled explicitly — majority wins with the minority auto-slashed 10% of remaining stake, and votes that deadlock into an unresolvable split are flagged disputed and resolved by the admin (who also slashes the losing side). Provable equivocation (two conflicting votes from the same oracle for the same match) auto-slashes the oracle's full remaining stake. Both are impossible to leave as an Err return, since a reverting call would undo the slash it's reporting — see the code comments and docs/oracle.md for why these paths return Ok(()) and signal via events instead.

The legacy admin-gated submit_result/submit_batch_results are unchanged and remain the degenerate n=1 configuration; the new consensus path also reproduces n=1 behavior at the default threshold of 1, and both are covered by tests running side by side on the same contract instance.

Also includes a minimal, separate fix to get contracts/escrow building again: the most recent merge to main (dispute-governance-security) silently dropped several DataKey/Error variants and mis-called invoke_contract during conflict resolution, leaving the escrow lib uncompilable. That fix was necessary infrastructure to run and verify the oracle crate's test suite (a dev-dependency on the escrow lib), and is unrelated in substance to the m-of-n oracle work.

- contracts/oracle/tests/benchmarks.rs: gas benchmarks for consensus-checking at 3/5/10/25 registered oracles (pending-vote and finalizing-vote costs)
- docs/oracle.md: consensus protocol, disagreement handling rationale, Byzantine-fault-tolerance bound (tolerates min(m-1, n-m) colluding oracles), and migration path from single-oracle
- docs/security.md: Known Limitations now describes which parts of the oracle trust model this does and doesn't change (EscrowContract's own oracle address is still single; OracleContract's admin override survives m-of-n)

Known pre-existing, unrelated failure: tests::test_oracle_to_escrow_full_payout_flow fails on main due to an escrow settlement/vesting amount regression from the same dispute-governance merge — not touched by this change.
## Related Issue

Link the issue number or task this PR addresses.

## What changed
- Contracts:
- Tests:
- Docs:
- Events / API / storage:

## Verification
- What did you run to verify this change?
  - `cargo test -p escrow`
  - `cargo test -p oracle`
  - `cargo fmt`
  - `cargo clippy`

## Checklist
- [x] I added or updated tests covering this change.
- [x] I updated documentation or confirmed no docs update is needed.
- [x] I confirmed any event/API/storage changes are documented and backward-compatible.
- [x] I manually verified the contract or CLI behavior where applicable.
- [x] I linked this PR to the related issue.
- [x] I included notes on any TTL or storage assumptions affecting contract state.

## Notes

Add any additional details, risks, or follow-up tasks here.
Closes #1057