### PR TITLE
Add unit tests for Lichess client and Oracle contract

### DIFF
--- a/contracts/oracle/src/tests.rs
+++ b/contracts/oracle/src/tests.rs
@@ -2369,3 +2369,24 @@ fn test_oracle_store_result_when_paused() {
     );
     assert_eq!(result, Err(Ok(Error::ContractPaused)));
 }
+
+#[test]
+fn test_oracle_store_result_idempotent() {
+    let (env, contract_id, ..) = setup();
+    let client = OracleContractClient::new(&env, &contract_id);
+
+    let game_id = String::from_str(&env, "game_idempotent_12345");
+    let winner = Winner::Player1;
+
+    client.submit_result(&0u64, &game_id, &Platform::Lichess, &winner);
+    assert!(client.has_result(&0u64));
+    let first_result = client.get_result(&0u64);
+    assert_eq!(first_result.result, winner);
+
+    client.submit_result(&0u64, &game_id, &Platform::Lichess, &winner);
+    assert!(client.has_result(&0u64));
+    let second_result = client.get_result(&0u64);
+    assert_eq!(second_result.result, winner);
+
+    assert_eq!(first_result.result, second_result.result);
+}

--- a/oracle-service/tests/lichess_client_unit.rs
+++ b/oracle-service/tests/lichess_client_unit.rs
@@ -208,3 +208,23 @@ async fn test_lichess_rate_limit_retry() {
     assert!(result.is_ok());
     assert_eq!(result.unwrap().winner, contracts_oracle::types::Winner::Player1);
 }
+
+#[tokio::test]
+async fn test_lichess_game_not_found() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/game/export/notfnd1"))
+        .respond_with(ResponseTemplate::new(404))
+        .mount(&server)
+        .await;
+
+    let client = LichessClient::new_with_base_and_timeout(
+        server.uri(),
+        std::time::Duration::from_secs(30),
+    )
+    .unwrap();
+
+    let err = client.fetch_result("notfnd1").await.unwrap_err();
+    assert!(matches!(err, LichessError::GameNotFound));
+}

--- a/oracle-service/tests/lichess_client_unit.rs
+++ b/oracle-service/tests/lichess_client_unit.rs
@@ -175,3 +175,36 @@ async fn test_lichess_missing_winner_field() {
     let err = client.fetch_result("miss1234").await.unwrap_err();
     assert!(matches!(err, LichessError::InvalidResponse));
 }
+
+#[tokio::test]
+async fn test_lichess_rate_limit_retry() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/game/export/rate1234"))
+        .respond_with(ResponseTemplate::new(429).append_header("Retry-After", "1"))
+        .up_to_n_times(1)
+        .mount(&server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/game/export/rate1234"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "winner": "white"
+        })))
+        .mount(&server)
+        .await;
+
+    let client = LichessClient::new_with_base_and_timeout(
+        server.uri(),
+        std::time::Duration::from_secs(30),
+    )
+    .unwrap();
+
+    let start = std::time::Instant::now();
+    let result = client.fetch_result("rate1234").await;
+    let elapsed = start.elapsed();
+
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap().winner, contracts_oracle::types::Winner::Player1);
+}

--- a/oracle-service/tests/lichess_client_unit.rs
+++ b/oracle-service/tests/lichess_client_unit.rs
@@ -153,3 +153,25 @@ async fn fetch_result_non_2xx_maps_to_http_status() {
     let err = client.fetch_result("err12345").await.unwrap_err();
     assert!(matches!(err, LichessError::HttpStatus { .. }));
 }
+
+#[tokio::test]
+async fn test_lichess_missing_winner_field() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/game/export/miss1234"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "status": "finished"
+        })))
+        .mount(&server)
+        .await;
+
+    let client = LichessClient::new_with_base_and_timeout(
+        server.uri(),
+        std::time::Duration::from_secs(30),
+    )
+    .unwrap();
+
+    let err = client.fetch_result("miss1234").await.unwrap_err();
+    assert!(matches!(err, LichessError::InvalidResponse));
+}


### PR DESCRIPTION
## Summary
- Add unit test for LichessClient missing winner field handling
- Add unit test for LichessClient HTTP 429 rate limit retry logic
- Add unit test for LichessClient HTTP 404 game not found handling
- Add unit test for Oracle store_result idempotency

## Test Coverage
All four unit tests verify the correct error handling and behavior for various edge cases in the Lichess client and Oracle contract.

Closes #1115
Closes #1116
Closes #1117
Closes #1118