### PR TITLE
Fix register_oracle_with_stake to accumulate stake instead of overwri…

### DIFF
--- a/contracts/oracle/src/errors.rs
+++ b/contracts/oracle/src/errors.rs
@@ -53,4 +53,8 @@ pub enum Error {
     InvalidAmount = 19,
     Overflow = 20,
     SlippageExceeded = 21,
+    /// `register_oracle_with_stake` was called with a `token` that differs
+    /// from the token backing an existing registration for the same oracle
+    /// address — stake denominated in two different tokens cannot be summed.
+    StakeTokenMismatch = 22,
 }

--- a/contracts/oracle/src/lib.rs
+++ b/contracts/oracle/src/lib.rs
@@ -103,6 +103,19 @@ impl OracleContract {
     }
 
     /// Register an oracle with a token stake that can be slashed if needed.
+    ///
+    /// If `oracle_address` already has a registration, `stake_amount` is
+    /// added to its existing `oracle_stake` rather than overwriting it — this
+    /// is the top-up path an oracle uses to replenish its bond after a
+    /// partial slash. `token` must match the token of the existing
+    /// registration; topping up with a different token is rejected, since
+    /// stake denominated in two different tokens cannot be meaningfully
+    /// summed.
+    ///
+    /// # Errors
+    /// - [`Error::InsufficientStake`] — `stake_amount` is not positive.
+    /// - [`Error::StakeTokenMismatch`] — `token` differs from the token
+    ///   backing this oracle's existing registration.
     pub fn register_oracle_with_stake(
         env: Env,
         oracle_address: Address,
@@ -116,6 +129,15 @@ impl OracleContract {
             return Err(Error::InsufficientStake);
         }
 
+        let registration_key = DataKey::OracleRegistration(oracle_address.clone());
+        let existing: Option<OracleRegistration> = env.storage().instance().get(&registration_key);
+
+        if let Some(existing) = &existing {
+            if existing.token != token {
+                return Err(Error::StakeTokenMismatch);
+            }
+        }
+
         let token_client = token::Client::new(&env, &token);
         token_client.transfer(
             &oracle_address,
@@ -123,11 +145,16 @@ impl OracleContract {
             &stake_amount,
         );
 
+        let new_stake = existing
+            .map(|r| r.oracle_stake)
+            .unwrap_or(0)
+            .saturating_add(stake_amount);
+
         env.storage().instance().set(
-            &DataKey::OracleRegistration(oracle_address.clone()),
+            &registration_key,
             &OracleRegistration {
                 oracle_address: oracle_address.clone(),
-                oracle_stake: stake_amount,
+                oracle_stake: new_stake,
                 token: token.clone(),
             },
         );

--- a/contracts/oracle/src/tests.rs
+++ b/contracts/oracle/src/tests.rs
@@ -107,6 +107,130 @@ fn test_slash_oracle_reduces_stake_and_transfers_tokens() {
 }
 
 #[test]
+fn test_register_oracle_with_stake_first_registration_unchanged() {
+    // Regression: a single (first-time) registration must behave identically
+    // to today — the stake stored equals the amount transferred.
+    let (env, contract_id, .., oracle_admin, _, _, token_addr) = setup();
+    let client = OracleContractClient::new(&env, &contract_id);
+    let asset_client = StellarAssetClient::new(&env, &token_addr);
+    let balance_client = soroban_sdk::token::Client::new(&env, &token_addr);
+
+    asset_client.mint(&oracle_admin, &200);
+    client.register_oracle_with_stake(&oracle_admin, &200i128, &token_addr);
+
+    assert_eq!(balance_client.balance(&contract_id), 200);
+
+    let registration: OracleRegistration = env.as_contract(&contract_id, || {
+        env.storage()
+            .instance()
+            .get(&DataKey::OracleRegistration(oracle_admin.clone()))
+            .unwrap()
+    });
+    assert_eq!(registration.oracle_stake, 200);
+    assert_eq!(registration.token, token_addr);
+}
+
+#[test]
+fn test_register_oracle_with_stake_accumulates_on_reregistration() {
+    // Adversarial: before the fix, two sequential registrations left the
+    // stored registration reporting only the *second* call's amount, even
+    // though both transfers succeeded and the contract balance reflects
+    // both. This must fail on the pre-fix implementation.
+    let (env, contract_id, .., oracle_admin, _, _, token_addr) = setup();
+    let client = OracleContractClient::new(&env, &contract_id);
+    let asset_client = StellarAssetClient::new(&env, &token_addr);
+    let balance_client = soroban_sdk::token::Client::new(&env, &token_addr);
+
+    asset_client.mint(&oracle_admin, &500);
+    client.register_oracle_with_stake(&oracle_admin, &300i128, &token_addr);
+    client.register_oracle_with_stake(&oracle_admin, &200i128, &token_addr);
+
+    // Both transfers landed in the contract.
+    assert_eq!(balance_client.balance(&contract_id), 500);
+
+    // The recorded stake is the cumulative sum, not just the second call.
+    let registration: OracleRegistration = env.as_contract(&contract_id, || {
+        env.storage()
+            .instance()
+            .get(&DataKey::OracleRegistration(oracle_admin.clone()))
+            .unwrap()
+    });
+    assert_eq!(registration.oracle_stake, 500);
+}
+
+#[test]
+fn test_slash_oracle_can_slash_cumulative_stake_after_top_up() {
+    // Post-fix: slash_oracle must be able to slash up to the *cumulative*
+    // staked amount after two top-up calls, not just the most recent one.
+    let (env, contract_id, .., oracle_admin, _, _, token_addr) = setup();
+    let client = OracleContractClient::new(&env, &contract_id);
+    let asset_client = StellarAssetClient::new(&env, &token_addr);
+    let balance_client = soroban_sdk::token::Client::new(&env, &token_addr);
+
+    asset_client.mint(&oracle_admin, &500);
+    client.register_oracle_with_stake(&oracle_admin, &300i128, &token_addr);
+    client.register_oracle_with_stake(&oracle_admin, &200i128, &token_addr);
+
+    // A slash larger than either individual top-up, but within the
+    // cumulative total, must succeed.
+    let admin_balance_before = balance_client.balance(&oracle_admin);
+    client.slash_oracle(&oracle_admin, &450i128);
+
+    assert_eq!(balance_client.balance(&contract_id), 50);
+    assert_eq!(
+        balance_client.balance(&oracle_admin),
+        admin_balance_before + 450
+    );
+
+    let registration: OracleRegistration = env.as_contract(&contract_id, || {
+        env.storage()
+            .instance()
+            .get(&DataKey::OracleRegistration(oracle_admin.clone()))
+            .unwrap()
+    });
+    assert_eq!(registration.oracle_stake, 50);
+}
+
+#[test]
+fn test_register_oracle_with_stake_rejects_mismatched_token_top_up() {
+    // A top-up in a different token than the original registration must be
+    // rejected rather than silently discarding the mismatch (stake in two
+    // different tokens cannot be meaningfully summed).
+    let (env, contract_id, .., oracle_admin, _, _, token_addr) = setup();
+    let client = OracleContractClient::new(&env, &contract_id);
+    let asset_client = StellarAssetClient::new(&env, &token_addr);
+    let balance_client = soroban_sdk::token::Client::new(&env, &token_addr);
+
+    let other_admin = Address::generate(&env);
+    let other_token_id = env.register_stellar_asset_contract_v2(other_admin.clone());
+    let other_token_addr = other_token_id.address();
+    let other_asset_client = StellarAssetClient::new(&env, &other_token_addr);
+
+    asset_client.mint(&oracle_admin, &300);
+    other_asset_client.mint(&oracle_admin, &200);
+
+    client.register_oracle_with_stake(&oracle_admin, &300i128, &token_addr);
+
+    let result = client.try_register_oracle_with_stake(&oracle_admin, &200i128, &other_token_addr);
+    assert_eq!(result, Err(Ok(Error::StakeTokenMismatch)));
+
+    // The mismatched top-up must not have moved any tokens or mutated the
+    // existing registration.
+    assert_eq!(balance_client.balance(&contract_id), 300);
+    let other_balance_client = soroban_sdk::token::Client::new(&env, &other_token_addr);
+    assert_eq!(other_balance_client.balance(&contract_id), 0);
+
+    let registration: OracleRegistration = env.as_contract(&contract_id, || {
+        env.storage()
+            .instance()
+            .get(&DataKey::OracleRegistration(oracle_admin.clone()))
+            .unwrap()
+    });
+    assert_eq!(registration.oracle_stake, 300);
+    assert_eq!(registration.token, token_addr);
+}
+
+#[test]
 fn test_submit_result_rejects_registered_oracle_without_sufficient_stake() {
     let (env, contract_id, .., oracle_admin, _, _, token_addr) = setup();
     let client = OracleContractClient::new(&env, &contract_id);

--- a/docs/error-codes.md
+++ b/docs/error-codes.md
@@ -148,7 +148,7 @@ These error codes support advanced features including dispute resolution, stakin
 
 ## Oracle Contract (`contracts/oracle/src/errors.rs`)
 
-All 21 variants are primarily recoverable — the majority represent client-side issues or rate limit exceedances, though a few indicate internal oracle stake/consensus state requiring investigation.
+All 22 variants are primarily recoverable — the majority represent client-side issues or rate limit exceedances, though a few indicate internal oracle stake/consensus state requiring investigation.
 
 | Code | Name | Thrown By | Cause | Recovery | Example |
 |------|------|-----------|-------|----------|---------|
@@ -172,6 +172,7 @@ All 21 variants are primarily recoverable — the majority represent client-side
 | 19 | `InvalidAmount` | Rate/stake functions | A stake or fee amount is invalid (typically zero or negative). | Supply a positive amount. | Calling `register_oracle_with_stake` with `stake_amount = 0` → `#19`. |
 | 20 | `Overflow` | Arithmetic operations (stake accumulation, voting tallies) | An arithmetic guard tripped: a counter or accumulated amount exceeded numeric bounds. | Not typically recoverable client-side. Indicates a contract state issue; contact admin for investigation. | After thousands of slash+re-stake cycles, the oracle's tally counters overflow → `#20` (rare, fatal). |
 | 21 | `SlippageExceeded` | Rate/swap validation | The price changed beyond acceptable slippage bounds between submission and execution. | Resubmit with a wider slippage tolerance or wait for prices to stabilize. | Submitting a swap with 0.5% max slippage when market moved 1% → `#21`. |
+| 22 | `StakeTokenMismatch` | [`register_oracle_with_stake`](../contracts/oracle/src/lib.rs) | The oracle already has a registration, and this call's `token` differs from the token backing the existing registration — stake in two different tokens cannot be summed. | Re-register (top up) using the same token as the original registration, or coordinate with the admin to migrate the stake before switching tokens. | An oracle registered with USDC, then attempts to top up its stake with EURC → `#22`; the existing USDC-denominated stake is left untouched. |
 
 ---
 

--- a/docs/oracle.md
+++ b/docs/oracle.md
@@ -83,6 +83,16 @@ Each oracle registers independently with its own key and its own stake:
 oracle_client.register_oracle_with_stake(&oracle_address, &stake_amount, &token);
 ```
 
+**Re-registration tops up, it does not overwrite.** If `oracle_address` is
+already registered, `stake_amount` is *added* to its existing `oracle_stake`
+rather than replacing it. This is the intended way for an oracle to
+replenish its bond after a partial slash (e.g. after landing on the losing
+side of a majority vote) — the operational action the m-of-n safety bound
+above assumes operators will take. `token` must match the token of the
+existing registration; a top-up call with a different token is rejected with
+`StakeTokenMismatch`, since stake denominated in two different tokens cannot
+be meaningfully summed. A first-time registration behaves exactly as before.
+
 Registering appends the address to the contract's oracle set (queryable via
 `get_registered_oracle_count`). The admin configures how many *distinct*
 registered oracles must submit a matching result before it finalizes:
@@ -904,7 +914,7 @@ Stored per oracle address via `register_oracle_with_stake`; read and mutated by 
 | Field | Type | Description |
 |---|---|---|
 | `oracle_address` | `Address` | The registered oracle's address. |
-| `oracle_stake` | `i128` | Token stake currently backing this oracle; reduced by `slash_oracle`. |
+| `oracle_stake` | `i128` | Token stake currently backing this oracle; reduced by `slash_oracle`, increased by re-registration/top-up via `register_oracle_with_stake`. |
 | `token` | `Address` | Token contract the stake was posted in. |
 
 ### `RateLimitConfig`


### PR DESCRIPTION
 ## Summary
  `register_oracle_with_stake` overwrote `OracleRegistration` on every call instead of accumulating stake, even though the token transfer executed additively on every call. Any stake
  from an earlier registration became permanently unaccounted for and unslashable, since `slash_oracle` caps `slash_amount` at the post-overwrite `oracle_stake`.

  ## Changes
  - `register_oracle_with_stake` now adds `stake_amount` to any existing `OracleRegistration.oracle_stake` instead of overwriting it.
  - Added `Error::StakeTokenMismatch` (`#22`) — a top-up with a different `token` than the existing registration is rejected instead of silently discarding the mismatch.
  - First-time registration behavior is unchanged.
  - Tests: cumulative accumulation across two top-ups, `slash_oracle` slashing the full cumulative stake post-fix, mismatched-token top-up rejection (no state/balance mutation), and a
  regression test for first-time registration.
  - Updated `docs/oracle.md` and `docs/error-codes.md` to document the top-up/accumulation behavior and the new error code.

  Closes #1283