### PR TITLE
docs: add changelog contribution guidelines and PR template link

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -26,6 +26,7 @@ Link the issue number or task this PR addresses.
 - [ ] I manually verified the contract or CLI behavior where applicable.
 - [ ] I linked this PR to the related issue.
 - [ ] I included notes on any TTL or storage assumptions affecting contract state.
+- [ ] I added a `CHANGELOG.md` entry under `[Unreleased]` following the [changelog guidelines](../CONTRIBUTING.md#updating-the-changelog).
 
 ## Notes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,6 +90,60 @@ cargo test -p oracle
 
 See [docs/repository-health-checklist.md](docs/repository-health-checklist.md) for checklist details.
 
+## Updating the Changelog
+
+Every pull request **must** include a changelog entry. This keeps the release history accurate and helps reviewers understand the impact of a change at a glance.
+
+### Where to add your entry
+
+Open `CHANGELOG.md` and add your entry under the `## [Unreleased]` section at the top of the file. If that section does not exist yet, add it directly below the introductory paragraph.
+
+### Entry format
+
+The project follows the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) convention. Use one of these subsection headings — add only the ones that apply:
+
+```markdown
+## [Unreleased]
+
+### Added
+- Short description of a new feature or capability.
+
+### Changed
+- Short description of a change to existing behavior.
+
+### Fixed
+- Short description of a bug that was fixed.
+
+### Removed
+- Short description of something that was removed.
+```
+
+### Full entry template
+
+Copy the block below into `CHANGELOG.md` under `## [Unreleased]` and delete the subsections you don't need:
+
+```markdown
+### Added
+- <!-- Describe new features or functions introduced by this PR -->
+
+### Changed
+- <!-- Describe modifications to existing behavior, APIs, or configuration -->
+
+### Fixed
+- <!-- Describe bugs or incorrect behavior that this PR corrects -->
+
+### Removed
+- <!-- Describe features, flags, or APIs that were deleted -->
+```
+
+### Guidelines
+
+- Write entries from the perspective of a **user or integrator**, not an implementer. Explain *what changed* and *why it matters*, not *how* the code was restructured.
+- Use the past tense and start with a capital letter: `Added support for …`, `Fixed incorrect payout when …`
+- One bullet per logical change. If a PR touches multiple independent areas, add one bullet for each.
+- Do **not** include internal refactors or test-only changes unless they affect observable behavior.
+- When a version is released, maintainers will move `[Unreleased]` entries into a new versioned section (e.g. `## [1.1.0] - 2026-08-01`). You don't need to do this yourself.
+
 ## Submitting a Pull Request
 
 1. Push your branch to your fork:


### PR DESCRIPTION
### Summary

Standardized the changelog contribution process by adding clear documentation, a reusable template, and guidance for contributors to keep release notes up to date.

### Changes

* Added a changelog entry template to `CONTRIBUTING.md`
* Documented the required format using:

  * `## [version] - date`
  * `Added`
  * `Changed`
  * `Fixed`
  * `Removed`
* Added guidance requiring contributors to update `CHANGELOG.md` with every PR
* Linked the PR template to the changelog instructions for easier discoverability

### Testing

* Reviewed documentation flow to ensure contributors can easily locate and follow the changelog process
* Verified links and formatting render correctly

### Notes

* This PR introduces documentation improvements only.
* No application code or functionality was changed.

Closes #1135