### PR TITLE
Add structured logging, local docker-compose stack, and lifecycle integration tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,19 @@ LICHESS_API_TOKEN=
 # Chess.com Oracle is planned for v1.1 and not yet implemented
 CHESSDOTCOM_API_KEY=
 
+# Oracle service signing key — hex-encoded 32-byte ed25519 seed used to sign
+# submit_result transactions. Generate one with: openssl rand -hex 32
+# The corresponding G-address must be set as the escrow contract's oracle
+# (see docs/oracle.md). Never commit a real key.
+ORACLE_SIGNING_KEY=
+ORACLE_QUEUE_DIR=./oracle-queue
+ORACLE_POLL_INTERVAL_SECS=30
+ORACLE_MAX_RETRIES=5
+ORACLE_RETRY_BASE_DELAY_SECS=10
+# RPC URL used by the oracle service specifically. Defaults to the local
+# stellar-standalone container when running via docker-compose.
+ORACLE_RPC_URL=http://localhost:8000/soroban/rpc
+
 VITE_STELLAR_NETWORK=testnet
 VITE_STELLAR_RPC_URL=https://soroban-testnet.stellar.org
 
@@ -21,3 +34,11 @@ VITE_STELLAR_RPC_URL=https://soroban-testnet.stellar.org
 # Set it when running more than one indexer replica so that one replica's
 # cache invalidation is seen by all of them.
 REDIS_URL=redis://localhost:6379
+
+# Event indexer / API server — structured JSON logging.
+# LOG_LEVEL sets the service's own log level (error, warn, info, debug, trace).
+LOG_LEVEL=info
+# RUST_LOG overrides per-module log levels using `tracing-subscriber`'s
+# EnvFilter syntax, e.g. `RUST_LOG=event_indexer=debug,tower_http=debug`.
+# Leave unset to use LOG_LEVEL for the whole service.
+RUST_LOG=

--- a/contracts/escrow/tests/match_lifecycle_test.rs
+++ b/contracts/escrow/tests/match_lifecycle_test.rs
@@ -1,0 +1,87 @@
+//! Integration test: full match lifecycle via the escrow contract's public API.
+//!
+//! Sequence: create match → both players deposit → oracle submits result →
+//! match state is `Completed` and the winner is paid out.
+//!
+//! Runs entirely against a local Soroban test environment (`Env::default()`),
+//! no testnet or network access required.
+//!
+//! Run with:
+//!   cargo test -p escrow --test match_lifecycle_test
+
+use escrow::types::{MatchState, Platform, ProtocolConfig, Winner};
+use escrow::{EscrowContract, EscrowContractClient};
+use soroban_sdk::{
+    testutils::Address as _, token::StellarAssetClient, Address, Env, String as SorobanString,
+};
+
+const STAKE: i128 = 100;
+const MINT_AMOUNT: i128 = 10_000;
+
+/// Returns `(env, contract_id, oracle, player1, player2, token)`.
+fn setup() -> (Env, Address, Address, Address, Address, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let oracle = Address::generate(&env);
+    let player1 = Address::generate(&env);
+    let player2 = Address::generate(&env);
+
+    let token_id = env.register_stellar_asset_contract_v2(admin.clone());
+    let token = token_id.address();
+    let asset = StellarAssetClient::new(&env, &token);
+    asset.mint(&player1, &MINT_AMOUNT);
+    asset.mint(&player2, &MINT_AMOUNT);
+
+    let contract_id = env.register_contract(None, EscrowContract);
+    let client = EscrowContractClient::new(&env, &contract_id);
+    client.initialize(&oracle, &admin);
+    client.set_protocol_config(&ProtocolConfig {
+        vesting_duration_seconds: 0,
+        cancellation_fee_basis_points: 0,
+        treasury: admin.clone(),
+    });
+
+    (env, contract_id, oracle, player1, player2, token)
+}
+
+#[test]
+fn full_match_lifecycle_create_deposit_result_completed() {
+    let (env, contract_id, _oracle, player1, player2, token) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    // 1. Create match — starts Pending, awaiting deposits.
+    let match_id = client.create_match(
+        &player1,
+        &player2,
+        &STAKE,
+        &token,
+        &SorobanString::from_str(&env, "lifecycle_e2e_game"),
+        &Platform::Lichess,
+    );
+    assert_eq!(client.get_match(&match_id).state, MatchState::Pending);
+
+    // 2. Both players deposit — match becomes Active and fully funded.
+    client.deposit(&match_id, &player1);
+    assert_eq!(client.get_match(&match_id).state, MatchState::Pending);
+
+    client.deposit(&match_id, &player2);
+    assert_eq!(client.get_match(&match_id).state, MatchState::Active);
+    assert!(client.is_funded(&match_id));
+    assert_eq!(client.get_escrow_balance(&match_id), STAKE * 2);
+
+    let token_client = soroban_sdk::token::Client::new(&env, &token);
+    let winner_balance_before = token_client.balance(&player1);
+
+    // 3. Oracle submits the result — player1 wins.
+    client.submit_result(&match_id, &Winner::Player1);
+
+    // 4. Match transitions to Completed and the winner is paid the full pot.
+    assert_eq!(client.get_match(&match_id).state, MatchState::Completed);
+    assert_eq!(client.get_escrow_balance(&match_id), 0);
+    assert_eq!(
+        token_client.balance(&player1),
+        winner_balance_before + STAKE * 2
+    );
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,28 @@
 version: '3.8'
 
 services:
+  # ── Stellar standalone node (local Soroban network + RPC) ─────────────────
+  # Provides a throwaway local network for contract deployment and testing —
+  # no testnet/mainnet access needed for local full-stack development.
+  stellar-standalone:
+    image: stellar/quickstart:latest
+    restart: unless-stopped
+    command: ["--standalone", "--enable-soroban-rpc"]
+    ports:
+      - "8000:8000"
+    healthcheck:
+      test:
+        - "CMD-SHELL"
+        - >-
+          curl -sf -X POST http://localhost:8000/soroban/rpc
+          -H 'Content-Type: application/json'
+          -d '{"jsonrpc":"2.0","id":1,"method":"getHealth"}'
+          | grep -q healthy
+      interval: 10s
+      timeout: 5s
+      retries: 15
+      start_period: 30s
+
   # ── PostgreSQL ─────────────────────────────────────────────────────────────
   postgres:
     image: postgres:15-alpine
@@ -147,6 +169,40 @@ services:
     profiles:
       - testing
 
+  # ── Oracle service (Lichess/Chess.com result submission) ─────────────────
+  # Requires CONTRACT_ESCROW, CONTRACT_ORACLE and ORACLE_SIGNING_KEY to be set
+  # in .env once contracts are deployed to stellar-standalone — see
+  # docs/local-dev.md for the full local deployment walkthrough.
+  oracle-service:
+    build:
+      context: .
+      dockerfile: oracle-service/Dockerfile
+    restart: unless-stopped
+    depends_on:
+      stellar-standalone:
+        condition: service_healthy
+    ports:
+      - "8095:8000"
+    environment:
+      STELLAR_RPC_URL: ${ORACLE_RPC_URL:-http://stellar-standalone:8000/soroban/rpc}
+      STELLAR_NETWORK: ${STELLAR_NETWORK:-standalone}
+      CONTRACT_ESCROW: ${CONTRACT_ESCROW}
+      CONTRACT_ORACLE: ${CONTRACT_ORACLE}
+      ORACLE_SIGNING_KEY: ${ORACLE_SIGNING_KEY}
+      LICHESS_API_TOKEN: ${LICHESS_API_TOKEN:-}
+      CHESSDOTCOM_API_KEY: ${CHESSDOTCOM_API_KEY:-}
+      ORACLE_POLL_INTERVAL_SECS: ${ORACLE_POLL_INTERVAL_SECS:-30}
+      ORACLE_MAX_RETRIES: ${ORACLE_MAX_RETRIES:-5}
+      ORACLE_RETRY_BASE_DELAY_SECS: ${ORACLE_RETRY_BASE_DELAY_SECS:-10}
+      ORACLE_QUEUE_DIR: /data/oracle-queue
+    volumes:
+      - oracle-queue-data:/data/oracle-queue
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+
   # ── WebSocket server (real-time match events) ────────────────────────────
   websocket-server:
     build:
@@ -177,4 +233,6 @@ services:
 
 volumes:
   postgres-data:
+    driver: local
+  oracle-queue-data:
     driver: local

--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -59,13 +59,47 @@ The event indexer tracks on-chain events and indexes them for quick queries. Con
 
 #### Using Docker Compose
 
-Alternatively, run the event indexer in a container via Docker Compose. Make sure `.env` is set up first (see [Environment variables](#environment-variables)):
+`docker compose up` runs the full stack — a local Stellar network, the event
+indexer (API server), the oracle service, Postgres/Redis, and the WebSocket
+server — with one command, no manual multi-terminal setup required.
+
+Make sure `.env` is set up first (see [Environment variables](#environment-variables)):
 
 ```bash
+cp .env.example .env
 docker compose up --build
 ```
 
-This builds the `event-indexer` service from `services/event-indexer/Dockerfile`, persists its SQLite database in a named Docker volume, and exposes the API on `http://localhost:8080`. Environment variables are sourced from `.env` at the repo root, with sensible defaults applied for anything not set (see `docker-compose.yml`).
+Services started:
+
+| Service | Container port | Host port | Purpose |
+|---|---|---|---|
+| `stellar-standalone` | 8000 | 8000 | Local Soroban network + RPC (`stellar/quickstart`) |
+| `postgres` | 5432 | 5432 | Event indexer storage |
+| `redis` | 6379 | 6379 | Shared API response cache |
+| `event-indexer-1` (API server) | 8080 | 8080 | REST API — matches, events, analytics |
+| `event-indexer-2` | 8080 | 8081 | Second leader-eligible replica |
+| `oracle-service` | 8000 | 8095 | Polls Lichess/Chess.com and submits results |
+| `websocket-server` | 8090 | 8090 | Real-time match events |
+
+`event-indexer-3` only starts with `docker compose --profile testing up`, for
+exercising 3+ instance HA locally.
+
+To exercise the full local flow against the contracts:
+
+1. Start the stack: `docker compose up --build -d stellar-standalone`.
+2. Build and deploy the contracts to the running standalone node (see
+   `./scripts/build.sh` and [Using a local Stellar network](#using-a-local-stellar-network)
+   below), using `--network standalone` so the RPC points at
+   `http://localhost:8000/soroban/rpc`.
+3. Set `CONTRACT_ESCROW`, `CONTRACT_ORACLE` and `ORACLE_SIGNING_KEY` in `.env`
+   to the deployed contract IDs and a generated oracle key
+   (`openssl rand -hex 32`).
+4. Start the rest of the stack: `docker compose up --build`. The oracle
+   service and event indexer will pick up the new `.env` values.
+
+Environment variables are sourced from `.env` at the repo root, with sensible
+defaults applied for anything not set (see `docker-compose.yml`).
 
 ## Configuration
 

--- a/oracle-service/Dockerfile
+++ b/oracle-service/Dockerfile
@@ -1,0 +1,11 @@
+FROM rust:1.82-slim AS builder
+WORKDIR /app
+COPY . .
+RUN cargo build --release --manifest-path oracle-service/Cargo.toml
+
+FROM debian:bookworm-slim
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl && rm -rf /var/lib/apt/lists/*
+WORKDIR /app
+COPY --from=builder /app/target/release/oracle-service /usr/local/bin/oracle-service
+EXPOSE 8000
+CMD ["oracle-service"]

--- a/oracle-service/tests/lichess_e2e_test.rs
+++ b/oracle-service/tests/lichess_e2e_test.rs
@@ -1,0 +1,177 @@
+//! Integration test: Lichess oracle completes a match end-to-end.
+//!
+//! Sequence: the (mocked) Lichess API returns a decisive game result, the
+//! oracle's poller picks it up, signs and submits `submit_result` to the
+//! (mocked) Soroban RPC, and the transaction lifecycle reports success.
+//!
+//! No real network access is used — both the Lichess API and the Soroban RPC
+//! are `wiremock` servers on localhost.
+//!
+//! Run with:
+//!   cargo test -p oracle-service --test lichess_e2e_test
+
+use oracle_service::{
+    config::{OracleConfig, Platform},
+    dead_letter::DeadLetterStore,
+    poller::Poller,
+    queue::{PendingEntry, PendingQueue},
+};
+
+use chrono::Utc;
+use stellar_xdr::{HostFunction, Limits, OperationBody, ReadXdr, ScSymbol, ScVal, TransactionEnvelope};
+use tempfile::TempDir;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+use zeroize::Zeroizing;
+
+const MATCH_ID: u64 = 4242;
+const GAME_ID: &str = "e2e_lichess_game";
+
+/// Build a minimal OracleConfig pointing at the mock Soroban RPC.
+fn make_config(soroban_rpc_url: &str, queue_dir: &str) -> OracleConfig {
+    // Fixed 32-byte key so the test is deterministic.
+    let seed = [0x7Au8; 32];
+    let signing_key = Zeroizing::new(seed);
+
+    use ed25519_dalek::SigningKey;
+    let sk = SigningKey::from_bytes(&seed);
+    let vk = sk.verifying_key();
+    let oracle_address = format!("{}", stellar_strkey::ed25519::PublicKey(vk.to_bytes()));
+
+    OracleConfig {
+        rpc_url: soroban_rpc_url.to_string(),
+        network_passphrase: "Test SDF Network ; September 2015".to_string(),
+        contract_escrow: "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM".to_string(),
+        contract_oracle: "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM".to_string(),
+        oracle_signing_key: signing_key,
+        oracle_address,
+        lichess_api_token: None,
+        chessdotcom_api_key: None,
+        poll_interval_secs: 1,
+        max_retries: 3,
+        retry_base_delay_secs: 1,
+        queue_dir: queue_dir.to_string(),
+    }
+}
+
+/// Mounts the full getAccount → simulateTransaction → sendTransaction →
+/// getTransaction lifecycle. A single catch-all response covers all four RPC
+/// methods since the client only reads whichever fields it needs per call.
+async fn mount_soroban_success(server: &MockServer) {
+    Mock::given(method("POST"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {
+                "sequence": "100",
+                "transactionData": "",
+                "minResourceFee": "0",
+                "results": [],
+                "status": "SUCCESS",
+                "hash": "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+            }
+        })))
+        .up_to_n_times(100)
+        .mount(server)
+        .await;
+}
+
+async fn enqueue_due(queue: &PendingQueue, match_id: u64, game_id: &str, platform: Platform) {
+    let mut entry = PendingEntry::new(match_id, game_id.to_string(), platform);
+    entry.next_attempt_at = Utc::now() - chrono::Duration::seconds(1);
+    queue.save(&[entry]).await.unwrap();
+}
+
+/// Full happy path: Lichess reports a decisive win, the oracle signs and
+/// submits `submit_result(match_id, winner)` for the correct match, and the
+/// Soroban RPC confirms the transaction.
+///
+/// Asserting the escrow contract's on-chain state directly would require a
+/// live Soroban network, which is out of scope for this service-level test
+/// (see `contracts/escrow/tests/match_lifecycle_test.rs` for that, run
+/// against a real in-process Soroban `Env`). Here we assert on the boundary
+/// this service owns: it must submit exactly one `submit_result` invocation
+/// carrying the correct match id and winner, and it only clears the entry
+/// from its pending queue once the RPC lifecycle reports the transaction
+/// succeeded — i.e. once the ledger has recorded the match's completion and
+/// payout.
+#[tokio::test]
+async fn lichess_oracle_completes_match_end_to_end() {
+    // ── Mock Lichess API: white wins ───────────────────────────────────────
+    let lichess_server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path(format!("/game/export/{}", GAME_ID)))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "winner": "white"
+        })))
+        .mount(&lichess_server)
+        .await;
+
+    // ── Mock Soroban RPC ─────────────────────────────────────────────────────
+    let rpc_server = MockServer::start().await;
+    mount_soroban_success(&rpc_server).await;
+
+    // ── Setup ────────────────────────────────────────────────────────────────
+    let dir = TempDir::new().unwrap();
+    let dir_str = dir.path().to_str().unwrap();
+    let cfg = make_config(&rpc_server.uri(), dir_str);
+
+    let poller = Poller::new_with_lichess_base(&cfg, lichess_server.uri()).unwrap();
+    let queue = PendingQueue::new(dir_str);
+    let dead_letter = DeadLetterStore::new(dir_str);
+
+    enqueue_due(&queue, MATCH_ID, GAME_ID, Platform::Lichess).await;
+
+    // ── Poll once: fetch the result and submit it on-chain ──────────────────
+    poller.tick().await.unwrap();
+
+    // The queue entry is only removed once submit_result is confirmed, so an
+    // empty queue is proof the oracle drove the match to completion.
+    assert!(
+        queue.load().await.unwrap().is_empty(),
+        "match should be completed and removed from the pending queue"
+    );
+    assert!(
+        dead_letter.load().await.unwrap().is_empty(),
+        "a successful submission must not be dead-lettered"
+    );
+
+    // ── Verify the exact call the oracle made to the contract ──────────────
+    let requests = rpc_server.received_requests().await.unwrap();
+    let send_tx_body = requests
+        .iter()
+        .find_map(|req| {
+            let body: serde_json::Value = serde_json::from_slice(&req.body).ok()?;
+            if body.get("method")?.as_str()? == "sendTransaction" {
+                Some(body)
+            } else {
+                None
+            }
+        })
+        .expect("oracle must call sendTransaction to submit the result");
+
+    let tx_xdr = send_tx_body["params"]["transaction"]
+        .as_str()
+        .expect("sendTransaction must carry a transaction XDR");
+    let envelope = TransactionEnvelope::from_xdr_base64(tx_xdr, Limits::none())
+        .expect("submitted transaction must be well-formed XDR");
+
+    let TransactionEnvelope::Tx(v1) = envelope else {
+        panic!("expected a TransactionV1Envelope");
+    };
+    let op = v1.tx.operations.get(0).expect("transaction must have one operation");
+    let OperationBody::InvokeHostFunction(invoke_op) = &op.body else {
+        panic!("expected an InvokeHostFunction operation");
+    };
+    let HostFunction::InvokeContract(invoke_args) = &invoke_op.host_function else {
+        panic!("expected an InvokeContract host function");
+    };
+
+    let expected_fn_name = ScSymbol("submit_result".try_into().unwrap());
+    assert_eq!(invoke_args.function_name, expected_fn_name);
+
+    assert_eq!(invoke_args.args.get(0), Some(&ScVal::U64(MATCH_ID)));
+
+    let expected_winner = ScVal::Symbol(ScSymbol("Player1".try_into().unwrap()));
+    assert_eq!(invoke_args.args.get(1), Some(&expected_winner));
+}

--- a/services/event-indexer/Dockerfile
+++ b/services/event-indexer/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.75-slim AS builder
+FROM rust:1.82-slim AS builder
 WORKDIR /app
 COPY . .
 RUN cargo build --release --manifest-path services/event-indexer/Cargo.toml

--- a/services/event-indexer/src/api.rs
+++ b/services/event-indexer/src/api.rs
@@ -22,14 +22,17 @@
 
 use axum::{
     async_trait,
-    extract::{rejection::QueryRejection, FromRequestParts, Path, Query, State},
+    extract::{rejection::QueryRejection, FromRequestParts, Path, Query, Request, State},
     http::{request::Parts, StatusCode},
+    middleware::Next,
+    response::Response,
     routing::get,
     Json, Router,
 };
 use serde::{Deserialize, Serialize};
 use serde_json;
 use std::sync::Arc;
+use std::time::Instant;
 use tokio::sync::RwLock;
 use tracing::info;
 
@@ -138,6 +141,36 @@ pub struct TransactionHistoryQuery {
     pub sort_order: Option<String>,
 }
 
+// ── Structured request logging ─────────────────────────────────────────────────
+
+/// Logs one structured JSON line per request: `request_id`, `method`, `path`,
+/// `status_code` and `duration_ms`, alongside the `timestamp`/`level` every
+/// `tracing-subscriber` JSON line already carries. Wraps every other layer so
+/// the recorded status and duration reflect what the caller actually saw,
+/// including responses short-circuited by [`validation::validate_request`].
+async fn request_logging_middleware(req: Request, next: Next) -> Response {
+    let start = Instant::now();
+    let request_id = uuid::Uuid::new_v4().to_string();
+    let method = req.method().to_string();
+    let path = req.uri().path().to_string();
+
+    let response = next.run(req).await;
+
+    let duration_ms = start.elapsed().as_millis();
+    let status_code = response.status().as_u16();
+
+    info!(
+        request_id = %request_id,
+        method = %method,
+        path = %path,
+        status_code = status_code,
+        duration_ms = duration_ms,
+        "request completed"
+    );
+
+    response
+}
+
 // ── Router ────────────────────────────────────────────────────────────────────
 
 pub fn build_router(
@@ -166,6 +199,9 @@ pub fn build_router(
         // Validation runs before routing dispatches to a handler, so malformed
         // input never reaches the database.
         .layer(axum::middleware::from_fn(validation::validate_request))
+        // Outermost layer: logs every request, including ones rejected by
+        // validation above, with the status and latency the caller observed.
+        .layer(axum::middleware::from_fn(request_logging_middleware))
         .with_state(state)
 }
 

--- a/services/event-indexer/src/config.rs
+++ b/services/event-indexer/src/config.rs
@@ -166,7 +166,10 @@ impl Config {
         }
 
         // ── Logging ───────────────────────────────────────────────────────
-        let log_level = env::var("EVENT_INDEXER_LOG_LEVEL")
+        // `LOG_LEVEL` is the standard variable name; `EVENT_INDEXER_LOG_LEVEL`
+        // is kept as a fallback for existing deployments that already set it.
+        let log_level = env::var("LOG_LEVEL")
+            .or_else(|_| env::var("EVENT_INDEXER_LOG_LEVEL"))
             .unwrap_or_else(|_| "info".to_string());
 
         Ok(Config {

--- a/services/event-indexer/src/main.rs
+++ b/services/event-indexer/src/main.rs
@@ -11,6 +11,10 @@ async fn main() -> Result<()> {
     let config = Config::from_env()?;
 
     tracing_subscriber::fmt()
+        .json()
+        .flatten_event(true)
+        .with_current_span(false)
+        .with_span_list(false)
         .with_env_filter(
             tracing_subscriber::EnvFilter::from_default_env()
                 .add_directive(format!("event_indexer={}", config.log_level).parse()?),


### PR DESCRIPTION
## Summary
- Structured JSON request logging for the event-indexer API server (timestamp, level, request_id, method, path, status_code, duration_ms), configurable via `LOG_LEVEL` (closes #1151)
- `docker-compose.yml` bringing up a full local stack — `stellar-standalone`, Postgres, Redis, event-indexer replicas, `oracle-service`, and the WebSocket server — with new `Dockerfile`s for the oracle and API services, documented in `docs/local-dev.md` (closes #1154)
- Integration test exercising the full match lifecycle (create → deposit → oracle result → payout) against a local Soroban `Env` (closes #1152)
- Integration test exercising the Lichess oracle end-to-end flow against mocked Lichess/Soroban RPC servers, asserting the correct `submit_result` call is submitted (closes #1153)

## Test plan
- [ ] `cargo test -p escrow --test match_lifecycle_test`
- [ ] `cargo test -p oracle-service --test lichess_e2e_test`
- [ ] `docker compose up --build` brings up a healthy stack