### PR TITLE
feat: build websocket server for real time match update

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ Prefer to learn by watching or testing yourself?
 - [Glossary](docs/glossary.md) — key terms (escrow, oracle, match states, Soroban, wave-ready, and more) for new contributors
 - [Architecture Overview](docs/architecture.md)
 - [Oracle Design](docs/oracle.md)
+- [WebSocket API](docs/websocket-api.md) — real-time match event protocol (protocol v1), connection lifecycle, subscription model, React hook
 - [Threat Model & Security](docs/security.md)
 - [Balance-Privacy Model](docs/privacy-model.md) — what the balance-snapshot APIs hide from non-admins, and what they don't
 - [Roadmap](docs/roadmap.md)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -114,6 +114,34 @@ services:
     profiles:
       - testing
 
+  # ── WebSocket server (real-time match events) ────────────────────────────
+  websocket-server:
+    build:
+      context: services/websocket-server
+      dockerfile: Dockerfile
+    restart: unless-stopped
+    depends_on:
+      event-indexer-1:
+        condition: service_healthy
+    ports:
+      - "8090:8090"
+    environment:
+      WS_PORT: 8090
+      WS_HOST: 0.0.0.0
+      EVENT_INDEXER_URL: http://event-indexer-1:8080
+      WS_POLL_INTERVAL_MS: ${WS_POLL_INTERVAL_MS:-5000}
+      WS_HEARTBEAT_INTERVAL_MS: ${WS_HEARTBEAT_INTERVAL_MS:-30000}
+      WS_HEARTBEAT_TIMEOUT_MS: ${WS_HEARTBEAT_TIMEOUT_MS:-60000}
+      WS_RATE_LIMIT_MAX_SUBSCRIBES: ${WS_RATE_LIMIT_MAX_SUBSCRIBES:-20}
+      WS_RATE_LIMIT_WINDOW_MS: ${WS_RATE_LIMIT_WINDOW_MS:-60000}
+      WS_MAX_SUBSCRIPTIONS_PER_CLIENT: ${WS_MAX_SUBSCRIPTIONS_PER_CLIENT:-50}
+      LOG_LEVEL: ${WS_LOG_LEVEL:-info}
+    healthcheck:
+      test: ["CMD", "node", "-e", "require('net').createConnection(8090,'localhost').on('connect',()=>process.exit(0)).on('error',()=>process.exit(1))"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+
 volumes:
   postgres-data:
     driver: local

--- a/docs/websocket-api.md
+++ b/docs/websocket-api.md
@@ -1,0 +1,412 @@
+# WebSocket API — Real-Time Match Updates
+
+The Checkmate-Escrow WebSocket server (`services/websocket-server`) delivers
+real-time match events over a persistent WebSocket connection.
+
+**Protocol version:** `1`  
+**Default port:** `8090`  
+**Wire format:** JSON text frames  
+**Endpoint:** `ws://<host>:<port>/`
+
+---
+
+## Contents
+
+1. [Quick start](#1-quick-start)
+2. [Connection lifecycle](#2-connection-lifecycle)
+3. [Client → Server messages](#3-client--server-messages)
+4. [Server → Client messages](#4-server--client-messages)
+5. [Event types](#5-event-types)
+6. [Subscription model](#6-subscription-model)
+7. [Reconnect strategy](#7-reconnect-strategy)
+8. [Rate limiting](#8-rate-limiting)
+9. [Heartbeat](#9-heartbeat)
+10. [Security considerations](#10-security-considerations)
+11. [Configuration reference](#11-configuration-reference)
+12. [React hook](#12-react-hook)
+13. [Protocol changelog](#13-protocol-changelog)
+
+---
+
+## 1. Quick start
+
+```js
+const ws = new WebSocket('ws://localhost:8090');
+
+ws.onmessage = ({ data }) => {
+  const msg = JSON.parse(data);
+
+  if (msg.type === 'welcome') {
+    // Subscribe to match 42 and to a player address
+    ws.send(JSON.stringify({
+      type: 'subscribe',
+      payload: {
+        match_ids: [42],
+        player_addresses: ['GABC...XYZ'],
+      },
+    }));
+  }
+
+  if (msg.type === 'event') {
+    console.log('New match event:', msg.event);
+  }
+};
+```
+
+---
+
+## 2. Connection lifecycle
+
+```
+Client                           Server
+  |                                |
+  |──── TCP / WS handshake ────────▶|
+  |◀─── welcome ───────────────────|   (protocol_version, server_time)
+  |                                |
+  |──── subscribe ─────────────────▶|   (match_ids, player_addresses)
+  |◀─── subscribed ────────────────|   (echo of active subscriptions)
+  |                                |
+  |◀─── event (push) ──────────────|   (whenever a new event is indexed)
+  |◀─── event (push) ──────────────|
+  |                                |
+  |──── ping ──────────────────────▶|   (optional app-level ping)
+  |◀─── pong ──────────────────────|
+  |                                |
+  |──── close ─────────────────────▶|
+```
+
+The server also sends native WebSocket **ping frames** on the heartbeat
+interval.  Compliant clients (browsers, `ws` library) respond automatically.
+
+---
+
+## 3. Client → Server messages
+
+All messages are JSON objects with a `type` field.
+
+### `subscribe`
+
+Subscribe to events for specific match IDs or player addresses.  
+Can be sent multiple times; subscriptions are **additive**.
+
+```json
+{
+  "type": "subscribe",
+  "payload": {
+    "match_ids": [42, 100],
+    "player_addresses": ["GABC...XYZ", "GDEF...UVW"]
+  }
+}
+```
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `payload.match_ids` | `number[]` | no | Soroban match IDs (non-negative integers) |
+| `payload.player_addresses` | `string[]` | no | Stellar account IDs (case-insensitive) |
+
+At least one of the two fields must be non-empty.
+
+### `unsubscribe`
+
+Remove specific match IDs or player addresses from active subscriptions.
+
+```json
+{
+  "type": "unsubscribe",
+  "payload": {
+    "match_ids": [42],
+    "player_addresses": []
+  }
+}
+```
+
+### `ping`
+
+Application-level ping.  The server replies with `pong`.
+
+```json
+{ "type": "ping" }
+```
+
+---
+
+## 4. Server → Client messages
+
+### `welcome`
+
+Sent immediately on connection.
+
+```json
+{
+  "type": "welcome",
+  "protocol_version": 1,
+  "server_time": "2026-07-24T13:02:08.276Z"
+}
+```
+
+**Clients must wait for `welcome` before sending any commands.**
+
+### `subscribed`
+
+Acknowledgement sent after a successful `subscribe` command.  Contains the
+**full** current subscription state for the connection, not just the newly
+added entries.
+
+```json
+{
+  "type": "subscribed",
+  "match_ids": [42, 100],
+  "player_addresses": ["gabc...xyz"]
+}
+```
+
+Note: player addresses are always stored and returned in lower-case.
+
+### `unsubscribed`
+
+Acknowledgement sent after a successful `unsubscribe` command.
+
+```json
+{
+  "type": "unsubscribed",
+  "match_ids": [42],
+  "player_addresses": []
+}
+```
+
+### `event`
+
+Pushed to clients whose subscriptions match the event.
+
+```json
+{
+  "type": "event",
+  "event": {
+    "id": "a1b2c3d4-...",
+    "ledger_sequence": 123456,
+    "match_id": 42,
+    "event_type": "match/created",
+    "player1": "GABC...XYZ",
+    "player2": "GDEF...UVW",
+    "status": "pending",
+    "winner": null,
+    "stake_amount": "10000000",
+    "token": "USDC_TOKEN_ADDRESS",
+    "game_id": "abcdef123456",
+    "platform": "Lichess",
+    "timestamp": "2026-07-24T13:02:08.276Z",
+    "txn_hash": "abc123...",
+    "event_index_in_txn": 0
+  }
+}
+```
+
+See [Event types](#5-event-types) for all possible `event_type` values.
+
+### `pong`
+
+Response to a client `ping`.
+
+```json
+{
+  "type": "pong",
+  "server_time": "2026-07-24T13:02:10.100Z"
+}
+```
+
+### `error`
+
+Sent when the server rejects a command.
+
+```json
+{
+  "type": "error",
+  "code": "PARSE_ERROR",
+  "message": "Message must be valid JSON"
+}
+```
+
+| Code | Cause |
+|---|---|
+| `PARSE_ERROR` | Frame body is not valid JSON |
+| `INVALID_MESSAGE` | JSON is valid but `type` field is missing |
+| `UNKNOWN_MESSAGE_TYPE` | `type` is not a recognised command |
+| `SUBSCRIBE_ERROR` | Invalid payload or subscription cap exceeded |
+| `UNSUBSCRIBE_ERROR` | Client not found or invalid payload |
+
+### `rate_limited`
+
+Sent when the client exceeds the subscribe/unsubscribe command rate.
+
+```json
+{
+  "type": "rate_limited",
+  "message": "rate_limited: max 20 subscription commands per 60000ms",
+  "retry_after_ms": 60000
+}
+```
+
+The connection is **not** closed.  The client should back off for at least
+`retry_after_ms` milliseconds before retrying.
+
+---
+
+## 5. Event types
+
+These mirror the Soroban contract events defined in the [README](../README.md#events-reference).
+
+| `event_type` | Emitted when | Key payload fields |
+|---|---|---|
+| `match/created` | `create_match` called | `player1`, `player2`, `stake_amount`, `token`, `game_id`, `platform` |
+| `match/completed` | `submit_result` called | `winner` (`player1` / `player2` / `draw`) |
+| `match/cancelled` | `cancel_match` called | — |
+| `match/expired` | `expire_match` called | — |
+
+---
+
+## 6. Subscription model
+
+### How routing works
+
+The server maintains two in-memory indices:
+
+- **Match index:** `match_id → Set<clientId>`
+- **Player index:** `player_address (lower-case) → Set<clientId>`
+
+When an event arrives, the server looks up both indices (by `match_id` and by
+`player1`/`player2`) and delivers the event to the **union** of matched client
+IDs.  A client that matches on both channels receives the event exactly once.
+
+### Limits
+
+| Limit | Default | Env var |
+|---|---|---|
+| Subscriptions per client (matchIds + playerAddresses) | 50 | `WS_MAX_SUBSCRIPTIONS_PER_CLIENT` |
+| Subscribe/unsubscribe commands per window | 20 | `WS_RATE_LIMIT_MAX_SUBSCRIBES` |
+| Rate-limit window | 60 s | `WS_RATE_LIMIT_WINDOW_MS` |
+
+---
+
+## 7. Reconnect strategy
+
+The server does not send a `reconnect` signal.  Clients should implement
+automatic reconnect with **exponential back-off**:
+
+```
+delay = min(BASE_BACKOFF × 2^attempt, MAX_BACKOFF) + random_jitter(0–500ms)
+```
+
+| Parameter | Recommended value |
+|---|---|
+| `BASE_BACKOFF` | 1 000 ms |
+| `MAX_BACKOFF` | 30 000 ms |
+| Jitter | 0–500 ms |
+
+After reconnect, clients must re-subscribe because all server-side state is
+ephemeral.  The provided [React hook](#12-react-hook) handles this
+automatically.
+
+---
+
+## 8. Rate limiting
+
+Subscribe and unsubscribe commands count against a rolling per-client window.
+Exceeding the limit triggers a `rate_limited` message.  The connection stays
+open; wait `retry_after_ms` before sending more subscription commands.
+
+---
+
+## 9. Heartbeat
+
+The server sends a native WebSocket **ping frame** every
+`WS_HEARTBEAT_INTERVAL_MS` milliseconds (default 30 s).  Connections that have
+not sent any frame for `WS_HEARTBEAT_TIMEOUT_MS` (default 60 s) are terminated
+with reason `heartbeat_timeout`.
+
+Disconnection reasons are written to the structured log at `info` level.
+
+---
+
+## 10. Security considerations
+
+| Concern | Mitigation |
+|---|---|
+| Unauthorised data access | Clients only receive events for match IDs / player addresses they explicitly subscribed to.  The server never broadcasts all-events. |
+| Subscription flooding | Per-client rate limit (`WS_RATE_LIMIT_MAX_SUBSCRIBES`) prevents abuse. |
+| Slow-client back-pressure | Each socket has its own send queue; a slow consumer is terminated via heartbeat timeout rather than blocking other clients. |
+| TLS | Deploy behind a TLS-terminating reverse proxy (nginx, Caddy, ALB) for production. |
+| Authentication | The current implementation does not require authentication.  For production, add JWT verification in the `connection` handler before sending `welcome`. |
+
+---
+
+## 11. Configuration reference
+
+All settings are read from environment variables at startup.
+
+| Env var | Default | Description |
+|---|---|---|
+| `WS_PORT` | `8090` | TCP port to listen on |
+| `WS_HOST` | `0.0.0.0` | Bind address |
+| `EVENT_INDEXER_URL` | `http://localhost:8080` | Event-indexer REST API base URL |
+| `WS_POLL_INTERVAL_MS` | `5000` | How often to poll event-indexer for new events (ms) |
+| `WS_HEARTBEAT_INTERVAL_MS` | `30000` | Interval between server-initiated pings (ms) |
+| `WS_HEARTBEAT_TIMEOUT_MS` | `60000` | Max silence before connection is terminated (ms) |
+| `WS_RATE_LIMIT_MAX_SUBSCRIBES` | `20` | Max subscribe/unsubscribe commands per window |
+| `WS_RATE_LIMIT_WINDOW_MS` | `60000` | Rate-limit window duration (ms) |
+| `WS_MAX_SUBSCRIPTIONS_PER_CLIENT` | `50` | Max active subscriptions per connection |
+| `LOG_LEVEL` | `info` | Pino log level (`trace`/`debug`/`info`/`warn`/`error`) |
+
+---
+
+## 12. React hook
+
+The frontend ships a `useMatchWebSocket` hook that wraps the protocol:
+
+```tsx
+import { useMatchWebSocket } from './hooks/useMatchWebSocket';
+
+function MatchCard({ matchId }: { matchId: number }) {
+  const { status, latestEvent, events, error, reconnect } = useMatchWebSocket({
+    matchIds: [matchId],
+    // Optionally also track a player's address across all matches:
+    // playerAddresses: [walletAddress],
+    url: import.meta.env.VITE_WS_SERVER_URL, // defaults to ws://localhost:8090
+    onEvent: (event) => {
+      console.log('Real-time event:', event.event_type, event);
+    },
+  });
+
+  if (status === 'error') return <button onClick={reconnect}>Reconnect</button>;
+  if (latestEvent?.event_type === 'match/completed') {
+    return <div>Winner: {latestEvent.winner}</div>;
+  }
+  return <div>Status: {status} — {events.length} events received</div>;
+}
+```
+
+### Hook API
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `matchIds` | `number[]` | `[]` | Match IDs to subscribe to |
+| `playerAddresses` | `string[]` | `[]` | Stellar addresses to subscribe to |
+| `url` | `string` | `VITE_WS_SERVER_URL` or `ws://localhost:8090` | WebSocket server URL |
+| `enabled` | `boolean` | `true` | Set `false` to disable without unmounting |
+| `maxHistory` | `number` | `100` | Max events kept in `events` array |
+| `onEvent` | `(event) => void` | — | Called for every incoming event |
+
+| Return value | Type | Description |
+|---|---|---|
+| `status` | `ConnectionStatus` | `connecting` / `subscribing` / `ready` / `reconnecting` / `error` / `closed` |
+| `latestEvent` | `IndexedEvent \| null` | Most recent event |
+| `events` | `IndexedEvent[]` | History (capped at `maxHistory`) |
+| `error` | `string \| null` | Last error message |
+| `reconnect` | `() => void` | Force immediate reconnect |
+
+---
+
+## 13. Protocol changelog
+
+| Version | Date | Changes |
+|---|---|---|
+| **1** | 2026-07-24 | Initial release — `subscribe`, `unsubscribe`, `ping/pong`, `welcome`, `subscribed`, `unsubscribed`, `event`, `error`, `rate_limited` messages |

--- a/frontend/src/hooks/useMatchWebSocket.test.ts
+++ b/frontend/src/hooks/useMatchWebSocket.test.ts
@@ -1,0 +1,327 @@
+/**
+ * Unit tests for useMatchWebSocket
+ *
+ * Uses a mock WebSocket class (injected via global) so no real network is
+ * needed.  Tests cover:
+ *   - Welcome handshake + auto-subscribe
+ *   - Status transitions
+ *   - Incoming event delivery
+ *   - Exponential back-off reconnect
+ *   - enabled=false disables connection
+ *   - reconnect() public API
+ */
+
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { useMatchWebSocket } from '../useMatchWebSocket';
+
+// ─── Mock WebSocket ────────────────────────────────────────────────────────
+
+class MockWebSocket {
+  static CONNECTING = 0;
+  static OPEN = 1;
+  static CLOSING = 2;
+  static CLOSED = 3;
+
+  readonly url: string;
+  readyState = MockWebSocket.CONNECTING;
+
+  onopen: (() => void) | null = null;
+  onmessage: ((evt: { data: string }) => void) | null = null;
+  onclose: ((evt: { code: number; reason: string }) => void) | null = null;
+  onerror: (() => void) | null = null;
+
+  private static instances: MockWebSocket[] = [];
+
+  constructor(url: string) {
+    this.url = url;
+    MockWebSocket.instances.push(this);
+  }
+
+  send(_data: string): void {}
+  close(_code?: number, _reason?: string): void {
+    this.readyState = MockWebSocket.CLOSED;
+    this.onclose?.({ code: 1000, reason: 'Normal closure' });
+  }
+
+  /** Test helpers */
+  simulateOpen(): void {
+    this.readyState = MockWebSocket.OPEN;
+    this.onopen?.();
+  }
+  simulateMessage(msg: object): void {
+    this.onmessage?.({ data: JSON.stringify(msg) });
+  }
+  simulateClose(code = 1006, reason = 'connection lost'): void {
+    this.readyState = MockWebSocket.CLOSED;
+    this.onclose?.({ code, reason });
+  }
+  simulateError(): void {
+    this.onerror?.();
+  }
+
+  static lastInstance(): MockWebSocket {
+    return MockWebSocket.instances[MockWebSocket.instances.length - 1];
+  }
+  static reset(): void {
+    MockWebSocket.instances = [];
+  }
+}
+
+// ─── Setup / teardown ──────────────────────────────────────────────────────
+
+beforeEach(() => {
+  MockWebSocket.reset();
+  vi.useFakeTimers();
+  // Inject mock into global
+  (global as unknown as Record<string, unknown>).WebSocket = MockWebSocket;
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  delete (global as unknown as Record<string, unknown>).WebSocket;
+});
+
+// ─── Tests ─────────────────────────────────────────────────────────────────
+
+describe('useMatchWebSocket', () => {
+
+  describe('initial connection', () => {
+    it('starts with status "connecting"', () => {
+      const { result } = renderHook(() =>
+        useMatchWebSocket({ url: 'ws://localhost:8090', enabled: true }),
+      );
+      expect(result.current.status).toBe('connecting');
+    });
+
+    it('transitions to "subscribing" after welcome (with matchIds)', async () => {
+      const { result } = renderHook(() =>
+        useMatchWebSocket({ url: 'ws://localhost:8090', matchIds: [1] }),
+      );
+
+      const ws = MockWebSocket.lastInstance();
+      act(() => ws.simulateOpen());
+      act(() => ws.simulateMessage({ type: 'welcome', protocol_version: 1, server_time: new Date().toISOString() }));
+
+      await waitFor(() => expect(result.current.status).toBe('subscribing'));
+    });
+
+    it('transitions to "ready" after welcome (no subscriptions)', async () => {
+      const { result } = renderHook(() =>
+        useMatchWebSocket({ url: 'ws://localhost:8090' }),
+      );
+
+      const ws = MockWebSocket.lastInstance();
+      act(() => ws.simulateOpen());
+      act(() => ws.simulateMessage({ type: 'welcome', protocol_version: 1, server_time: new Date().toISOString() }));
+
+      await waitFor(() => expect(result.current.status).toBe('ready'));
+    });
+
+    it('transitions to "ready" after subscribed message', async () => {
+      const { result } = renderHook(() =>
+        useMatchWebSocket({ url: 'ws://localhost:8090', matchIds: [42] }),
+      );
+
+      const ws = MockWebSocket.lastInstance();
+      act(() => ws.simulateOpen());
+      act(() => ws.simulateMessage({ type: 'welcome', protocol_version: 1, server_time: '' }));
+      act(() => ws.simulateMessage({ type: 'subscribed', match_ids: [42], player_addresses: [] }));
+
+      await waitFor(() => expect(result.current.status).toBe('ready'));
+    });
+  });
+
+  describe('event delivery', () => {
+    const mockEvent = {
+      id: 'evt-1',
+      ledger_sequence: 100,
+      match_id: 42,
+      event_type: 'match/created',
+      player1: 'GABC',
+      player2: 'GDEF',
+      timestamp: '2024-01-01T00:00:00Z',
+    };
+
+    async function connectAndReady() {
+      const { result } = renderHook(() =>
+        useMatchWebSocket({ url: 'ws://localhost:8090', matchIds: [42] }),
+      );
+      const ws = MockWebSocket.lastInstance();
+      act(() => ws.simulateOpen());
+      act(() => ws.simulateMessage({ type: 'welcome', protocol_version: 1, server_time: '' }));
+      act(() => ws.simulateMessage({ type: 'subscribed', match_ids: [42], player_addresses: [] }));
+      await waitFor(() => expect(result.current.status).toBe('ready'));
+      return { result, ws };
+    }
+
+    it('populates latestEvent when event arrives', async () => {
+      const { result, ws } = await connectAndReady();
+
+      act(() => ws.simulateMessage({ type: 'event', event: mockEvent }));
+
+      await waitFor(() => expect(result.current.latestEvent).not.toBeNull());
+      expect(result.current.latestEvent?.match_id).toBe(42);
+    });
+
+    it('accumulates events in history array', async () => {
+      const { result, ws } = await connectAndReady();
+
+      act(() => ws.simulateMessage({ type: 'event', event: { ...mockEvent, id: 'evt-1' } }));
+      act(() => ws.simulateMessage({ type: 'event', event: { ...mockEvent, id: 'evt-2' } }));
+
+      await waitFor(() => expect(result.current.events).toHaveLength(2));
+    });
+
+    it('caps history at maxHistory', async () => {
+      const maxHistory = 3;
+      const { result, ws } = await connectAndReady();
+      // Override maxHistory by rendering fresh
+      const { result: r2 } = renderHook(() =>
+        useMatchWebSocket({ url: 'ws://localhost:8090', matchIds: [42], maxHistory }),
+      );
+      const ws2 = MockWebSocket.lastInstance();
+      act(() => ws2.simulateOpen());
+      act(() => ws2.simulateMessage({ type: 'welcome', protocol_version: 1, server_time: '' }));
+      act(() => ws2.simulateMessage({ type: 'subscribed', match_ids: [42], player_addresses: [] }));
+      await waitFor(() => expect(r2.current.status).toBe('ready'));
+
+      for (let i = 0; i < 5; i++) {
+        act(() => ws2.simulateMessage({ type: 'event', event: { ...mockEvent, id: `evt-${i}` } }));
+      }
+
+      await waitFor(() => expect(r2.current.events.length).toBeLessThanOrEqual(maxHistory));
+      // Suppress unused variable warning for ws
+      void ws;
+      void result;
+    });
+
+    it('calls onEvent callback for each event', async () => {
+      const onEvent = vi.fn();
+      const { result } = renderHook(() =>
+        useMatchWebSocket({ url: 'ws://localhost:8090', matchIds: [42], onEvent }),
+      );
+      const ws = MockWebSocket.lastInstance();
+      act(() => ws.simulateOpen());
+      act(() => ws.simulateMessage({ type: 'welcome', protocol_version: 1, server_time: '' }));
+      act(() => ws.simulateMessage({ type: 'subscribed', match_ids: [42], player_addresses: [] }));
+      await waitFor(() => expect(result.current.status).toBe('ready'));
+
+      act(() => ws.simulateMessage({ type: 'event', event: mockEvent }));
+
+      await waitFor(() => expect(onEvent).toHaveBeenCalledTimes(1));
+      expect(onEvent).toHaveBeenCalledWith(expect.objectContaining({ match_id: 42 }));
+    });
+  });
+
+  describe('reconnect behaviour', () => {
+    it('transitions to "reconnecting" on close', async () => {
+      const { result } = renderHook(() =>
+        useMatchWebSocket({ url: 'ws://localhost:8090' }),
+      );
+      const ws = MockWebSocket.lastInstance();
+      act(() => ws.simulateOpen());
+      act(() => ws.simulateMessage({ type: 'welcome', protocol_version: 1, server_time: '' }));
+
+      act(() => ws.simulateClose());
+      await waitFor(() => expect(result.current.status).toBe('reconnecting'));
+    });
+
+    it('creates a new WebSocket after back-off delay', async () => {
+      const initialCount = 1; // first socket created in renderHook
+      renderHook(() => useMatchWebSocket({ url: 'ws://localhost:8090' }));
+      const ws = MockWebSocket.lastInstance();
+      act(() => ws.simulateOpen());
+      act(() => ws.simulateMessage({ type: 'welcome', protocol_version: 1, server_time: '' }));
+      act(() => ws.simulateClose());
+
+      // Advance timers to trigger reconnect (base 1s)
+      act(() => vi.advanceTimersByTime(2_000));
+
+      // A second socket should have been created
+      await waitFor(() => {
+        const allInstances = (MockWebSocket as unknown as { instances: MockWebSocket[] }).instances;
+        expect(allInstances.length).toBeGreaterThan(initialCount);
+      });
+    });
+  });
+
+  describe('enabled flag', () => {
+    it('does not create WebSocket when enabled=false', () => {
+      renderHook(() =>
+        useMatchWebSocket({ url: 'ws://localhost:8090', enabled: false }),
+      );
+      const allInstances = (MockWebSocket as unknown as { instances: MockWebSocket[] }).instances;
+      expect(allInstances.length).toBe(0);
+    });
+
+    it('sets status to "closed" when enabled=false', () => {
+      const { result } = renderHook(() =>
+        useMatchWebSocket({ url: 'ws://localhost:8090', enabled: false }),
+      );
+      expect(result.current.status).toBe('closed');
+    });
+  });
+
+  describe('reconnect() API', () => {
+    it('resets retry count and reconnects immediately', async () => {
+      const { result } = renderHook(() =>
+        useMatchWebSocket({ url: 'ws://localhost:8090' }),
+      );
+      const ws = MockWebSocket.lastInstance();
+      act(() => ws.simulateOpen());
+      act(() => ws.simulateMessage({ type: 'welcome', protocol_version: 1, server_time: '' }));
+      act(() => ws.simulateClose());
+
+      await waitFor(() => expect(result.current.status).toBe('reconnecting'));
+
+      act(() => result.current.reconnect());
+
+      const allInstances = (MockWebSocket as unknown as { instances: MockWebSocket[] }).instances;
+      await waitFor(() => expect(allInstances.length).toBeGreaterThan(1));
+      expect(result.current.status).toBe('connecting');
+    });
+  });
+
+  describe('error handling', () => {
+    it('sets error on rate_limited message', async () => {
+      const { result } = renderHook(() =>
+        useMatchWebSocket({ url: 'ws://localhost:8090', matchIds: [1] }),
+      );
+      const ws = MockWebSocket.lastInstance();
+      act(() => ws.simulateOpen());
+      act(() => ws.simulateMessage({ type: 'welcome', protocol_version: 1, server_time: '' }));
+
+      act(() =>
+        ws.simulateMessage({
+          type: 'rate_limited',
+          message: 'Too many subscribe commands',
+          retry_after_ms: 60000,
+        }),
+      );
+
+      await waitFor(() => expect(result.current.error).not.toBeNull());
+      expect(result.current.error).toMatch(/Too many/);
+    });
+
+    it('sets error on server error message', async () => {
+      const { result } = renderHook(() =>
+        useMatchWebSocket({ url: 'ws://localhost:8090' }),
+      );
+      const ws = MockWebSocket.lastInstance();
+      act(() => ws.simulateOpen());
+      act(() => ws.simulateMessage({ type: 'welcome', protocol_version: 1, server_time: '' }));
+
+      act(() =>
+        ws.simulateMessage({
+          type: 'error',
+          code: 'SUBSCRIBE_ERROR',
+          message: 'Subscription cap exceeded',
+        }),
+      );
+
+      await waitFor(() => expect(result.current.error).not.toBeNull());
+      expect(result.current.error).toMatch(/SUBSCRIBE_ERROR/);
+    });
+  });
+});

--- a/frontend/src/hooks/useMatchWebSocket.ts
+++ b/frontend/src/hooks/useMatchWebSocket.ts
@@ -1,0 +1,322 @@
+/**
+ * useMatchWebSocket
+ *
+ * React hook that maintains a WebSocket connection to the Checkmate-Escrow
+ * real-time server and delivers match events to the caller.
+ *
+ * Features:
+ *  - Automatic connection with 'welcome' handshake
+ *  - Subscribes to match IDs and/or player addresses
+ *  - Exponential back-off reconnect (1 s → 2 s → … capped at 30 s)
+ *  - Responds to server-initiated pings with pong
+ *  - Re-subscribes automatically after reconnect
+ *  - Returns connection status, latest event, and full event history
+ *  - Clean-up on unmount
+ *
+ * Protocol version: 1
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+// ─── Types (subset of the server's type definitions) ─────────────────────────
+
+export interface IndexedEvent {
+  id: string;
+  ledger_sequence: number;
+  match_id: number;
+  event_type: string;
+  player1?: string;
+  player2?: string;
+  status?: string;
+  winner?: string;
+  stake_amount?: string;
+  token?: string;
+  game_id?: string;
+  platform?: string;
+  timestamp: string;
+  txn_hash?: string;
+  event_index_in_txn?: number;
+}
+
+export type ConnectionStatus =
+  | 'connecting'
+  | 'connected'
+  | 'subscribing'
+  | 'ready'
+  | 'reconnecting'
+  | 'error'
+  | 'closed';
+
+export interface UseMatchWebSocketOptions {
+  /** Match IDs to subscribe to */
+  matchIds?: number[];
+  /** Player Stellar addresses to subscribe to */
+  playerAddresses?: string[];
+  /**
+   * WebSocket server URL.
+   * Defaults to VITE_WS_SERVER_URL env var, falling back to ws://localhost:8090
+   */
+  url?: string;
+  /**
+   * Whether the hook should be active.
+   * Set to false to disable the connection without unmounting the component.
+   * @default true
+   */
+  enabled?: boolean;
+  /**
+   * Maximum history length (number of events to retain).
+   * @default 100
+   */
+  maxHistory?: number;
+  /**
+   * Called for every event that arrives (regardless of history).
+   */
+  onEvent?: (event: IndexedEvent) => void;
+}
+
+export interface UseMatchWebSocketReturn {
+  status: ConnectionStatus;
+  /** The most recently received event, or null if none yet */
+  latestEvent: IndexedEvent | null;
+  /** All events received since mount (capped at maxHistory) */
+  events: IndexedEvent[];
+  /** Error message if status === 'error' */
+  error: string | null;
+  /** Force a re-connection (e.g. after an error) */
+  reconnect: () => void;
+}
+
+// ─── Internal message shapes ──────────────────────────────────────────────────
+
+interface WelcomeMsg { type: 'welcome'; protocol_version: number; server_time: string }
+interface SubscribedMsg { type: 'subscribed'; match_ids: number[]; player_addresses: string[] }
+interface EventMsg { type: 'event'; event: IndexedEvent }
+interface PingMsg { type: 'ping' }
+interface RateLimitedMsg { type: 'rate_limited'; message: string; retry_after_ms: number }
+interface ErrorMsg { type: 'error'; code: string; message: string }
+type ServerMsg = WelcomeMsg | SubscribedMsg | EventMsg | PingMsg | RateLimitedMsg | ErrorMsg | { type: string };
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const MAX_BACKOFF_MS = 30_000;
+const BASE_BACKOFF_MS = 1_000;
+
+// ─── Hook ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Connects to the Checkmate-Escrow WebSocket server and subscribes to
+ * real-time match events for the given match IDs and/or player addresses.
+ *
+ * @example
+ * ```tsx
+ * const { status, latestEvent, events } = useMatchWebSocket({
+ *   matchIds: [42],
+ *   playerAddresses: ['GABC...'],
+ *   onEvent: (e) => console.log('new event', e),
+ * });
+ * ```
+ */
+export function useMatchWebSocket({
+  matchIds = [],
+  playerAddresses = [],
+  url,
+  enabled = true,
+  maxHistory = 100,
+  onEvent,
+}: UseMatchWebSocketOptions = {}): UseMatchWebSocketReturn {
+  const resolvedUrl =
+    url ??
+    (typeof import.meta !== 'undefined' && (import.meta as { env?: Record<string, string> }).env?.VITE_WS_SERVER_URL) ??
+    'ws://localhost:8090';
+
+  const [status, setStatus] = useState<ConnectionStatus>('connecting');
+  const [latestEvent, setLatestEvent] = useState<IndexedEvent | null>(null);
+  const [events, setEvents] = useState<IndexedEvent[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  const wsRef = useRef<WebSocket | null>(null);
+  const retryCountRef = useRef(0);
+  const retryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  /** Stable refs to options so reconnect callback can read latest values */
+  const matchIdsRef = useRef(matchIds);
+  const playerAddressesRef = useRef(playerAddresses);
+  const onEventRef = useRef(onEvent);
+  const enabledRef = useRef(enabled);
+  const reconnectRequestedRef = useRef(false);
+
+  // Keep refs in sync with props without triggering reconnect
+  useEffect(() => { matchIdsRef.current = matchIds; }, [matchIds]);
+  useEffect(() => { playerAddressesRef.current = playerAddresses; }, [playerAddresses]);
+  useEffect(() => { onEventRef.current = onEvent; }, [onEvent]);
+  useEffect(() => { enabledRef.current = enabled; }, [enabled]);
+
+  const clearRetryTimer = useCallback(() => {
+    if (retryTimerRef.current) {
+      clearTimeout(retryTimerRef.current);
+      retryTimerRef.current = null;
+    }
+  }, []);
+
+  const connect = useCallback(() => {
+    if (!enabledRef.current) return;
+
+    // Close any existing socket
+    if (wsRef.current) {
+      wsRef.current.onclose = null; // prevent triggering reconnect loop
+      wsRef.current.close();
+      wsRef.current = null;
+    }
+
+    setStatus('connecting');
+    setError(null);
+
+    let ws: WebSocket;
+    try {
+      ws = new WebSocket(resolvedUrl);
+    } catch (err) {
+      setStatus('error');
+      setError(String(err));
+      return;
+    }
+
+    wsRef.current = ws;
+
+    ws.onopen = () => {
+      // Wait for 'welcome' before subscribing
+    };
+
+    ws.onmessage = (evt) => {
+      let msg: ServerMsg;
+      try {
+        msg = JSON.parse(evt.data as string) as ServerMsg;
+      } catch {
+        return;
+      }
+
+      switch (msg.type) {
+        case 'welcome': {
+          retryCountRef.current = 0; // reset back-off on successful handshake
+          setStatus('subscribing');
+          const ids = matchIdsRef.current;
+          const addrs = playerAddressesRef.current;
+          if (ids.length > 0 || addrs.length > 0) {
+            ws.send(
+              JSON.stringify({
+                type: 'subscribe',
+                payload: { match_ids: ids, player_addresses: addrs },
+              }),
+            );
+          } else {
+            setStatus('ready');
+          }
+          break;
+        }
+
+        case 'subscribed':
+          setStatus('ready');
+          break;
+
+        case 'event': {
+          const event = (msg as EventMsg).event;
+          setLatestEvent(event);
+          setEvents((prev) => {
+            const next = [...prev, event];
+            return next.length > maxHistory ? next.slice(next.length - maxHistory) : next;
+          });
+          onEventRef.current?.(event);
+          break;
+        }
+
+        case 'ping':
+          ws.send(JSON.stringify({ type: 'pong', server_time: new Date().toISOString() }));
+          break;
+
+        case 'rate_limited':
+          setError((msg as RateLimitedMsg).message);
+          break;
+
+        case 'error':
+          setError(`${(msg as ErrorMsg).code}: ${(msg as ErrorMsg).message}`);
+          break;
+      }
+    };
+
+    ws.onclose = (evt) => {
+      wsRef.current = null;
+      if (!enabledRef.current) {
+        setStatus('closed');
+        return;
+      }
+
+      const reason = evt.reason || `code ${evt.code}`;
+      const backoff = Math.min(BASE_BACKOFF_MS * 2 ** retryCountRef.current, MAX_BACKOFF_MS);
+      const jitter = Math.random() * 500;
+      retryCountRef.current += 1;
+
+      setStatus('reconnecting');
+      setError(`Disconnected (${reason}). Reconnecting in ${Math.round(backoff)}ms…`);
+
+      retryTimerRef.current = setTimeout(() => {
+        if (enabledRef.current || reconnectRequestedRef.current) {
+          reconnectRequestedRef.current = false;
+          connect();
+        }
+      }, backoff + jitter);
+    };
+
+    ws.onerror = () => {
+      // onerror is always followed by onclose; let onclose handle retry
+      setError('WebSocket error');
+    };
+  }, [resolvedUrl, maxHistory]); // only changes when URL or history cap changes
+
+  // Re-subscribe when matchIds / playerAddresses change after connection
+  useEffect(() => {
+    const ws = wsRef.current;
+    if (!ws || ws.readyState !== WebSocket.OPEN || status !== 'ready') return;
+    if (matchIds.length === 0 && playerAddresses.length === 0) return;
+
+    ws.send(
+      JSON.stringify({
+        type: 'subscribe',
+        payload: { match_ids: matchIds, player_addresses: playerAddresses },
+      }),
+    );
+  }, [matchIds, playerAddresses, status]);
+
+  // Connect on mount / when enabled changes
+  useEffect(() => {
+    if (!enabled) {
+      clearRetryTimer();
+      if (wsRef.current) {
+        wsRef.current.onclose = null;
+        wsRef.current.close();
+        wsRef.current = null;
+      }
+      setStatus('closed');
+      return;
+    }
+
+    connect();
+
+    return () => {
+      clearRetryTimer();
+      if (wsRef.current) {
+        wsRef.current.onclose = null;
+        wsRef.current.close();
+        wsRef.current = null;
+      }
+    };
+    // connect is stable (memoised); enabled controls the gate
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [enabled]);
+
+  const reconnect = useCallback(() => {
+    clearRetryTimer();
+    reconnectRequestedRef.current = true;
+    retryCountRef.current = 0;
+    connect();
+  }, [connect, clearRetryTimer]);
+
+  return { status, latestEvent, events, error, reconnect };
+}

--- a/services/websocket-server/package.json
+++ b/services/websocket-server/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "checkmate-websocket-server",
+  "version": "1.0.0",
+  "description": "WebSocket server for real-time match status updates in Checkmate-Escrow",
+  "private": true,
+  "type": "module",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "dev": "tsx watch src/index.ts",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:load": "tsx src/tests/load.test.ts",
+    "lint": "eslint src --ext .ts"
+  },
+  "dependencies": {
+    "ws": "8.18.0",
+    "node-fetch": "3.3.2",
+    "pino": "9.3.2",
+    "pino-pretty": "11.2.1"
+  },
+  "devDependencies": {
+    "@types/node": "22.5.0",
+    "@types/ws": "8.5.12",
+    "tsx": "4.19.1",
+    "typescript": "5.5.4",
+    "vitest": "2.1.8",
+    "@vitest/coverage-v8": "2.1.8"
+  }
+}

--- a/services/websocket-server/src/connectionManager.ts
+++ b/services/websocket-server/src/connectionManager.ts
@@ -1,0 +1,301 @@
+/**
+ * ConnectionManager
+ *
+ * Owns the ws.WebSocketServer instance and all per-connection lifecycle:
+ *   - sends the 'welcome' message on connect
+ *   - dispatches inbound client messages to SubscriptionManager
+ *   - runs the heartbeat loop (ping every N seconds, close stale connections)
+ *   - logs disconnect reasons
+ *   - calls SubscriptionManager.removeClient on close
+ *   - exposes a `broadcast(event)` method for the poller to call
+ */
+
+import { WebSocketServer, WebSocket } from 'ws';
+import { randomUUID } from 'crypto';
+import type {
+  ClientMessage,
+  ClientState,
+  IndexedEvent,
+  ServerConfig,
+  ServerMessage,
+} from './types.js';
+import { PROTOCOL_VERSION } from './types.js';
+import { SubscriptionManager } from './subscriptionManager.js';
+import { logger } from './logger.js';
+
+export class ConnectionManager {
+  private wss: WebSocketServer;
+  private readonly subscriptions: SubscriptionManager;
+  /** Map clientId → raw WebSocket for message delivery */
+  private readonly sockets = new Map<string, WebSocket>();
+  private heartbeatTimer: ReturnType<typeof setInterval> | null = null;
+
+  constructor(private readonly config: ServerConfig) {
+    this.subscriptions = new SubscriptionManager({
+      maxSubscriptionsPerClient: config.maxSubscriptionsPerClient,
+      rateLimitMaxSubscribes: config.rateLimitMaxSubscribes,
+      rateLimitWindowMs: config.rateLimitWindowMs,
+    });
+
+    this.wss = new WebSocketServer({
+      host: config.host,
+      port: config.port,
+      // Limit back-pressure: each socket gets its own send queue
+      perMessageDeflate: false,
+    });
+  }
+
+  // ─── Lifecycle ─────────────────────────────────────────────────────────
+
+  start(): void {
+    this.wss.on('connection', (ws, req) => this.handleConnection(ws, req));
+    this.wss.on('error', (err) => {
+      logger.error({ err }, 'WebSocketServer error');
+    });
+
+    this.heartbeatTimer = setInterval(
+      () => this.runHeartbeat(),
+      this.config.heartbeatIntervalMs,
+    );
+
+    logger.info(
+      { host: this.config.host, port: this.config.port },
+      'WebSocket server listening',
+    );
+  }
+
+  stop(): Promise<void> {
+    if (this.heartbeatTimer) {
+      clearInterval(this.heartbeatTimer);
+      this.heartbeatTimer = null;
+    }
+    return new Promise((resolve, reject) => {
+      this.wss.close((err) => (err ? reject(err) : resolve()));
+    });
+  }
+
+  get connectionCount(): number {
+    return this.subscriptions.clientCount;
+  }
+
+  /** Push an event to all clients that subscribed to it */
+  broadcast(event: IndexedEvent): void {
+    const targets = this.subscriptions.matchingClients(event);
+    if (targets.size === 0) return;
+
+    const msg = JSON.stringify({ type: 'event', event } satisfies ServerMessage);
+
+    for (const clientId of targets) {
+      const ws = this.sockets.get(clientId);
+      if (ws && ws.readyState === WebSocket.OPEN) {
+        ws.send(msg, (err) => {
+          if (err) {
+            logger.warn({ clientId, err }, 'Failed to send event to client');
+          }
+        });
+      }
+    }
+
+    logger.debug(
+      { matchId: event.match_id, eventType: event.event_type, recipientCount: targets.size },
+      'Broadcast event',
+    );
+  }
+
+  // ─── Connection handler ────────────────────────────────────────────────
+
+  private handleConnection(ws: WebSocket, req: import('http').IncomingMessage): void {
+    const clientId = randomUUID();
+    const remoteAddress =
+      (req.headers['x-forwarded-for'] as string | undefined)?.split(',')[0]?.trim() ??
+      req.socket.remoteAddress ??
+      'unknown';
+
+    const state: ClientState = {
+      id: clientId,
+      matchIds: new Set(),
+      playerAddresses: new Set(),
+      lastSeenAt: Date.now(),
+      subscribeCount: 0,
+      rateLimitWindowStart: Date.now(),
+      remoteAddress,
+    };
+
+    this.subscriptions.addClient(state);
+    this.sockets.set(clientId, ws);
+
+    logger.info({ clientId, remoteAddress, total: this.connectionCount }, 'Client connected');
+
+    // Send welcome
+    this.send(ws, {
+      type: 'welcome',
+      protocol_version: PROTOCOL_VERSION,
+      server_time: new Date().toISOString(),
+    });
+
+    ws.on('message', (data) => {
+      state.lastSeenAt = Date.now();
+      this.handleMessage(clientId, ws, data.toString());
+    });
+
+    ws.on('close', (code, reason) => {
+      const reasonStr = reason.toString() || `code=${code}`;
+      state.disconnectReason = reasonStr;
+      logger.info(
+        { clientId, remoteAddress, reason: reasonStr, total: this.connectionCount - 1 },
+        'Client disconnected',
+      );
+      this.subscriptions.removeClient(clientId);
+      this.sockets.delete(clientId);
+    });
+
+    ws.on('error', (err) => {
+      state.disconnectReason = err.message;
+      logger.warn({ clientId, remoteAddress, err }, 'Client socket error');
+    });
+
+    // Respond to built-in WebSocket pings
+    ws.on('ping', () => {
+      state.lastSeenAt = Date.now();
+    });
+  }
+
+  // ─── Message dispatcher ────────────────────────────────────────────────
+
+  private handleMessage(clientId: string, ws: WebSocket, raw: string): void {
+    let msg: ClientMessage;
+    try {
+      msg = JSON.parse(raw) as ClientMessage;
+    } catch {
+      this.send(ws, {
+        type: 'error',
+        code: 'PARSE_ERROR',
+        message: 'Message must be valid JSON',
+      });
+      return;
+    }
+
+    if (!msg || typeof msg.type !== 'string') {
+      this.send(ws, {
+        type: 'error',
+        code: 'INVALID_MESSAGE',
+        message: 'Missing required field: type',
+      });
+      return;
+    }
+
+    switch (msg.type) {
+      case 'subscribe': {
+        const result = this.subscriptions.subscribe(
+          clientId,
+          msg.payload?.match_ids,
+          msg.payload?.player_addresses,
+        );
+        if (!result.ok) {
+          const isRateLimit = result.error?.startsWith('rate_limited');
+          if (isRateLimit) {
+            this.send(ws, {
+              type: 'rate_limited',
+              message: result.error!,
+              retry_after_ms: this.config.rateLimitWindowMs,
+            });
+          } else {
+            this.send(ws, {
+              type: 'error',
+              code: 'SUBSCRIBE_ERROR',
+              message: result.error!,
+            });
+          }
+        } else {
+          const clientState = this.subscriptions.getClient(clientId)!;
+          this.send(ws, {
+            type: 'subscribed',
+            match_ids: Array.from(clientState.matchIds),
+            player_addresses: Array.from(clientState.playerAddresses),
+          });
+        }
+        break;
+      }
+
+      case 'unsubscribe': {
+        const result = this.subscriptions.unsubscribe(
+          clientId,
+          msg.payload?.match_ids,
+          msg.payload?.player_addresses,
+        );
+        if (!result.ok) {
+          this.send(ws, {
+            type: 'error',
+            code: 'UNSUBSCRIBE_ERROR',
+            message: result.error!,
+          });
+        } else {
+          const clientState = this.subscriptions.getClient(clientId)!;
+          this.send(ws, {
+            type: 'unsubscribed',
+            match_ids: msg.payload?.match_ids ?? [],
+            player_addresses: msg.payload?.player_addresses ?? [],
+          });
+          logger.debug(
+            {
+              clientId,
+              remaining: clientState.matchIds.size + clientState.playerAddresses.size,
+            },
+            'Client unsubscribed',
+          );
+        }
+        break;
+      }
+
+      case 'ping':
+        this.send(ws, { type: 'pong', server_time: new Date().toISOString() });
+        break;
+
+      default:
+        this.send(ws, {
+          type: 'error',
+          code: 'UNKNOWN_MESSAGE_TYPE',
+          message: `Unknown message type: ${(msg as { type: string }).type}`,
+        });
+    }
+  }
+
+  // ─── Heartbeat ─────────────────────────────────────────────────────────
+
+  private runHeartbeat(): void {
+    const now = Date.now();
+    const timeout = this.config.heartbeatTimeoutMs;
+    let pinged = 0;
+    let terminated = 0;
+
+    for (const state of this.subscriptions.allClients()) {
+      const ws = this.sockets.get(state.id);
+      if (!ws || ws.readyState !== WebSocket.OPEN) continue;
+
+      if (now - state.lastSeenAt > timeout) {
+        state.disconnectReason = 'heartbeat_timeout';
+        ws.terminate();
+        terminated += 1;
+      } else {
+        // Native WebSocket ping (distinct from app-level ping)
+        ws.ping(undefined, false, (err) => {
+          if (err) logger.warn({ clientId: state.id, err }, 'Heartbeat ping failed');
+        });
+        pinged += 1;
+      }
+    }
+
+    if (pinged > 0 || terminated > 0) {
+      logger.debug({ pinged, terminated }, 'Heartbeat cycle');
+    }
+  }
+
+  // ─── Helpers ───────────────────────────────────────────────────────────
+
+  private send(ws: WebSocket, msg: ServerMessage): void {
+    if (ws.readyState !== WebSocket.OPEN) return;
+    ws.send(JSON.stringify(msg), (err) => {
+      if (err) logger.warn({ err }, 'Failed to send message');
+    });
+  }
+}

--- a/services/websocket-server/src/eventPoller.ts
+++ b/services/websocket-server/src/eventPoller.ts
@@ -1,0 +1,106 @@
+/**
+ * EventPoller
+ *
+ * Periodically fetches new events from the event-indexer REST API and calls a
+ * callback for each one.  Tracks the highest seen ledger sequence so every
+ * event is emitted exactly once.
+ *
+ * Retry strategy: exponential back-off (1 s → 2 s → 4 s … capped at 30 s)
+ * with jitter so multiple instances don't thundering-herd the indexer.
+ */
+
+import type { IndexedEvent, ServerConfig } from './types.js';
+import { logger } from './logger.js';
+
+type EventCallback = (event: IndexedEvent) => void;
+
+interface ApiResponse<T> {
+  success: boolean;
+  data: T | null;
+  error: string | null;
+}
+
+export class EventPoller {
+  private running = false;
+  private timer: ReturnType<typeof setTimeout> | null = null;
+  /** Highest ledger_sequence we have already dispatched */
+  private highWatermark = 0;
+  /** Consecutive failure count (for back-off) */
+  private consecutiveFailures = 0;
+
+  constructor(
+    private readonly config: Pick<ServerConfig, 'eventIndexerUrl' | 'pollIntervalMs'>,
+    private readonly onEvent: EventCallback,
+  ) {}
+
+  start(): void {
+    if (this.running) return;
+    this.running = true;
+    this.scheduleNext(0); // first poll immediately
+  }
+
+  stop(): void {
+    this.running = false;
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+  }
+
+  // ─── Internal ──────────────────────────────────────────────────────────
+
+  private scheduleNext(delayMs: number): void {
+    this.timer = setTimeout(() => {
+      void this.poll();
+    }, delayMs);
+  }
+
+  private async poll(): Promise<void> {
+    if (!this.running) return;
+
+    try {
+      const events = await this.fetchNewEvents();
+      this.consecutiveFailures = 0;
+
+      let maxLedger = this.highWatermark;
+      // Sort ascending so callbacks arrive in ledger order
+      const sorted = events.sort(
+        (a, b) => a.ledger_sequence - b.ledger_sequence || a.event_index_in_txn! - b.event_index_in_txn!,
+      );
+
+      for (const event of sorted) {
+        if (event.ledger_sequence > this.highWatermark) {
+          this.onEvent(event);
+          if (event.ledger_sequence > maxLedger) maxLedger = event.ledger_sequence;
+        }
+      }
+
+      this.highWatermark = maxLedger;
+      this.scheduleNext(this.config.pollIntervalMs);
+    } catch (err) {
+      this.consecutiveFailures += 1;
+      const backoff = Math.min(1000 * 2 ** (this.consecutiveFailures - 1), 30_000);
+      const jitter = Math.random() * 500;
+      const delay = backoff + jitter;
+      logger.warn(
+        { err, consecutiveFailures: this.consecutiveFailures, retryAfterMs: Math.round(delay) },
+        'EventPoller: fetch failed, retrying with back-off',
+      );
+      this.scheduleNext(delay);
+    }
+  }
+
+  private async fetchNewEvents(): Promise<IndexedEvent[]> {
+    const url = `${this.config.eventIndexerUrl}/events`;
+    const res = await fetch(url);
+    if (!res.ok) {
+      throw new Error(`Event-indexer responded ${res.status} ${res.statusText}`);
+    }
+    const body = (await res.json()) as ApiResponse<IndexedEvent[]>;
+    if (!body.success || !body.data) {
+      // The indexer returns 404 with success=false when no events exist yet
+      return [];
+    }
+    return body.data;
+  }
+}

--- a/services/websocket-server/src/index.ts
+++ b/services/websocket-server/src/index.ts
@@ -1,0 +1,44 @@
+/**
+ * Checkmate-Escrow WebSocket Server — Entry Point
+ *
+ * Reads config from environment, starts the WebSocket server, and kicks off
+ * the event poller which feeds broadcasted events to subscribed clients.
+ */
+
+import { loadConfig } from './types.js';
+import { ConnectionManager } from './connectionManager.js';
+import { EventPoller } from './eventPoller.js';
+import { logger } from './logger.js';
+
+const config = loadConfig();
+
+const connectionManager = new ConnectionManager(config);
+connectionManager.start();
+
+const poller = new EventPoller(config, (event) => {
+  connectionManager.broadcast(event);
+});
+poller.start();
+
+logger.info(
+  {
+    wsPort: config.port,
+    eventIndexerUrl: config.eventIndexerUrl,
+    pollIntervalMs: config.pollIntervalMs,
+    heartbeatIntervalMs: config.heartbeatIntervalMs,
+  },
+  'Checkmate WebSocket server started',
+);
+
+// ─── Graceful shutdown ────────────────────────────────────────────────────
+
+async function shutdown(signal: string): Promise<void> {
+  logger.info({ signal }, 'Shutting down');
+  poller.stop();
+  await connectionManager.stop();
+  logger.info('Shutdown complete');
+  process.exit(0);
+}
+
+process.on('SIGTERM', () => void shutdown('SIGTERM'));
+process.on('SIGINT', () => void shutdown('SIGINT'));

--- a/services/websocket-server/src/logger.ts
+++ b/services/websocket-server/src/logger.ts
@@ -1,0 +1,9 @@
+import pino from 'pino';
+
+export const logger = pino({
+  level: process.env.LOG_LEVEL ?? 'info',
+  transport:
+    process.env.NODE_ENV !== 'production'
+      ? { target: 'pino-pretty', options: { colorize: true } }
+      : undefined,
+});

--- a/services/websocket-server/src/subscriptionManager.ts
+++ b/services/websocket-server/src/subscriptionManager.ts
@@ -1,0 +1,224 @@
+/**
+ * SubscriptionManager
+ *
+ * Tracks which clients are interested in which match IDs / player addresses
+ * and efficiently routes incoming events to the correct set of WebSocket
+ * connections.
+ *
+ * Design decisions:
+ *  - Two separate indices (matchId → clientIds, playerAddress → clientIds) for
+ *    O(1) dispatch without iterating over every connected client.
+ *  - All mutations are synchronous; the caller is responsible for concurrency.
+ *  - Validation of subscription payloads happens here, not in the transport
+ *    layer, so the same logic can be exercised in pure-unit tests.
+ */
+
+import type { ClientState, IndexedEvent, ServerConfig } from './types.js';
+
+export interface SubscriptionResult {
+  ok: boolean;
+  error?: string;
+}
+
+export class SubscriptionManager {
+  /** clientId → ClientState */
+  private readonly clients = new Map<string, ClientState>();
+
+  /** matchId → Set<clientId> */
+  private readonly matchIndex = new Map<number, Set<string>>();
+
+  /** playerAddress (lower-cased) → Set<clientId> */
+  private readonly playerIndex = new Map<string, Set<string>>();
+
+  constructor(private readonly config: Pick<ServerConfig, 'maxSubscriptionsPerClient' | 'rateLimitMaxSubscribes' | 'rateLimitWindowMs'>) {}
+
+  // ─── Client lifecycle ──────────────────────────────────────────────────
+
+  addClient(state: ClientState): void {
+    this.clients.set(state.id, state);
+  }
+
+  removeClient(clientId: string): void {
+    const state = this.clients.get(clientId);
+    if (!state) return;
+
+    // Remove from match index
+    for (const matchId of state.matchIds) {
+      this.removeFromMatchIndex(matchId, clientId);
+    }
+
+    // Remove from player index
+    for (const addr of state.playerAddresses) {
+      this.removeFromPlayerIndex(addr, clientId);
+    }
+
+    this.clients.delete(clientId);
+  }
+
+  getClient(clientId: string): ClientState | undefined {
+    return this.clients.get(clientId);
+  }
+
+  get clientCount(): number {
+    return this.clients.size;
+  }
+
+  allClients(): IterableIterator<ClientState> {
+    return this.clients.values();
+  }
+
+  // ─── Subscription mutation ─────────────────────────────────────────────
+
+  /**
+   * Subscribe a client to a set of match IDs and/or player addresses.
+   *
+   * Enforces:
+   *  - Rate limiting (max N subscribe commands per window)
+   *  - Per-client subscription cap
+   *  - Basic input validation
+   */
+  subscribe(
+    clientId: string,
+    matchIds: number[] = [],
+    playerAddresses: string[] = [],
+  ): SubscriptionResult {
+    const state = this.clients.get(clientId);
+    if (!state) return { ok: false, error: 'Client not found' };
+
+    // ── Rate limit ────────────────────────────────────────────────────────
+    const now = Date.now();
+    const windowElapsed = now - state.rateLimitWindowStart;
+    if (windowElapsed > this.config.rateLimitWindowMs) {
+      state.subscribeCount = 0;
+      state.rateLimitWindowStart = now;
+    }
+    state.subscribeCount += 1;
+    if (state.subscribeCount > this.config.rateLimitMaxSubscribes) {
+      return {
+        ok: false,
+        error: `rate_limited: max ${this.config.rateLimitMaxSubscribes} subscription commands per ${this.config.rateLimitWindowMs}ms`,
+      };
+    }
+
+    // ── Input validation ──────────────────────────────────────────────────
+    for (const id of matchIds) {
+      if (!Number.isInteger(id) || id < 0) {
+        return { ok: false, error: `Invalid match_id: ${id}` };
+      }
+    }
+    for (const addr of playerAddresses) {
+      if (typeof addr !== 'string' || addr.trim().length === 0) {
+        return { ok: false, error: `Invalid player_address: ${String(addr)}` };
+      }
+    }
+
+    // ── Cap check ─────────────────────────────────────────────────────────
+    const newMatchIds = matchIds.filter((id) => !state.matchIds.has(id));
+    const newAddresses = playerAddresses.filter((a) => !state.playerAddresses.has(a.toLowerCase()));
+    const projectedTotal =
+      state.matchIds.size + state.playerAddresses.size + newMatchIds.length + newAddresses.length;
+    if (projectedTotal > this.config.maxSubscriptionsPerClient) {
+      return {
+        ok: false,
+        error: `Subscription cap exceeded (max ${this.config.maxSubscriptionsPerClient})`,
+      };
+    }
+
+    // ── Apply ─────────────────────────────────────────────────────────────
+    for (const id of newMatchIds) {
+      state.matchIds.add(id);
+      let set = this.matchIndex.get(id);
+      if (!set) {
+        set = new Set();
+        this.matchIndex.set(id, set);
+      }
+      set.add(clientId);
+    }
+
+    for (const raw of newAddresses) {
+      const addr = raw.toLowerCase();
+      state.playerAddresses.add(addr);
+      let set = this.playerIndex.get(addr);
+      if (!set) {
+        set = new Set();
+        this.playerIndex.set(addr, set);
+      }
+      set.add(clientId);
+    }
+
+    return { ok: true };
+  }
+
+  /**
+   * Unsubscribe a client from the given match IDs and/or player addresses.
+   */
+  unsubscribe(
+    clientId: string,
+    matchIds: number[] = [],
+    playerAddresses: string[] = [],
+  ): SubscriptionResult {
+    const state = this.clients.get(clientId);
+    if (!state) return { ok: false, error: 'Client not found' };
+
+    for (const id of matchIds) {
+      state.matchIds.delete(id);
+      this.removeFromMatchIndex(id, clientId);
+    }
+
+    for (const raw of playerAddresses) {
+      const addr = raw.toLowerCase();
+      state.playerAddresses.delete(addr);
+      this.removeFromPlayerIndex(addr, clientId);
+    }
+
+    return { ok: true };
+  }
+
+  // ─── Event routing ─────────────────────────────────────────────────────
+
+  /**
+   * Given an event, returns the deduplicated set of client IDs that should
+   * receive it based on their subscriptions.
+   */
+  matchingClients(event: IndexedEvent): Set<string> {
+    const result = new Set<string>();
+
+    // Match by match_id
+    const byMatch = this.matchIndex.get(event.match_id);
+    if (byMatch) {
+      for (const id of byMatch) result.add(id);
+    }
+
+    // Match by player address (player1 or player2)
+    if (event.player1) {
+      const byPlayer1 = this.playerIndex.get(event.player1.toLowerCase());
+      if (byPlayer1) {
+        for (const id of byPlayer1) result.add(id);
+      }
+    }
+    if (event.player2) {
+      const byPlayer2 = this.playerIndex.get(event.player2.toLowerCase());
+      if (byPlayer2) {
+        for (const id of byPlayer2) result.add(id);
+      }
+    }
+
+    return result;
+  }
+
+  // ─── Helpers ───────────────────────────────────────────────────────────
+
+  private removeFromMatchIndex(matchId: number, clientId: string): void {
+    const set = this.matchIndex.get(matchId);
+    if (!set) return;
+    set.delete(clientId);
+    if (set.size === 0) this.matchIndex.delete(matchId);
+  }
+
+  private removeFromPlayerIndex(addr: string, clientId: string): void {
+    const set = this.playerIndex.get(addr);
+    if (!set) return;
+    set.delete(clientId);
+    if (set.size === 0) this.playerIndex.delete(addr);
+  }
+}

--- a/services/websocket-server/src/tests/integration.test.ts
+++ b/services/websocket-server/src/tests/integration.test.ts
@@ -1,0 +1,341 @@
+/**
+ * Integration tests: WebSocket server ↔ event-indexer
+ *
+ * These tests spin up:
+ *   1. A lightweight HTTP mock of the event-indexer REST API
+ *   2. The real EventPoller wired to that mock
+ *   3. The real ConnectionManager (WebSocket server)
+ *
+ * They verify the full end-to-end flow: event-indexer emits events →
+ * EventPoller picks them up → ConnectionManager broadcasts to clients →
+ * clients receive the event over their WebSocket connection.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import WebSocket from 'ws';
+import http from 'http';
+import { ConnectionManager } from '../connectionManager.js';
+import { EventPoller } from '../eventPoller.js';
+import type { IndexedEvent, ServerConfig } from '../types.js';
+
+// ─── Port registry — avoid conflicts between tests ────────────────────────
+
+let nextPort = 9200;
+function allocPort(): number { return nextPort++; }
+
+// ─── Helpers ──────────────────────────────────────────────────────────────
+
+function buildConfig(wsPort: number, indexerPort: number): ServerConfig {
+  return {
+    port: wsPort,
+    host: '127.0.0.1',
+    eventIndexerUrl: `http://127.0.0.1:${indexerPort}`,
+    pollIntervalMs: 100,         // fast polling for tests
+    heartbeatIntervalMs: 60_000,
+    heartbeatTimeoutMs: 120_000,
+    rateLimitMaxSubscribes: 100,
+    rateLimitWindowMs: 60_000,
+    maxSubscriptionsPerClient: 50,
+    logLevel: 'warn',
+  };
+}
+
+/**
+ * Minimal HTTP server that returns the configured events on GET /events.
+ * Supports dynamically updating the events list via `setEvents`.
+ */
+function createMockIndexer(port: number): {
+  setEvents: (events: IndexedEvent[]) => void;
+  stop: () => Promise<void>;
+} {
+  let currentEvents: IndexedEvent[] = [];
+  const server = http.createServer((_req, res) => {
+    if (currentEvents.length === 0) {
+      res.writeHead(404, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ success: false, data: null, error: 'No events found' }));
+    } else {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ success: true, data: currentEvents, error: null }));
+    }
+  });
+
+  server.listen(port);
+
+  return {
+    setEvents: (events) => { currentEvents = events; },
+    stop: () =>
+      new Promise((resolve, reject) =>
+        server.close((err) => (err ? reject(err) : resolve())),
+      ),
+  };
+}
+
+function connectClient(wsPort: number): Promise<WebSocket> {
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(`ws://127.0.0.1:${wsPort}`);
+    ws.once('open', () => resolve(ws));
+    ws.once('error', reject);
+  });
+}
+
+function waitForMessage(ws: WebSocket, type: string, timeoutMs = 5_000): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(
+      () => reject(new Error(`Timed out waiting for message type '${type}'`)),
+      timeoutMs,
+    );
+    ws.on('message', function handler(raw) {
+      try {
+        const msg = JSON.parse(raw.toString()) as { type: string };
+        if (msg.type === type) {
+          clearTimeout(timer);
+          ws.off('message', handler);
+          resolve(msg);
+        }
+      } catch {/* ignore */}
+    });
+  });
+}
+
+function makeEvent(overrides: Partial<IndexedEvent> = {}): IndexedEvent {
+  return {
+    id: `evt-${Date.now()}`,
+    ledger_sequence: 1000,
+    match_id: 1,
+    event_type: 'match/created',
+    player1: 'GABC',
+    player2: 'GDEF',
+    timestamp: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+// ─── Test suite ───────────────────────────────────────────────────────────
+
+describe('WebSocket server ↔ event-indexer integration', () => {
+  let wsPort: number;
+  let indexerPort: number;
+  let indexer: ReturnType<typeof createMockIndexer>;
+  let manager: ConnectionManager;
+  let poller: EventPoller;
+
+  beforeEach(async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+
+    wsPort = allocPort();
+    indexerPort = allocPort();
+
+    indexer = createMockIndexer(indexerPort);
+    const config = buildConfig(wsPort, indexerPort);
+
+    manager = new ConnectionManager(config);
+    manager.start();
+
+    poller = new EventPoller(config, (event) => manager.broadcast(event));
+  });
+
+  afterEach(async () => {
+    poller.stop();
+    await manager.stop();
+    await indexer.stop();
+    vi.useRealTimers();
+  });
+
+  // ── Connection handshake ───────────────────────────────────────────────
+
+  it('sends protocol version 1 welcome on connect', async () => {
+    const ws = await connectClient(wsPort);
+    const msg = (await waitForMessage(ws, 'welcome')) as { protocol_version: number };
+    expect(msg.protocol_version).toBe(1);
+    ws.close();
+  });
+
+  it('acknowledges subscription with subscribed message', async () => {
+    const ws = await connectClient(wsPort);
+    await waitForMessage(ws, 'welcome');
+
+    ws.send(JSON.stringify({ type: 'subscribe', payload: { match_ids: [42] } }));
+    const sub = (await waitForMessage(ws, 'subscribed')) as { match_ids: number[] };
+    expect(sub.match_ids).toContain(42);
+    ws.close();
+  });
+
+  // ── Event delivery ─────────────────────────────────────────────────────
+
+  it('delivers a polled event to a subscribed client', async () => {
+    const ws = await connectClient(wsPort);
+    await waitForMessage(ws, 'welcome');
+    ws.send(JSON.stringify({ type: 'subscribe', payload: { match_ids: [7] } }));
+    await waitForMessage(ws, 'subscribed');
+
+    // Prime the mock indexer with an event
+    indexer.setEvents([makeEvent({ match_id: 7, ledger_sequence: 2000 })]);
+
+    // Start polling — event should arrive
+    poller.start();
+
+    const eventMsg = (await waitForMessage(ws, 'event', 3_000)) as { event: IndexedEvent };
+    expect(eventMsg.event.match_id).toBe(7);
+    expect(eventMsg.event.event_type).toBe('match/created');
+    ws.close();
+  });
+
+  it('does NOT deliver event to client subscribed to different match', async () => {
+    const ws = await connectClient(wsPort);
+    await waitForMessage(ws, 'welcome');
+    ws.send(JSON.stringify({ type: 'subscribe', payload: { match_ids: [99] } }));
+    await waitForMessage(ws, 'subscribed');
+
+    indexer.setEvents([makeEvent({ match_id: 7, ledger_sequence: 2001 })]);
+    poller.start();
+
+    // Wait 500 ms — should not receive an event
+    const received = await new Promise<boolean>((resolve) => {
+      const timer = setTimeout(() => resolve(false), 500);
+      ws.on('message', (raw) => {
+        const msg = JSON.parse(raw.toString()) as { type: string };
+        if (msg.type === 'event') {
+          clearTimeout(timer);
+          resolve(true);
+        }
+      });
+    });
+
+    expect(received).toBe(false);
+    ws.close();
+  });
+
+  it('delivers event to client subscribed by player address', async () => {
+    const ws = await connectClient(wsPort);
+    await waitForMessage(ws, 'welcome');
+    ws.send(JSON.stringify({
+      type: 'subscribe',
+      payload: { player_addresses: ['GABC'] },
+    }));
+    await waitForMessage(ws, 'subscribed');
+
+    indexer.setEvents([makeEvent({ match_id: 5, player1: 'GABC', ledger_sequence: 3000 })]);
+    poller.start();
+
+    const eventMsg = (await waitForMessage(ws, 'event', 3_000)) as { event: IndexedEvent };
+    expect(eventMsg.event.player1).toBe('GABC');
+    ws.close();
+  });
+
+  it('does not deliver the same event twice', async () => {
+    const ws = await connectClient(wsPort);
+    await waitForMessage(ws, 'welcome');
+    ws.send(JSON.stringify({ type: 'subscribe', payload: { match_ids: [7] } }));
+    await waitForMessage(ws, 'subscribed');
+
+    const event = makeEvent({ match_id: 7, ledger_sequence: 4000 });
+    indexer.setEvents([event]);
+    poller.start();
+
+    let eventCount = 0;
+    ws.on('message', (raw) => {
+      const msg = JSON.parse(raw.toString()) as { type: string };
+      if (msg.type === 'event') eventCount += 1;
+    });
+
+    // First poll delivers the event
+    await waitForMessage(ws, 'event', 3_000);
+
+    // Wait for a second poll cycle — event should not re-deliver
+    await new Promise((r) => setTimeout(r, 300));
+
+    expect(eventCount).toBe(1);
+    ws.close();
+  });
+
+  // ── Error handling ─────────────────────────────────────────────────────
+
+  it('returns error message for invalid JSON', async () => {
+    const ws = await connectClient(wsPort);
+    await waitForMessage(ws, 'welcome');
+
+    ws.send('this is not json');
+    const err = (await waitForMessage(ws, 'error')) as { code: string };
+    expect(err.code).toBe('PARSE_ERROR');
+    ws.close();
+  });
+
+  it('returns error message for unknown message type', async () => {
+    const ws = await connectClient(wsPort);
+    await waitForMessage(ws, 'welcome');
+
+    ws.send(JSON.stringify({ type: 'bogus' }));
+    const err = (await waitForMessage(ws, 'error')) as { code: string };
+    expect(err.code).toBe('UNKNOWN_MESSAGE_TYPE');
+    ws.close();
+  });
+
+  it('responds to ping with pong', async () => {
+    const ws = await connectClient(wsPort);
+    await waitForMessage(ws, 'welcome');
+
+    ws.send(JSON.stringify({ type: 'ping' }));
+    const pong = (await waitForMessage(ws, 'pong')) as { server_time: string };
+    expect(typeof pong.server_time).toBe('string');
+    ws.close();
+  });
+
+  // ── Unsubscribe ────────────────────────────────────────────────────────
+
+  it('stops delivering events after unsubscribe', async () => {
+    const ws = await connectClient(wsPort);
+    await waitForMessage(ws, 'welcome');
+    ws.send(JSON.stringify({ type: 'subscribe', payload: { match_ids: [7] } }));
+    await waitForMessage(ws, 'subscribed');
+
+    // Unsubscribe before any events arrive
+    ws.send(JSON.stringify({ type: 'unsubscribe', payload: { match_ids: [7] } }));
+    await waitForMessage(ws, 'unsubscribed');
+
+    indexer.setEvents([makeEvent({ match_id: 7, ledger_sequence: 5000 })]);
+    poller.start();
+
+    const received = await new Promise<boolean>((resolve) => {
+      const timer = setTimeout(() => resolve(false), 500);
+      ws.on('message', (raw) => {
+        const msg = JSON.parse(raw.toString()) as { type: string };
+        if (msg.type === 'event') { clearTimeout(timer); resolve(true); }
+      });
+    });
+
+    expect(received).toBe(false);
+    ws.close();
+  });
+
+  // ── Rate limiting ──────────────────────────────────────────────────────
+
+  it('rate-limits clients that exceed subscribe command threshold', async () => {
+    // Build a very tight rate-limit config
+    const tightWsPort = allocPort();
+    const tightCfg = buildConfig(tightWsPort, indexerPort);
+    tightCfg.rateLimitMaxSubscribes = 2;
+    tightCfg.rateLimitWindowMs = 60_000;
+
+    const tightManager = new ConnectionManager(tightCfg);
+    tightManager.start();
+
+    try {
+      const ws = await connectClient(tightWsPort);
+      await waitForMessage(ws, 'welcome');
+
+      // 2 subscribes should work
+      ws.send(JSON.stringify({ type: 'subscribe', payload: { match_ids: [1] } }));
+      await waitForMessage(ws, 'subscribed');
+      ws.send(JSON.stringify({ type: 'subscribe', payload: { match_ids: [2] } }));
+      await waitForMessage(ws, 'subscribed');
+
+      // 3rd should be rate-limited
+      ws.send(JSON.stringify({ type: 'subscribe', payload: { match_ids: [3] } }));
+      const rateLimited = (await waitForMessage(ws, 'rate_limited')) as { retry_after_ms: number };
+      expect(rateLimited.retry_after_ms).toBeGreaterThan(0);
+      ws.close();
+    } finally {
+      await tightManager.stop();
+    }
+  });
+});

--- a/services/websocket-server/src/tests/load.test.ts
+++ b/services/websocket-server/src/tests/load.test.ts
@@ -1,0 +1,232 @@
+/**
+ * Load test: 1000+ concurrent WebSocket connections
+ *
+ * Run with: npm run test:load
+ * (This file is excluded from the normal vitest run because it starts a real
+ * server and holds 1000+ sockets open simultaneously.)
+ *
+ * What it tests:
+ *   1. The server accepts 1000 concurrent connections without crashing
+ *   2. Every connected client receives the correct 'welcome' message
+ *   3. Targeted event broadcast reaches only subscribed clients and not others
+ *   4. Peak RSS memory is below a generous 512 MB threshold
+ *   5. All connections close cleanly
+ */
+
+import WebSocket from 'ws';
+import { ConnectionManager } from '../connectionManager.js';
+import type { ServerConfig } from '../types.js';
+
+const LOAD_PORT = 9099;
+const TOTAL_CLIENTS = 1_000;
+const SUBSCRIBED_MATCH_ID = 42;
+const SUBSCRIBED_COUNT = 200; // first 200 clients subscribe to match 42
+
+const TEST_CONFIG: ServerConfig = {
+  port: LOAD_PORT,
+  host: '127.0.0.1',
+  eventIndexerUrl: 'http://localhost:8080',
+  pollIntervalMs: 5_000,
+  heartbeatIntervalMs: 60_000,    // long — don't interfere with the test
+  heartbeatTimeoutMs: 120_000,
+  rateLimitMaxSubscribes: 1_000,  // generous for load test
+  rateLimitWindowMs: 60_000,
+  maxSubscriptionsPerClient: 50,
+  logLevel: 'warn',               // suppress noise during load test
+};
+
+// ─── Utilities ─────────────────────────────────────────────────────────────
+
+function connectClient(url: string): Promise<WebSocket> {
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(url);
+    ws.once('open', () => resolve(ws));
+    ws.once('error', reject);
+  });
+}
+
+function waitForMessage(ws: WebSocket, type: string, timeoutMs = 5_000): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(`Timed out waiting for '${type}'`)), timeoutMs);
+    ws.on('message', function handler(raw) {
+      try {
+        const msg = JSON.parse(raw.toString()) as { type: string };
+        if (msg.type === type) {
+          clearTimeout(timer);
+          ws.off('message', handler);
+          resolve(msg);
+        }
+      } catch {/* ignore parse errors */}
+    });
+  });
+}
+
+function closeAll(sockets: WebSocket[]): Promise<void> {
+  return new Promise((resolve) => {
+    let pending = sockets.length;
+    if (pending === 0) { resolve(); return; }
+    for (const ws of sockets) {
+      ws.once('close', () => { if (--pending === 0) resolve(); });
+      ws.close();
+    }
+  });
+}
+
+// ─── Main ──────────────────────────────────────────────────────────────────
+
+async function main() {
+  const manager = new ConnectionManager(TEST_CONFIG);
+  manager.start();
+
+  const url = `ws://127.0.0.1:${LOAD_PORT}`;
+  const sockets: WebSocket[] = [];
+
+  try {
+    console.log(`\nConnecting ${TOTAL_CLIENTS} clients to ${url}…`);
+    const t0 = Date.now();
+
+    // Connect all clients in batches of 100 to avoid overwhelming the OS
+    const BATCH = 100;
+    for (let i = 0; i < TOTAL_CLIENTS; i += BATCH) {
+      const batch = Array.from({ length: Math.min(BATCH, TOTAL_CLIENTS - i) }, () =>
+        connectClient(url),
+      );
+      sockets.push(...(await Promise.all(batch)));
+    }
+
+    const connectMs = Date.now() - t0;
+    console.log(`✓ All ${TOTAL_CLIENTS} clients connected in ${connectMs}ms`);
+
+    // Wait for welcome on all clients
+    console.log('Waiting for welcome messages…');
+    const welcomePromises = sockets.map((ws) => waitForMessage(ws, 'welcome', 10_000));
+    await Promise.all(welcomePromises);
+    console.log(`✓ All ${TOTAL_CLIENTS} clients received 'welcome'`);
+
+    // Subscribe the first SUBSCRIBED_COUNT clients to match 42
+    console.log(`Subscribing first ${SUBSCRIBED_COUNT} clients to match ${SUBSCRIBED_MATCH_ID}…`);
+    const subMsg = JSON.stringify({
+      type: 'subscribe',
+      payload: { match_ids: [SUBSCRIBED_MATCH_ID], player_addresses: [] },
+    });
+    const subscribedSockets = sockets.slice(0, SUBSCRIBED_COUNT);
+    const unsubscribedSockets = sockets.slice(SUBSCRIBED_COUNT);
+
+    const subscribedPromises = subscribedSockets.map((ws) => {
+      const p = waitForMessage(ws, 'subscribed', 10_000);
+      ws.send(subMsg);
+      return p;
+    });
+    await Promise.all(subscribedPromises);
+    console.log(`✓ ${SUBSCRIBED_COUNT} clients subscribed`);
+
+    // Broadcast an event — only subscribed clients should receive it
+    console.log('Broadcasting event to subscribed clients…');
+    const receivedBySubscribed: number[] = [];
+    const receivedByUnsubscribed: number[] = [];
+
+    // Set up listeners before broadcast
+    const eventListeners: Promise<void>[] = [];
+    subscribedSockets.forEach((ws, i) => {
+      eventListeners.push(
+        waitForMessage(ws, 'event', 5_000)
+          .then(() => { receivedBySubscribed.push(i); })
+          .catch(() => {/* timeout = did not receive */}),
+      );
+    });
+    unsubscribedSockets.forEach((ws, i) => {
+      // These should NOT receive an event; we give them 1 s to NOT fire
+      eventListeners.push(
+        new Promise<void>((resolve) => {
+          const timer = setTimeout(resolve, 1_000);
+          ws.once('message', (raw) => {
+            try {
+              const msg = JSON.parse(raw.toString()) as { type: string };
+              if (msg.type === 'event') {
+                receivedByUnsubscribed.push(i);
+              }
+            } catch {/* ignore */}
+            clearTimeout(timer);
+            resolve();
+          });
+        }),
+      );
+    });
+
+    manager.broadcast({
+      id: 'load-test-event',
+      ledger_sequence: 999,
+      match_id: SUBSCRIBED_MATCH_ID,
+      event_type: 'match/created',
+      player1: 'GABC',
+      player2: 'GDEF',
+      timestamp: new Date().toISOString(),
+    });
+
+    await Promise.all(eventListeners);
+
+    // ── Assertions ──────────────────────────────────────────────────────
+    let passed = true;
+
+    if (manager.connectionCount !== TOTAL_CLIENTS) {
+      console.error(`✗ Expected ${TOTAL_CLIENTS} connections, got ${manager.connectionCount}`);
+      passed = false;
+    } else {
+      console.log(`✓ Server holds ${manager.connectionCount} concurrent connections`);
+    }
+
+    if (receivedBySubscribed.length < SUBSCRIBED_COUNT * 0.99) {
+      // Allow ≤1% delivery failure (timing edge cases in test harness)
+      console.error(
+        `✗ Only ${receivedBySubscribed.length}/${SUBSCRIBED_COUNT} subscribed clients received the event`,
+      );
+      passed = false;
+    } else {
+      console.log(
+        `✓ ${receivedBySubscribed.length}/${SUBSCRIBED_COUNT} subscribed clients received the event`,
+      );
+    }
+
+    if (receivedByUnsubscribed.length > 0) {
+      console.error(
+        `✗ ${receivedByUnsubscribed.length} non-subscribed clients received the event (data leak!)`,
+      );
+      passed = false;
+    } else {
+      console.log('✓ Non-subscribed clients received no event (no data leak)');
+    }
+
+    const rssBytes = process.memoryUsage().rss;
+    const rssMb = rssBytes / 1024 / 1024;
+    const memLimit = 512;
+    if (rssMb > memLimit) {
+      console.error(`✗ RSS ${rssMb.toFixed(1)} MB exceeds ${memLimit} MB limit`);
+      passed = false;
+    } else {
+      console.log(`✓ Peak RSS: ${rssMb.toFixed(1)} MB (limit: ${memLimit} MB)`);
+    }
+
+    // ── Cleanup ────────────────────────────────────────────────────────
+    console.log('Closing all client connections…');
+    const t1 = Date.now();
+    await closeAll(sockets);
+    console.log(`✓ All connections closed in ${Date.now() - t1}ms`);
+
+    await manager.stop();
+
+    if (!passed) {
+      console.error('\n❌ Load test FAILED');
+      process.exit(1);
+    }
+
+    console.log('\n✅ Load test PASSED');
+    process.exit(0);
+  } catch (err) {
+    console.error('Load test error:', err);
+    await closeAll(sockets).catch(() => {/* ignore */});
+    await manager.stop().catch(() => {/* ignore */});
+    process.exit(1);
+  }
+}
+
+void main();

--- a/services/websocket-server/src/tests/subscriptionManager.test.ts
+++ b/services/websocket-server/src/tests/subscriptionManager.test.ts
@@ -1,0 +1,369 @@
+/**
+ * Unit tests for SubscriptionManager
+ *
+ * These tests exercise subscription filtering in isolation — no network I/O,
+ * no WebSocket connection required.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { SubscriptionManager } from '../subscriptionManager.js';
+import type { ClientState, IndexedEvent } from '../types.js';
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+const DEFAULT_CONFIG = {
+  maxSubscriptionsPerClient: 50,
+  rateLimitMaxSubscribes: 20,
+  rateLimitWindowMs: 60_000,
+};
+
+function makeState(overrides: Partial<ClientState> = {}): ClientState {
+  return {
+    id: Math.random().toString(36).slice(2),
+    matchIds: new Set(),
+    playerAddresses: new Set(),
+    lastSeenAt: Date.now(),
+    subscribeCount: 0,
+    rateLimitWindowStart: Date.now(),
+    remoteAddress: '127.0.0.1',
+    ...overrides,
+  };
+}
+
+function makeEvent(overrides: Partial<IndexedEvent> = {}): IndexedEvent {
+  return {
+    id: 'evt-1',
+    ledger_sequence: 100,
+    match_id: 1,
+    event_type: 'match/created',
+    player1: 'GABC',
+    player2: 'GDEF',
+    timestamp: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('SubscriptionManager', () => {
+  let manager: SubscriptionManager;
+
+  beforeEach(() => {
+    manager = new SubscriptionManager(DEFAULT_CONFIG);
+  });
+
+  // ── Client lifecycle ────────────────────────────────────────────────────
+
+  describe('client lifecycle', () => {
+    it('adds a client', () => {
+      const state = makeState();
+      manager.addClient(state);
+      expect(manager.clientCount).toBe(1);
+      expect(manager.getClient(state.id)).toBe(state);
+    });
+
+    it('removes a client and cleans up indices', () => {
+      const state = makeState();
+      manager.addClient(state);
+      manager.subscribe(state.id, [42], ['GABC']);
+      manager.removeClient(state.id);
+      expect(manager.clientCount).toBe(0);
+      expect(manager.getClient(state.id)).toBeUndefined();
+    });
+
+    it('is a no-op to remove a non-existent client', () => {
+      expect(() => manager.removeClient('nonexistent')).not.toThrow();
+    });
+  });
+
+  // ── Subscribe ───────────────────────────────────────────────────────────
+
+  describe('subscribe', () => {
+    it('subscribes to match IDs', () => {
+      const state = makeState();
+      manager.addClient(state);
+      const result = manager.subscribe(state.id, [1, 2, 3]);
+      expect(result.ok).toBe(true);
+      expect(state.matchIds.has(1)).toBe(true);
+      expect(state.matchIds.has(2)).toBe(true);
+      expect(state.matchIds.has(3)).toBe(true);
+    });
+
+    it('subscribes to player addresses (case-normalised)', () => {
+      const state = makeState();
+      manager.addClient(state);
+      const result = manager.subscribe(state.id, [], ['GABC', 'gDEF']);
+      expect(result.ok).toBe(true);
+      expect(state.playerAddresses.has('gabc')).toBe(true);
+      expect(state.playerAddresses.has('gdef')).toBe(true);
+    });
+
+    it('is idempotent for duplicate subscriptions', () => {
+      const state = makeState();
+      manager.addClient(state);
+      manager.subscribe(state.id, [1]);
+      manager.subscribe(state.id, [1]);
+      expect(state.matchIds.size).toBe(1);
+    });
+
+    it('rejects invalid match IDs (negative)', () => {
+      const state = makeState();
+      manager.addClient(state);
+      const result = manager.subscribe(state.id, [-1]);
+      expect(result.ok).toBe(false);
+      expect(result.error).toMatch(/Invalid match_id/);
+    });
+
+    it('rejects invalid match IDs (non-integer)', () => {
+      const state = makeState();
+      manager.addClient(state);
+      const result = manager.subscribe(state.id, [1.5 as unknown as number]);
+      expect(result.ok).toBe(false);
+    });
+
+    it('rejects empty player address strings', () => {
+      const state = makeState();
+      manager.addClient(state);
+      const result = manager.subscribe(state.id, [], ['   ']);
+      expect(result.ok).toBe(false);
+      expect(result.error).toMatch(/Invalid player_address/);
+    });
+
+    it('enforces per-client subscription cap', () => {
+      const mgr = new SubscriptionManager({ ...DEFAULT_CONFIG, maxSubscriptionsPerClient: 3 });
+      const state = makeState();
+      mgr.addClient(state);
+      mgr.subscribe(state.id, [1, 2, 3]);
+      const result = mgr.subscribe(state.id, [4]);
+      expect(result.ok).toBe(false);
+      expect(result.error).toMatch(/cap exceeded/);
+    });
+
+    it('returns error for unknown client ID', () => {
+      const result = manager.subscribe('ghost', [1]);
+      expect(result.ok).toBe(false);
+      expect(result.error).toMatch(/Client not found/);
+    });
+  });
+
+  // ── Unsubscribe ─────────────────────────────────────────────────────────
+
+  describe('unsubscribe', () => {
+    it('removes match IDs from subscription', () => {
+      const state = makeState();
+      manager.addClient(state);
+      manager.subscribe(state.id, [1, 2]);
+      manager.unsubscribe(state.id, [1]);
+      expect(state.matchIds.has(1)).toBe(false);
+      expect(state.matchIds.has(2)).toBe(true);
+    });
+
+    it('removes player addresses from subscription', () => {
+      const state = makeState();
+      manager.addClient(state);
+      manager.subscribe(state.id, [], ['GABC', 'GDEF']);
+      manager.unsubscribe(state.id, [], ['GABC']);
+      expect(state.playerAddresses.has('gabc')).toBe(false);
+      expect(state.playerAddresses.has('gdef')).toBe(true);
+    });
+
+    it('is a no-op for match IDs the client did not subscribe to', () => {
+      const state = makeState();
+      manager.addClient(state);
+      const result = manager.unsubscribe(state.id, [999]);
+      expect(result.ok).toBe(true);
+    });
+
+    it('returns error for unknown client', () => {
+      const result = manager.unsubscribe('ghost', [1]);
+      expect(result.ok).toBe(false);
+    });
+  });
+
+  // ── Event routing ───────────────────────────────────────────────────────
+
+  describe('matchingClients', () => {
+    it('returns empty set when no clients are subscribed', () => {
+      const event = makeEvent({ match_id: 5 });
+      expect(manager.matchingClients(event).size).toBe(0);
+    });
+
+    it('matches client subscribed by match ID', () => {
+      const state = makeState();
+      manager.addClient(state);
+      manager.subscribe(state.id, [5]);
+
+      const event = makeEvent({ match_id: 5 });
+      const clients = manager.matchingClients(event);
+      expect(clients.has(state.id)).toBe(true);
+      expect(clients.size).toBe(1);
+    });
+
+    it('does NOT match client subscribed to different match ID', () => {
+      const state = makeState();
+      manager.addClient(state);
+      manager.subscribe(state.id, [5]);
+
+      const event = makeEvent({ match_id: 99 });
+      expect(manager.matchingClients(event).size).toBe(0);
+    });
+
+    it('matches client subscribed to player1 address', () => {
+      const state = makeState();
+      manager.addClient(state);
+      manager.subscribe(state.id, [], ['GABC']);
+
+      const event = makeEvent({ match_id: 1, player1: 'GABC', player2: 'GXYZ' });
+      const clients = manager.matchingClients(event);
+      expect(clients.has(state.id)).toBe(true);
+    });
+
+    it('matches client subscribed to player2 address', () => {
+      const state = makeState();
+      manager.addClient(state);
+      manager.subscribe(state.id, [], ['GDEF']);
+
+      const event = makeEvent({ match_id: 1, player1: 'GABC', player2: 'GDEF' });
+      expect(manager.matchingClients(event).has(state.id)).toBe(true);
+    });
+
+    it('matches on player address case-insensitively', () => {
+      const state = makeState();
+      manager.addClient(state);
+      manager.subscribe(state.id, [], ['GABC']); // subscribed uppercase
+
+      // event has lowercase player1
+      const event = makeEvent({ match_id: 1, player1: 'gabc', player2: 'GDEF' });
+      expect(manager.matchingClients(event).has(state.id)).toBe(true);
+    });
+
+    it('deduplicates clients matching by both match ID and player address', () => {
+      const state = makeState();
+      manager.addClient(state);
+      manager.subscribe(state.id, [1], ['GABC']); // subscribed to both
+
+      const event = makeEvent({ match_id: 1, player1: 'GABC' });
+      const clients = manager.matchingClients(event);
+      // Should appear exactly once
+      expect(clients.size).toBe(1);
+    });
+
+    it('routes event to multiple different subscribers', () => {
+      const s1 = makeState();
+      const s2 = makeState();
+      const s3 = makeState();
+      manager.addClient(s1);
+      manager.addClient(s2);
+      manager.addClient(s3);
+
+      manager.subscribe(s1.id, [10]);
+      manager.subscribe(s2.id, [], ['GABC']);
+      // s3 subscribed to a different match
+      manager.subscribe(s3.id, [99]);
+
+      const event = makeEvent({ match_id: 10, player1: 'GABC', player2: 'GDEF' });
+      const clients = manager.matchingClients(event);
+      expect(clients.has(s1.id)).toBe(true);
+      expect(clients.has(s2.id)).toBe(true);
+      expect(clients.has(s3.id)).toBe(false);
+    });
+
+    it('does not route to removed client', () => {
+      const state = makeState();
+      manager.addClient(state);
+      manager.subscribe(state.id, [1]);
+      manager.removeClient(state.id);
+
+      const event = makeEvent({ match_id: 1 });
+      expect(manager.matchingClients(event).size).toBe(0);
+    });
+
+    it('does not route to client that unsubscribed', () => {
+      const state = makeState();
+      manager.addClient(state);
+      manager.subscribe(state.id, [1]);
+      manager.unsubscribe(state.id, [1]);
+
+      const event = makeEvent({ match_id: 1 });
+      expect(manager.matchingClients(event).size).toBe(0);
+    });
+
+    it('handles events without player fields gracefully', () => {
+      const state = makeState();
+      manager.addClient(state);
+      manager.subscribe(state.id, [1]);
+
+      const event = makeEvent({ match_id: 1, player1: undefined, player2: undefined });
+      const clients = manager.matchingClients(event);
+      expect(clients.has(state.id)).toBe(true); // matched by match_id
+    });
+  });
+
+  // ── Rate limiting ───────────────────────────────────────────────────────
+
+  describe('rate limiting', () => {
+    it('blocks subscribe after exceeding limit', () => {
+      const mgr = new SubscriptionManager({
+        ...DEFAULT_CONFIG,
+        rateLimitMaxSubscribes: 3,
+        rateLimitWindowMs: 60_000,
+      });
+      const state = makeState();
+      mgr.addClient(state);
+
+      // 3 commands should succeed
+      mgr.subscribe(state.id, [1]);
+      mgr.subscribe(state.id, [2]);
+      mgr.subscribe(state.id, [3]);
+
+      // 4th should be rate-limited
+      const result = mgr.subscribe(state.id, [4]);
+      expect(result.ok).toBe(false);
+      expect(result.error).toMatch(/rate_limited/);
+    });
+
+    it('resets rate-limit counter after window expires', () => {
+      const mgr = new SubscriptionManager({
+        ...DEFAULT_CONFIG,
+        rateLimitMaxSubscribes: 1,
+        rateLimitWindowMs: 100,
+      });
+      const state = makeState({ rateLimitWindowStart: Date.now() - 200 }); // window already expired
+      mgr.addClient(state);
+
+      const result = mgr.subscribe(state.id, [1]);
+      expect(result.ok).toBe(true);
+    });
+  });
+
+  // ── Edge cases ──────────────────────────────────────────────────────────
+
+  describe('edge cases', () => {
+    it('handles subscribing to 0 match IDs and 0 addresses', () => {
+      const state = makeState();
+      manager.addClient(state);
+      const result = manager.subscribe(state.id, [], []);
+      expect(result.ok).toBe(true);
+    });
+
+    it('handles many clients subscribing to the same match', () => {
+      const count = 500;
+      for (let i = 0; i < count; i++) {
+        const s = makeState();
+        manager.addClient(s);
+        manager.subscribe(s.id, [77]);
+      }
+      const event = makeEvent({ match_id: 77 });
+      expect(manager.matchingClients(event).size).toBe(count);
+    });
+
+    it('allClients() returns all registered clients', () => {
+      const s1 = makeState();
+      const s2 = makeState();
+      manager.addClient(s1);
+      manager.addClient(s2);
+      const all = Array.from(manager.allClients());
+      expect(all).toHaveLength(2);
+    });
+  });
+});

--- a/services/websocket-server/src/types.ts
+++ b/services/websocket-server/src/types.ts
@@ -1,0 +1,190 @@
+/**
+ * Checkmate-Escrow WebSocket Server — Shared Types
+ *
+ * Protocol version: 1
+ *
+ * All messages are JSON-encoded text frames.
+ */
+
+// ─── Protocol version ──────────────────────────────────────────────────────
+
+export const PROTOCOL_VERSION = 1;
+
+// ─── Subscription types ────────────────────────────────────────────────────
+
+/** Subscribe by match ID, player address, or both */
+export interface SubscribePayload {
+  match_ids?: number[];
+  player_addresses?: string[];
+}
+
+/** Unsubscribe from specific match IDs or player addresses */
+export interface UnsubscribePayload {
+  match_ids?: number[];
+  player_addresses?: string[];
+}
+
+// ─── Client → Server messages ──────────────────────────────────────────────
+
+export type ClientMessageType = 'subscribe' | 'unsubscribe' | 'ping';
+
+export interface ClientSubscribeMessage {
+  type: 'subscribe';
+  payload: SubscribePayload;
+}
+
+export interface ClientUnsubscribeMessage {
+  type: 'unsubscribe';
+  payload: UnsubscribePayload;
+}
+
+export interface ClientPingMessage {
+  type: 'ping';
+}
+
+export type ClientMessage =
+  | ClientSubscribeMessage
+  | ClientUnsubscribeMessage
+  | ClientPingMessage;
+
+// ─── Server → Client messages ──────────────────────────────────────────────
+
+export type ServerMessageType =
+  | 'welcome'
+  | 'subscribed'
+  | 'unsubscribed'
+  | 'event'
+  | 'pong'
+  | 'error'
+  | 'rate_limited';
+
+export interface WelcomeMessage {
+  type: 'welcome';
+  protocol_version: number;
+  server_time: string;
+}
+
+export interface SubscribedMessage {
+  type: 'subscribed';
+  match_ids: number[];
+  player_addresses: string[];
+}
+
+export interface UnsubscribedMessage {
+  type: 'unsubscribed';
+  match_ids: number[];
+  player_addresses: string[];
+}
+
+export interface MatchEventMessage {
+  type: 'event';
+  event: IndexedEvent;
+}
+
+export interface PongMessage {
+  type: 'pong';
+  server_time: string;
+}
+
+export interface ErrorMessage {
+  type: 'error';
+  code: string;
+  message: string;
+}
+
+export interface RateLimitedMessage {
+  type: 'rate_limited';
+  message: string;
+  retry_after_ms: number;
+}
+
+export type ServerMessage =
+  | WelcomeMessage
+  | SubscribedMessage
+  | UnsubscribedMessage
+  | MatchEventMessage
+  | PongMessage
+  | ErrorMessage
+  | RateLimitedMessage;
+
+// ─── Event model (mirrors event-indexer Rust model) ────────────────────────
+
+export interface IndexedEvent {
+  id: string;
+  ledger_sequence: number;
+  match_id: number;
+  event_type: string;
+  player1?: string;
+  player2?: string;
+  status?: string;
+  winner?: string;
+  stake_amount?: string;
+  token?: string;
+  game_id?: string;
+  platform?: string;
+  timestamp: string;
+  txn_hash?: string;
+  event_index_in_txn?: number;
+}
+
+// ─── Internal client state ─────────────────────────────────────────────────
+
+export interface ClientState {
+  /** Unique connection ID (UUID v4) */
+  id: string;
+  /** Match IDs this client is watching */
+  matchIds: Set<number>;
+  /** Player addresses this client is watching */
+  playerAddresses: Set<string>;
+  /** Epoch ms of last message received (for heartbeat) */
+  lastSeenAt: number;
+  /** Number of subscribe/unsubscribe commands in the current rate-limit window */
+  subscribeCount: number;
+  /** Epoch ms when the current rate-limit window started */
+  rateLimitWindowStart: number;
+  /** Remote address for logging */
+  remoteAddress: string;
+  /** Disconnect reason – populated on close for logging */
+  disconnectReason?: string;
+}
+
+// ─── Config ────────────────────────────────────────────────────────────────
+
+export interface ServerConfig {
+  /** TCP port to listen on. Default: 8090 */
+  port: number;
+  /** Bind address. Default: 0.0.0.0 */
+  host: string;
+  /** Base URL of the event-indexer REST API. Default: http://localhost:8080 */
+  eventIndexerUrl: string;
+  /** How often (ms) to poll event-indexer for new events. Default: 5000 */
+  pollIntervalMs: number;
+  /** Interval (ms) to send server-initiated pings. Default: 30000 */
+  heartbeatIntervalMs: number;
+  /** Time (ms) before a non-responsive connection is terminated. Default: 60000 */
+  heartbeatTimeoutMs: number;
+  /** Max subscribe/unsubscribe commands per rate-limit window per client. Default: 20 */
+  rateLimitMaxSubscribes: number;
+  /** Rate-limit window duration (ms). Default: 60000 */
+  rateLimitWindowMs: number;
+  /** Max total subscriptions (matchIds + playerAddresses) a single client may hold. Default: 50 */
+  maxSubscriptionsPerClient: number;
+  /** Log level. Default: info */
+  logLevel: string;
+}
+
+export function loadConfig(): ServerConfig {
+  return {
+    port: Number(process.env.WS_PORT ?? 8090),
+    host: process.env.WS_HOST ?? '0.0.0.0',
+    eventIndexerUrl:
+      process.env.EVENT_INDEXER_URL ?? 'http://localhost:8080',
+    pollIntervalMs: Number(process.env.WS_POLL_INTERVAL_MS ?? 5000),
+    heartbeatIntervalMs: Number(process.env.WS_HEARTBEAT_INTERVAL_MS ?? 30_000),
+    heartbeatTimeoutMs: Number(process.env.WS_HEARTBEAT_TIMEOUT_MS ?? 60_000),
+    rateLimitMaxSubscribes: Number(process.env.WS_RATE_LIMIT_MAX_SUBSCRIBES ?? 20),
+    rateLimitWindowMs: Number(process.env.WS_RATE_LIMIT_WINDOW_MS ?? 60_000),
+    maxSubscriptionsPerClient: Number(process.env.WS_MAX_SUBSCRIPTIONS_PER_CLIENT ?? 50),
+    logLevel: process.env.LOG_LEVEL ?? 'info',
+  };
+}

--- a/services/websocket-server/tsconfig.json
+++ b/services/websocket-server/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/services/websocket-server/vitest.config.ts
+++ b/services/websocket-server/vitest.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['src/tests/**/*.test.ts'],
+    exclude: ['src/tests/load.test.ts'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json', 'html'],
+      include: ['src/**/*.ts'],
+      exclude: ['src/tests/**', 'src/index.ts'],
+    },
+  },
+});


### PR DESCRIPTION
Summary
  
  Implements a real-time event streaming layer for Checkmate-Escrow. Clients can now subscribe to match events (created, deposit confirmed, result submitted) over a persistent WebSocket
  connection instead of polling the event-indexer REST API.
  
  Changes
  
  New service — services/websocket-server/
  
  - Node.js/TypeScript WebSocket server using ws@8.18.0 and pino for structured logging
  - SubscriptionManager — O(1) event routing via dual indices (match ID + player address); enforces per-client subscription caps and rate limiting
  - EventPoller — polls the event-indexer REST API at a configurable interval; tracks a high-watermark ledger sequence so each event is delivered exactly once; exponential back-off on
  indexer failures
  - ConnectionManager — WebSocket server lifecycle, heartbeat (native ping frames + timeout eviction), per-connection message dispatch, disconnect reason logging
  - Full config via environment variables (WS_PORT, EVENT_INDEXER_URL, WS_POLL_INTERVAL_MS, etc.)
  - Dockerfile for containerised deployment
  
  Frontend — frontend/src/hooks/useMatchWebSocket.ts
  
  - React hook with automatic reconnect (exponential back-off, capped at 30 s)
  - Sends subscribe on welcome and re-subscribes after every reconnect
  - Exposes status, latestEvent, events history, error, and reconnect()
  - enabled flag to disable without unmounting
  
  Tests
  
  - subscriptionManager.test.ts — 25+ pure unit tests for filtering, routing, rate limiting, and edge cases; no network required
  - integration.test.ts — full end-to-end tests against a real WebSocket server and a mock event-indexer HTTP server
  - load.test.ts — 1 000 concurrent connections; verifies targeted broadcast correctness, zero data leakage to non-subscribers, and peak RSS < 512 MB
  - useMatchWebSocket.test.ts — Vitest + jsdom tests with a mock WebSocket class covering all status transitions, event delivery, reconnect, rate-limited, and error paths
  
  Docs — docs/websocket-api.md
  
  - Protocol version 1 reference: all client→server and server→client message shapes with typed fields
  - Subscription model explanation (dual-index routing, limits)
  - Reconnect strategy with recommended back-off parameters
  - Rate limiting and heartbeat behaviour
  - Configuration reference table
  - React hook usage example and full API table
  - Protocol changelog
  
  Infrastructure
  
  - docker-compose.yml updated with websocket-server service wired to event-indexer-1
  - README.md updated to link docs/websocket-api.md
  
  Testing
  
  # Unit + integration tests
  cd services/websocket-server && npm test
  
  # Load test (1 000 concurrent connections)
  npm run test:load
  
  # Frontend hook tests
  cd frontend && npm test -- useMatchWebSocket

closes #745 