### PR TITLE
fix: add freighter unit tests and coverage badge (closes #838, #866)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Checkmate-Escrow — Competitive Chess Betting on Stellar
 
+[![Code Coverage](https://github.com/meetdarc-tech/Checkmate-Escrow/actions/workflows/coverage.yml/badge.svg)](https://github.com/meetdarc-tech/Checkmate-Escrow/actions/workflows/coverage.yml)
+
 A trustless chess wagering platform built on Stellar Soroban smart contracts. Players stake tokens before a match, and the winner is automatically paid out the moment the game ends — no middleman, no delays, no trust required.
 
 

--- a/frontend/src/test/freighter.test.ts
+++ b/frontend/src/test/freighter.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@stellar/freighter-api', () => ({
+  isConnected: vi.fn(),
+  getAddress: vi.fn(),
+  signTransaction: vi.fn(),
+}));
+
+import { isConnected, getAddress, signTransaction } from '@stellar/freighter-api';
+import {
+  freighterIsAvailable,
+  freighterGetPublicKey,
+  freighterSign,
+} from '../wallets/freighter';
+
+const FAKE_PUBKEY = 'GFREIGHTER1234567890ABCDE1234567890ABCDE1234567890ABCDE12345';
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('freighterIsAvailable', () => {
+  it('test_freighter_is_available_returns_true_when_connected', async () => {
+    vi.mocked(isConnected).mockResolvedValue({ isConnected: true } as Awaited<ReturnType<typeof isConnected>>);
+    const result = await freighterIsAvailable();
+    expect(result).toBe(true);
+  });
+
+  it('test_freighter_is_available_returns_false_when_not_connected', async () => {
+    vi.mocked(isConnected).mockResolvedValue({ isConnected: false } as Awaited<ReturnType<typeof isConnected>>);
+    const result = await freighterIsAvailable();
+    expect(result).toBe(false);
+  });
+
+  it('test_freighter_is_available_returns_false_on_error', async () => {
+    vi.mocked(isConnected).mockRejectedValue(new Error('Extension not found'));
+    const result = await freighterIsAvailable();
+    expect(result).toBe(false);
+  });
+});
+
+describe('freighterGetPublicKey', () => {
+  it('test_freighter_get_public_key_returns_address_on_success', async () => {
+    vi.mocked(getAddress).mockResolvedValue({
+      address: FAKE_PUBKEY,
+      error: undefined,
+    } as Awaited<ReturnType<typeof getAddress>>);
+    const key = await freighterGetPublicKey();
+    expect(key).toBe(FAKE_PUBKEY);
+  });
+
+  it('test_freighter_get_public_key_throws_when_error_present', async () => {
+    vi.mocked(getAddress).mockResolvedValue({
+      address: '',
+      error: { message: 'User rejected the request', code: 4001 },
+    } as Awaited<ReturnType<typeof getAddress>>);
+    await expect(freighterGetPublicKey()).rejects.toThrow('User rejected the request');
+  });
+
+  it('test_freighter_get_public_key_calls_getAddress', async () => {
+    vi.mocked(getAddress).mockResolvedValue({
+      address: FAKE_PUBKEY,
+      error: undefined,
+    } as Awaited<ReturnType<typeof getAddress>>);
+    await freighterGetPublicKey();
+    expect(getAddress).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('freighterSign', () => {
+  const FAKE_XDR = 'AAAA...fake_xdr...ZZZZ';
+  const FAKE_NETWORK = 'Test SDF Network ; September 2015';
+  const FAKE_SIGNED_XDR = 'BBBB...signed_xdr...YYYY';
+
+  it('test_freighter_sign_returns_signed_xdr_on_success', async () => {
+    vi.mocked(signTransaction).mockResolvedValue({
+      signedTxXdr: FAKE_SIGNED_XDR,
+      error: undefined,
+    } as Awaited<ReturnType<typeof signTransaction>>);
+    const result = await freighterSign(FAKE_XDR, FAKE_NETWORK);
+    expect(result.signedXdr).toBe(FAKE_SIGNED_XDR);
+  });
+
+  it('test_freighter_sign_passes_network_passphrase', async () => {
+    vi.mocked(signTransaction).mockResolvedValue({
+      signedTxXdr: FAKE_SIGNED_XDR,
+      error: undefined,
+    } as Awaited<ReturnType<typeof signTransaction>>);
+    await freighterSign(FAKE_XDR, FAKE_NETWORK);
+    expect(signTransaction).toHaveBeenCalledWith(FAKE_XDR, {
+      networkPassphrase: FAKE_NETWORK,
+    });
+  });
+
+  it('test_freighter_sign_throws_when_error_present', async () => {
+    vi.mocked(signTransaction).mockResolvedValue({
+      signedTxXdr: '',
+      error: { message: 'Transaction rejected', code: 4001 },
+    } as Awaited<ReturnType<typeof signTransaction>>);
+    await expect(freighterSign(FAKE_XDR, FAKE_NETWORK)).rejects.toThrow(
+      'Transaction rejected',
+    );
+  });
+});


### PR DESCRIPTION
## Summary

This PR resolves two open issues by adding unit test coverage for the Freighter wallet integration and surfacing the coverage report status directly in the README.

Closes #838
Closes #866

---

## Changes Made

### Issue #838 - Add reighter.ts unit tests

**File:** rontend/src/test/freighter.test.ts

The Freighter wallet adapter (rontend/src/wallets/freighter.ts) had no dedicated unit tests. This PR introduces a full test suite using **Vitest** with 9 test cases across 3 describe blocks:

#### reighterIsAvailable
- 	est_freighter_is_available_returns_true_when_connected - mocks isConnected to return { isConnected: true } and asserts the function returns 	rue.
- 	est_freighter_is_available_returns_false_when_not_connected - mocks isConnected to return { isConnected: false } and asserts the function returns alse.
- 	est_freighter_is_available_returns_false_on_error - mocks isConnected to reject and asserts the function catches the error and returns alse.

#### reighterGetPublicKey
- 	est_freighter_get_public_key_returns_address_on_success - mocks getAddress with a valid public key and asserts the returned value matches.
- 	est_freighter_get_public_key_throws_when_error_present - mocks getAddress returning an error object and asserts the function throws with the correct message.
- 	est_freighter_get_public_key_calls_getAddress - asserts that getAddress is called exactly once per invocation.

#### reighterSign
- 	est_freighter_sign_returns_signed_xdr_on_success - mocks signTransaction with a signed XDR string and asserts the result's signedXdr field matches.
- 	est_freighter_sign_passes_network_passphrase - asserts that signTransaction is called with the correct XDR and 
etworkPassphrase options.
- 	est_freighter_sign_throws_when_error_present - mocks signTransaction returning an error and asserts the function throws with the correct message.

The @stellar/freighter-api module is fully mocked via i.mock(...) so tests run offline without any browser extension dependency. eforeEach(() => vi.clearAllMocks()) ensures test isolation.

---

### Issue #866 - Add coverage badge to README.md

**File:** README.md

The coverage.yml GitHub Actions workflow was already generating a coverage report, but the result was not visible on the repository's main page. This PR adds a GitHub Actions workflow status badge on line 3 of README.md:

`md
[![Code Coverage](https://github.com/meetdarc-tech/Checkmate-Escrow/actions/workflows/coverage.yml/badge.svg)](https://github.com/meetdarc-tech/Checkmate-Escrow/actions/workflows/coverage.yml)
`

The badge:
- Links directly to the coverage.yml workflow run history for quick access to the latest report.
- Updates automatically on every push that triggers coverage.yml - no manual maintenance required.
- Is placed immediately below the repository title for maximum visibility.

---

## Testing

- All 9 Vitest unit tests in reighter.test.ts are self-contained and can be run with pnpm test or itest run from the rontend/ directory.
- The coverage badge reflects live CI status and requires no additional setup.

## Files Changed

| File | Change |
|------|--------|
| rontend/src/test/freighter.test.ts | New file - 102 lines, 9 unit tests |
| README.md | Added coverage badge (2 lines) |