### PR TITLE
Add validation and edge-case tests for escrow contract

### DIFF
--- a/contracts/escrow/src/tests/index.rs
+++ b/contracts/escrow/src/tests/index.rs
@@ -266,6 +266,15 @@ fn test_get_pending_matches_empty() {
 }
 
 #[test]
+fn test_get_pending_matches_empty_on_init() {
+    let (env, contract_id, _oracle, _player1, _player2, _token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let pending_matches = client.get_pending_matches();
+    assert_eq!(pending_matches.len(), 0);
+}
+
+#[test]
 fn test_get_active_matches_after_deposits() {
     let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
     let client = EscrowContractClient::new(&env, &contract_id);

--- a/contracts/escrow/src/tests/lifecycle.rs
+++ b/contracts/escrow/src/tests/lifecycle.rs
@@ -2247,3 +2247,23 @@ fn test_claim_unauthorized_parties() {
     let claim_res = client.try_claim_vested_payout(&id, &player2);
     assert_eq!(claim_res, Err(Ok(Error::Unauthorized)));
 }
+
+#[test]
+fn test_double_deposit_rejected() {
+    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let match_id = client.create_match(
+        &player1,
+        &player2,
+        &100,
+        &token,
+        &String::from_str(&env, "double_deposit_game"),
+        &Platform::Lichess,
+    );
+
+    client.deposit(&match_id, &player1);
+
+    let result = client.try_deposit(&match_id, &player1);
+    assert_eq!(result, Err(Ok(Error::AlreadyFunded)));
+}

--- a/contracts/escrow/src/tests/mod.rs
+++ b/contracts/escrow/src/tests/mod.rs
@@ -26,6 +26,7 @@ mod snapshots;
 mod tier;
 mod token_allowlist;
 mod ttl;
+mod validation;
 
 // ── Base fixture ─────────────────────────────────────────────────────────────
 

--- a/contracts/escrow/src/tests/security.rs
+++ b/contracts/escrow/src/tests/security.rs
@@ -732,3 +732,25 @@ fn test_pause_unauthorized() {
     assert_eq!(result, Err(Ok(Error::Unauthorized)));
 }
 
+/// Test that submit_result by non-oracle is rejected
+#[test]
+fn test_submit_result_unauthorized() {
+    let (env, contract_id, _oracle, _player1, _player2, _token, _admin, match_id) = setup_with_funded_match();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let non_oracle = Address::generate(&env);
+
+    env.mock_auths(&[MockAuth {
+        address: &non_oracle,
+        invoke: &MockAuthInvoke {
+            contract: &contract_id,
+            fn_name: "submit_result",
+            args: (match_id, Winner::Player1).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+
+    let result = client.try_submit_result(&match_id, &Winner::Player1);
+    assert_eq!(result, Err(Ok(Error::Unauthorized)));
+}
+

--- a/contracts/escrow/src/tests/validation.rs
+++ b/contracts/escrow/src/tests/validation.rs
@@ -1,0 +1,18 @@
+use super::*;
+
+#[test]
+fn test_create_match_zero_stake() {
+    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let result = client.try_create_match(
+        &player1,
+        &player2,
+        &0,
+        &token,
+        &String::from_str(&env, "zero_stake_game"),
+        &Platform::Lichess,
+    );
+
+    assert_eq!(result, Err(Ok(Error::InvalidAmount)));
+}


### PR DESCRIPTION
## Summary
This PR adds 4 comprehensive tests for the escrow contract covering critical edge cases and validation scenarios:

- **#1097**: Test for zero stake validation in `create_match`
- **#1098**: Test for oracle authorization in `submit_result`
- **#1099**: Test for duplicate deposit prevention
- **#1100**: Test for empty pending matches on contract initialization

## Test Implementation Details

Each test follows the existing test patterns and uses the standard setup fixtures. All tests validate proper error handling and state transitions:

1. `test_create_match_zero_stake`: Verifies InvalidAmount error
2. `test_submit_result_unauthorized`: Verifies Unauthorized error for non-oracle caller
3. `test_double_deposit_rejected`: Verifies AlreadyFunded error on second deposit
4. `test_get_pending_matches_empty_on_init`: Verifies empty Vec returned on initialization

## Files Changed
- `contracts/escrow/src/tests/validation.rs` (new file)
- `contracts/escrow/src/tests/mod.rs` (module registration)
- `contracts/escrow/src/tests/security.rs` (authorization test)
- `contracts/escrow/src/tests/lifecycle.rs` (deposit lifecycle test)
- `contracts/escrow/src/tests/index.rs` (query test)

Closes #1097
Closes #1098
Closes #1099
Closes #1100