### PR TITLE
Attach WAF and rate-limit middleware to oracle-service Router

### DIFF
--- a/docs/oracle.md
+++ b/docs/oracle.md
@@ -27,6 +27,29 @@ health check now:
 
 ---
 
+## HTTP Layer Protections (WAF & Rate Limiting)
+
+Every request to the oracle service's exposed HTTP endpoints (`/health`, `/api/docs`,
+`/api/openapi.yaml`) passes through two `axum` middleware layers before reaching a
+handler, applied in `oracle-service/src/main.rs`:
+
+1. **WAF** (`oracle_service::middleware::waf`) — outermost layer, runs first:
+   - Burst rate limiting: more than 20 requests/second from one IP → `429`
+   - Oversized body: `Content-Length` over 1 MiB → `413`
+   - Long URI: request URI over 2,048 characters → `400`
+   - Null byte in URI → `400`
+2. **Rate limiter** (`oracle_service::middleware::rate_limit`) — token-bucket
+   limiting per IP (100 req/min) and per `X-Api-Key` (1,000 req/min), returning
+   `429` with `X-RateLimit-*`/`Retry-After` headers when a bucket is exhausted.
+
+This is distinct from the on-chain [Oracle Submission Rate
+Limiting](#oracle-submission-rate-limiting) (which throttles `submit_result`
+calls) and from the client-side platform rate limiters described in [Chess.com
+API Rate Limits](#chesscom-api-rate-limits-timeouts-and-offline-fallback) —
+this section covers protection of the oracle service's own HTTP surface.
+
+---
+
 ## Oracle Contract Role
 
 The escrow contract uses its configured oracle address as the authoritative

--- a/docs/security.md
+++ b/docs/security.md
@@ -10,6 +10,7 @@ This document outlines the security considerations, trust assumptions, and risk 
 - [Re-initialization Protection](#re-initialization-protection)
 - [Pause Mechanism](#pause-mechanism)
 - [Cross-Contract Reentrancy Protection](#cross-contract-reentrancy-protection)
+- [Oracle Service HTTP Hardening](#oracle-service-http-hardening)
 - [Known Limitations](#known-limitations)
 - [Deployment Security](#deployment-security)
 - [Operational Security](#operational-security)
@@ -257,6 +258,24 @@ Key properties:
    state), a concurrent `deposit()` call for the same `match_id` is rejected
    with `Error::DepositInProgress`.
 2. After the guard is cleared, `deposit()` proceeds normally.
+
+## Oracle Service HTTP Hardening
+
+The oracle service's exposed HTTP endpoints (`/health`, `/api/docs`,
+`/api/openapi.yaml`) are protected by two `axum` middleware layers, attached
+in `oracle-service/src/main.rs` and implemented in
+`oracle-service/src/middleware/`:
+
+1. **WAF** — blocks request bursts over 20 req/s from one IP (`429`),
+   oversized bodies over 1 MiB (`413`), URIs over 2,048 characters (`400`),
+   and null bytes in the URI (`400`).
+2. **Rate limiter** — token-bucket limiting per IP (100 req/min) and per
+   `X-Api-Key` (1,000 req/min), returning `429` with standard
+   `X-RateLimit-*`/`Retry-After` headers.
+
+Both layers run on every request before it reaches a handler; see
+[docs/oracle.md § HTTP Layer Protections](oracle.md#http-layer-protections-waf--rate-limiting)
+for the layering order and full detail.
 
 ## Known Limitations
 

--- a/oracle-service/src/main.rs
+++ b/oracle-service/src/main.rs
@@ -28,7 +28,10 @@ use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilte
 use oracle_service::{
     config,
     health::HealthChecker,
-    middleware::{rate_limit::RateLimitState, waf::WafState},
+    middleware::{
+        rate_limit::{self, RateLimitState},
+        waf::{self, WafState},
+    },
     oracle::{ChessComClient, LichessClient},
     poller::Poller,
     soroban_client::SorobanClient,
@@ -39,6 +42,8 @@ use oracle_service::{
 #[derive(Clone)]
 struct AppState {
     health_checker: Arc<HealthChecker>,
+    rate_limiter: RateLimitState,
+    waf: WafState,
 }
 
 async fn health_check(State(state): State<AppState>) -> Json<serde_json::Value> {
@@ -148,16 +153,25 @@ async fn main() {
     // ── HTTP server state ─────────────────────────────────────────────────
     let app_state = AppState {
         health_checker: health_checker.clone(),
+        rate_limiter: RateLimitState::new(),
+        waf: WafState::new(),
     };
 
-    let _rate_limiter_state = RateLimitState::new();
-    let _waf_state = WafState::new();
-
+    // WAF is layered outermost so its burst/body/URI checks reject bad
+    // traffic before the token-bucket rate limiter does any bookkeeping.
     let app = Router::new()
         .route("/health", get(health_check))
         .route("/api/docs", get(api_docs_ui))
         .route("/api/openapi.yaml", get(api_openapi_yaml))
-        .with_state(app_state);
+        .with_state(app_state.clone())
+        .layer(axum::middleware::from_fn_with_state(
+            app_state.rate_limiter.clone(),
+            rate_limit::rate_limit_middleware,
+        ))
+        .layer(axum::middleware::from_fn_with_state(
+            app_state.waf.clone(),
+            waf::waf_middleware,
+        ));
 
     let listener = match tokio::net::TcpListener::bind("0.0.0.0:8000").await {
         Ok(l) => l,


### PR DESCRIPTION
## Summary
- `oracle-service/src/main.rs` built `RateLimitState`/`WafState` but never called `.layer(...)`, so `waf_middleware` and `rate_limit_middleware` never ran — every request to `/health`, `/api/docs`, and `/api/openapi.yaml` received zero WAF/rate-limit protection.
- Attach both as `axum::middleware::from_fn_with_state` layers on the `Router`, with WAF outermost so its burst/body/URI checks reject bad traffic before the token-bucket rate limiter does any bookkeeping.
- Drop the now-used `_rate_limiter_state`/`_waf_state` underscore prefixes and thread `RateLimitState`/`WafState` through `AppState` alongside `HealthChecker`, consistent with how health-checker state is already passed.
- Update `docs/security.md` and `docs/oracle.md` to document that HTTP-layer WAF/rate-limiting is active, not just implemented.

Closes #1284

## Test plan
- [x] `cargo check -p oracle-service` — compiles clean
- [x] `cargo fmt --all --check` — clean
- [x] `cargo clippy -p oracle-service --all-targets --all-features -- -D warnings` — clean
- [x] `scripts/check_links.sh` / `scripts/check_api_refs.sh` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)