### PR TITLE
Clarify disaster-recovery doc's automation status

### DIFF
--- a/docs/disaster-recovery.md
+++ b/docs/disaster-recovery.md
@@ -283,6 +283,15 @@ environment variables or the `.env` file (never committed to version control):
 
 ## Testing the Backup/Restore Cycle
 
+> **Automation status:** as of this writing, the backup/restore cycle has no
+> automated CI coverage — no test in this repository invokes
+> `backup_state.sh` or `restore_state.sh`, and `.github/workflows/backup.yml`
+> only runs on a schedule or manual dispatch against a real deployed
+> contract. The drill below is entirely manual. In particular, the network
+> confirmation prompt, the mainnet type-to-confirm guard, and in-flight match
+> recreation (see the [playbook](#in-flight-match-recovery-playbook)) all
+> require a human operator; none of them execute unattended.
+
 Run a full backup → restore drill on testnet at least once per month:
 
 ```bash


### PR DESCRIPTION
## Summary
- Addresses the docs-accuracy part of  closes #1285 
: confirms `docs/disaster-recovery.md` correctly reflects that the backup/restore cycle has zero automated CI coverage today.
- Adds an explicit "Automation status" note to the Testing section stating that `backup_state.sh`/`restore_state.sh` are invoked by no test in the repo, `backup.yml` only runs on schedule/manual dispatch, and the network confirmation prompt, mainnet type-to-confirm guard, and in-flight match recreation are all manual operator steps.

## Scope note
Per current instruction, the integration-test and adversarial-test tasks in #1285 (local-network backup/restore harness, schema-version-mismatch rejection test, etc.) are out of scope for this PR — only the documentation-accuracy task was completed.

## Test plan
- [x] `bash scripts/check_doc_conformance.sh` passes locally (no drift detected)

