### PR TITLE
Fix: Chess.com API key rotation and rate-limit retries

### DIFF
--- a/oracle-service/src/oracle/chess_com_client.rs
+++ b/oracle-service/src/oracle/chess_com_client.rs
@@ -4,12 +4,15 @@ use std::time::Duration;
 use contracts_oracle::types::Winner;
 use reqwest::Client;
 use serde::Deserialize;
-use tokio::sync::{OwnedSemaphorePermit, Semaphore};
+use tokio::sync::{OwnedSemaphorePermit, RwLock, Semaphore};
 
 use super::errors::ChessComError;
 use super::provider::GameProvider;
 use super::provider_error::ProviderError;
 use super::rate_limiter::{RateLimiter, RateLimiterConfig};
+
+const MAX_RETRIES: u32 = 3;
+const INITIAL_BACKOFF: Duration = Duration::from_secs(1);
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ChessComGameResult {
@@ -67,6 +70,7 @@ pub struct ChessComClient {
     api_base: String,
     rate_limiter: RateLimiter,
     semaphore: Arc<Semaphore>,
+    api_key: Arc<RwLock<Option<String>>>,
 }
 
 impl Default for ChessComClient {
@@ -93,6 +97,7 @@ impl ChessComClient {
             api_base: cfg.api_base,
             rate_limiter: RateLimiter::new(cfg.rate_limiter),
             semaphore: Arc::new(Semaphore::new(cfg.max_concurrent)),
+            api_key: Arc::new(RwLock::new(Self::load_api_key())),
         })
     }
 
@@ -110,6 +115,17 @@ impl ChessComClient {
     }
 
     /// Validate that `game_id` is a non-empty numeric string.
+
+    fn load_api_key() -> Option<String> {
+        std::env::var("CHESSDOTCOM_API_KEY")
+            .ok()
+            .filter(|key| !key.is_empty())
+    }
+
+    async fn reload_api_key(&self) {
+        *self.api_key.write().await = Self::load_api_key();
+    }
+
     pub fn validate_game_id(game_id: &str) -> Result<(), ChessComError> {
         if game_id.is_empty() || !game_id.chars().all(|c| c.is_ascii_digit()) {
             return Err(ChessComError::InvalidGameId);
@@ -140,13 +156,44 @@ impl ChessComClient {
             game_id
         );
 
-        let resp = self.http.get(&url).send().await.map_err(|e| {
-            if e.is_timeout() {
-                ChessComError::Timeout
-            } else {
-                ChessComError::Http(e)
+        let mut retry_count = 0;
+        let mut auth_retry_count = 0;
+        let resp = loop {
+            let api_key = self.api_key.read().await.clone();
+            let request = self.http.get(&url);
+            let request = match api_key {
+                Some(api_key) => request.bearer_auth(api_key),
+                None => request,
+            };
+            let resp = request.send().await.map_err(|e| {
+                if e.is_timeout() {
+                    ChessComError::Timeout
+                } else {
+                    ChessComError::Http(e)
+                }
+            })?;
+
+            if resp.status() == reqwest::StatusCode::UNAUTHORIZED && auth_retry_count == 0 {
+                auth_retry_count += 1;
+                self.reload_api_key().await;
+                continue;
             }
-        })?;
+
+            if resp.status() != reqwest::StatusCode::TOO_MANY_REQUESTS || retry_count >= MAX_RETRIES {
+                break resp;
+            }
+
+            let retry_after = resp
+                .headers()
+                .get(reqwest::header::RETRY_AFTER)
+                .and_then(|value| value.to_str().ok())
+                .and_then(|value| value.parse::<u64>().ok())
+                .map(Duration::from_secs)
+                .unwrap_or_else(|| INITIAL_BACKOFF * 2u32.pow(retry_count));
+
+            retry_count += 1;
+            tokio::time::sleep(retry_after).await;
+        };
 
         let status = resp.status();
         if status == reqwest::StatusCode::NOT_FOUND {

--- a/oracle-service/tests/chess_com_client_unit.rs
+++ b/oracle-service/tests/chess_com_client_unit.rs
@@ -1,6 +1,6 @@
 use oracle_service::oracle::{ChessComClient, ChessComError, ChessComGameResult};
 
-use wiremock::matchers::{method, path};
+use wiremock::matchers::{header, method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 #[tokio::test]
@@ -73,6 +73,75 @@ async fn fetch_result_maps_white_to_player1() {
 
     let res: ChessComGameResult = client.fetch_result("555").await.unwrap();
     assert_eq!(res.winner, contracts_oracle::types::Winner::Player1);
+}
+
+#[tokio::test]
+async fn fetch_result_retries_rate_limited_request_after_header_delay() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/pub/game/429"))
+        .respond_with(
+            ResponseTemplate::new(429)
+                .insert_header("Retry-After", "0")
+                .set_body_string("rate limited"),
+        )
+        .up_to_n_times(1)
+        .mount(&server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/pub/game/429"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "end": {"result": "draw"}
+        })))
+        .mount(&server)
+        .await;
+
+    let client = ChessComClient::new_with_base_and_timeout(
+        server.uri(),
+        std::time::Duration::from_secs(30),
+    )
+    .unwrap();
+
+    let result = client.fetch_result("429").await.unwrap();
+
+    assert_eq!(result.winner, contracts_oracle::types::Winner::Draw);
+}
+
+#[tokio::test]
+async fn fetch_result_reloads_rotated_api_key_after_unauthorized() {
+    let server = MockServer::start().await;
+    std::env::set_var("CHESSDOTCOM_API_KEY", "old-key");
+
+    Mock::given(method("GET"))
+        .and(path("/pub/game/401"))
+        .and(header("authorization", "Bearer old-key"))
+        .respond_with(ResponseTemplate::new(401))
+        .up_to_n_times(1)
+        .mount(&server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/pub/game/401"))
+        .and(header("authorization", "Bearer new-key"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "end": {"result": "white"}
+        })))
+        .mount(&server)
+        .await;
+
+    let client = ChessComClient::new_with_base_and_timeout(
+        server.uri(),
+        std::time::Duration::from_secs(30),
+    )
+    .unwrap();
+    std::env::set_var("CHESSDOTCOM_API_KEY", "new-key");
+
+    let result = client.fetch_result("401").await.unwrap();
+
+    std::env::remove_var("CHESSDOTCOM_API_KEY");
+    assert_eq!(result.winner, contracts_oracle::types::Winner::Player1);
 }
 
 #[tokio::test]

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -2,5 +2,5 @@
 set -euo pipefail
 
 echo "Building contracts..."
-cargo build --target wasm32-unknown-unknown --release
+cargo build -p escrow -p oracle --target wasm32-unknown-unknown --release
 echo "Build complete."

--- a/services/event-indexer/Cargo.toml
+++ b/services/event-indexer/Cargo.toml
@@ -18,7 +18,8 @@ serde_json = "1"
 reqwest = { version = "0.12", features = ["json", "rustls-tls"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "time", "sync"] }
 axum = "0.7"
-tower = "0.4"
+tower = { version = "0.4", features = ["util"] }
+tower-http = { version = "0.5", features = ["trace", "cors"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 chrono = { version = "0.4", features = ["serde"] }


### PR DESCRIPTION
## Summary

- Add hot reload support for `CHESSDOTCOM_API_KEY`
- Retry once with the reloaded key after HTTP 401 responses
- Honor `Retry-After` when retrying HTTP 429 responses
- Add tests for API-key rotation and rate-limit recovery
- Fix workspace test/build CLI blockers

## Validation

- `./scripts/test.sh`
- `./scripts/build.sh`
- `git diff --check`

All tests and the contract release build pass successfully.
closes #1346 
closes #1347