### PR TITLE
Add security tests and verify CI configuration

### DIFF
--- a/contracts/escrow/src/tests/security.rs
+++ b/contracts/escrow/src/tests/security.rs
@@ -710,3 +710,25 @@ fn test_transfer_admin_unauthorized() {
     assert_eq!(result, Err(Ok(Error::Unauthorized)));
 }
 
+/// Test that pause rejects non-admin caller
+#[test]
+fn test_pause_unauthorized() {
+    let (env, contract_id, _oracle, _player1, _player2, _token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let non_admin = Address::generate(&env);
+
+    env.mock_auths(&[MockAuth {
+        address: &non_admin,
+        invoke: &MockAuthInvoke {
+            contract: &contract_id,
+            fn_name: "pause",
+            args: ().into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+
+    let result = client.try_pause();
+    assert_eq!(result, Err(Ok(Error::Unauthorized)));
+}
+

--- a/contracts/escrow/src/tests/security.rs
+++ b/contracts/escrow/src/tests/security.rs
@@ -686,3 +686,27 @@ fn test_accept_admin_wrong_caller_rejected() {
     let result = client.try_accept_admin();
     assert_eq!(result, Err(Ok(Error::Unauthorized)));
 }
+
+/// Test that transfer_admin rejects non-admin caller
+#[test]
+fn test_transfer_admin_unauthorized() {
+    let (env, contract_id, _oracle, _player1, _player2, _token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let new_admin = Address::generate(&env);
+    let non_admin = Address::generate(&env);
+
+    env.mock_auths(&[MockAuth {
+        address: &non_admin,
+        invoke: &MockAuthInvoke {
+            contract: &contract_id,
+            fn_name: "transfer_admin",
+            args: (new_admin.clone(),).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+
+    let result = client.try_transfer_admin(&new_admin);
+    assert_eq!(result, Err(Ok(Error::Unauthorized)));
+}
+


### PR DESCRIPTION
## Summary

This pull request implements security tests for authorization checks and verifies CI lint configuration across 4 related issues:

- **#1129**: Add test_transfer_admin_unauthorized - Verifies that non-admin callers cannot transfer admin privileges
- **#1130**: Add test_pause_unauthorized - Verifies that non-admin callers cannot pause the contract
- **#1127**: Verify clippy lint step in CI - Ensures code quality checks are enforced
- **#1128**: Verify rustfmt format check in CI - Ensures consistent code formatting

## Changes

### Security Tests (contracts/escrow/src/tests/security.rs)

1. **test_transfer_admin_unauthorized()** - Tests authorization check for transfer_admin function
2. **test_pause_unauthorized()** - Tests authorization check for pause function

Both tests verify that non-admin addresses receive `Error::Unauthorized` when attempting restricted operations.

### CI Configuration Verification

- Clippy linter: `cargo clippy --all-targets --all-features -- -D warnings`
- Rustfmt checker: `cargo fmt --all --check`

Both steps are properly configured in `.github/workflows/ci.yml` and run on every PR and push to main.

Closes #1127
Closes #1128
Closes #1129
Closes #1130