### PR TITLE
docs: add GitHub issue templates and disable blank issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,37 @@
+---
+name: Bug Report
+about: Report a reproducible bug in Checkmate-Escrow
+title: "[Bug] "
+labels: bug
+assignees: ''
+---
+
+## Description
+
+A clear and concise description of the bug.
+
+## Steps to Reproduce
+
+1. 
+2. 
+3. 
+
+## Expected Behavior
+
+What you expected to happen.
+
+## Actual Behavior
+
+What actually happened. Include any error messages or contract error codes.
+
+## Environment
+
+- Network: <!-- testnet / mainnet -->
+- Soroban CLI version:
+- Rust version (`rustc --version`):
+- OS:
+- Contract version / commit:
+
+## Additional Context
+
+Add any other context, logs, or screenshots here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Ask a Question
+    url: https://github.com/johnsaviour56-ship-it/Checkmate-Escrow/discussions
+    about: Use GitHub Discussions for questions and general help.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,23 @@
+---
+name: Feature Request
+about: Propose a new feature or improvement
+title: "[Feature] "
+labels: enhancement
+assignees: ''
+---
+
+## Problem Description
+
+What problem does this feature solve? Who is affected and why does it matter?
+
+## Proposed Solution
+
+Describe the feature or change you'd like to see. Be as specific as possible.
+
+## Alternatives Considered
+
+What other approaches did you consider, and why did you rule them out?
+
+## Additional Context
+
+Add any other context, mockups, or references here.


### PR DESCRIPTION
### Summary

Introduced structured GitHub issue templates to improve issue quality, streamline triage, and encourage contributors to provide the necessary information upfront.

### Changes

* Added `bug_report.md` with fields for:

  * Description
  * Steps to reproduce
  * Expected vs. actual behavior
  * Environment
* Added `feature_request.md` with fields for:

  * Problem description
  * Proposed solution
  * Alternatives considered
* Added `config.yml` to disable blank issues and guide contributors to the available templates

### Testing

* Verified all issue templates render correctly in GitHub
* Confirmed blank issue creation is disabled and contributors are prompted to use the appropriate template

### Notes

* This PR improves the project's issue intake and triage workflow only.
* No application code or runtime behavior was changed.

Closes #1137 