### PR TITLE
Implement event emission tests for pause, transfer_admin, create_match, and cancel_match

### DIFF
--- a/contracts/escrow/src/tests/admin.rs
+++ b/contracts/escrow/src/tests/admin.rs
@@ -772,3 +772,34 @@ fn test_two_step_admin_transfer() {
     });
     assert!(pending.is_none(), "PendingAdmin key must be cleared after acceptance");
 }
+
+// #1101 — pause blocks create_match and unpause restores it
+#[test]
+fn test_pause_blocks_create_match() {
+    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    client.pause();
+
+    let result = client.try_create_match(
+        &player1,
+        &player2,
+        &100,
+        &token,
+        &String::from_str(&env, "paused_game"),
+        &Platform::Lichess,
+    );
+    assert_eq!(result, Err(Ok(Error::ContractPaused)), "create_match must fail when paused");
+
+    client.unpause();
+
+    let id = client.create_match(
+        &player1,
+        &player2,
+        &100,
+        &token,
+        &String::from_str(&env, "unpaused_game"),
+        &Platform::Lichess,
+    );
+    assert_eq!(id, 0, "create_match must succeed after unpause");
+}

--- a/contracts/escrow/src/tests/events.rs
+++ b/contracts/escrow/src/tests/events.rs
@@ -527,3 +527,28 @@ fn test_unpause_emits_event() {
         .find(|(_, topics, _)| *topics == expected_topics);
     assert!(matched.is_some(), "admin/unpaused event not emitted");
 }
+
+#[test]
+fn test_transfer_admin_emits_event() {
+    let (env, contract_id, _oracle, _player1, _player2, _token, admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let new_admin = Address::generate(&env);
+    client.transfer_admin(&new_admin);
+
+    let events = env.events().all();
+    let expected_topics = vec![
+        &env,
+        Symbol::new(&env, "admin").into_val(&env),
+        symbol_short!("xfer").into_val(&env),
+    ];
+    let matched = events
+        .iter()
+        .find(|(_, topics, _)| *topics == expected_topics);
+    assert!(matched.is_some(), "admin/xfer event not emitted");
+
+    let (_, _, data) = matched.unwrap();
+    let (ev_old_admin, ev_new_admin): (Address, Address) = TryFromVal::try_from_val(&env, &data).unwrap();
+    assert_eq!(ev_old_admin, admin, "old admin must match current admin");
+    assert_eq!(ev_new_admin, new_admin, "new admin must match provided address");
+}

--- a/contracts/escrow/src/tests/events.rs
+++ b/contracts/escrow/src/tests/events.rs
@@ -171,6 +171,7 @@ fn test_submit_result_emits_event() {
     assert_eq!(decoded, (id, Winner::Player1));
 }
 
+// #1104 — cancel_match emits match/cancelled event
 #[test]
 fn test_cancel_match_emits_event() {
     let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();

--- a/contracts/escrow/src/tests/events.rs
+++ b/contracts/escrow/src/tests/events.rs
@@ -30,6 +30,7 @@ fn test_initialize_emits_event() {
     assert_eq!(ev_admin, admin);
 }
 
+// #1103 — create_match emits match/created event
 #[test]
 fn test_create_match_emits_event() {
     let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();


### PR DESCRIPTION
## Summary

Implements comprehensive event emission tests for the escrow contract as specified in issues #1101-#1104:

- **#1101**: Test that `pause()` blocks `create_match` calls and `unpause()` restores them
- **#1102**: Test that `transfer_admin()` emits the `admin/xfer` event with correct payload
- **#1103**: Verify `create_match()` emits `match/created` event with match details
- **#1104**: Verify `cancel_match()` emits `match/cancelled` event with match_id

## Changes

- **contracts/escrow/src/tests/admin.rs**: Added `test_pause_blocks_create_match()` combining pause/unpause verification
- **contracts/escrow/src/tests/events.rs**: Added `test_transfer_admin_emits_event()` for admin transfer event validation

Existing tests verified:
- `test_create_match_emits_event()` in events.rs correctly validates match creation events
- `test_cancel_match_emits_event()` in events.rs correctly validates match cancellation events

## Test Coverage

All tests follow the established patterns in the codebase:
- Use `setup()` fixture for initialized contract with funded players
- Capture emitted events from `env.events().all()`
- Assert correct event topics and payload data
- Verify expected behavior in both success and error cases

Closes #1101
Closes #1102
Closes #1103
Closes #1104