### PR TITLE
Martinzhamez/fix 4 issues

### DIFF
--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -751,6 +751,8 @@ impl EscrowContract {
     /// `tiers` must be ordered by `max_stake` ascending.  The last entry acts
     /// as the open-ended catch-all (set `max_stake = i128::MAX`).  Pass an
     /// empty `Vec` to clear the schedule and fall back to zero protocol fees.
+    /// Each tier's `fee_basis_points` must be in the range `0..=10_000`
+    /// (0% to 100%).
     pub fn set_fee_tiers(env: Env, tiers: soroban_sdk::Vec<FeeTier>) -> Result<(), Error> {
         extend_instance_ttl(&env);
         let admin: Address = env
@@ -765,6 +767,9 @@ impl EscrowContract {
         let mut prev_max: i128 = -1;
         for tier in tiers.iter() {
             if tier.max_stake <= prev_max {
+                return Err(Error::InvalidAmount);
+            }
+            if tier.fee_basis_points > 10_000 {
                 return Err(Error::InvalidAmount);
             }
             prev_max = tier.max_stake;

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -2522,6 +2522,14 @@ impl EscrowContract {
             (match_id, resolution),
         );
 
+        // Also publish a match/cancelled event so the event-indexer picks up
+        // the terminal state transition out of Active (it only listens for
+        // the standard lifecycle events, not "adm_stall").
+        env.events().publish(
+            (Symbol::new(&env, "match"), symbol_short!("cancelled")),
+            match_id,
+        );
+
         Ok(())
     }
 

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -2984,6 +2984,22 @@ impl EscrowContract {
         Ok(Self::escrow_balance_of(&m))
     }
 
+    /// Return `true` only if funds are currently held in escrow for this
+    /// match, i.e. it is funded AND not yet Completed or Cancelled.
+    ///
+    /// Unlike [`Self::is_funded`], this reflects the *current* balance state
+    /// rather than historical deposit flags.
+    pub fn is_currently_escrowed(env: Env, match_id: u64) -> Result<bool, Error> {
+        let m: Match = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Match(match_id))
+            .ok_or(Error::MatchNotFound)?;
+        let funded = m.player1_deposited && m.player2_deposited;
+        let terminal = matches!(m.state, MatchState::Completed | MatchState::Cancelled);
+        Ok(funded && !terminal)
+    }
+
     fn depositor_count(m: &Match) -> i128 {
         let mut count: i128 = 0;
         if m.player1_deposited {

--- a/contracts/escrow/src/tests/admin_stall_resolution.rs
+++ b/contracts/escrow/src/tests/admin_stall_resolution.rs
@@ -510,3 +510,45 @@ fn test_admin_resolve_stalled_match_match_not_found() {
     let result = client.try_admin_resolve_stalled_match(&999, &admin, &Winner::Draw);
     assert_eq!(result, Err(Ok(Error::MatchNotFound)));
 }
+
+#[test]
+fn test_admin_resolve_stalled_match_emits_cancelled_event() {
+    let (env, contract_id, _oracle, player1, player2, token, admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let id = client.create_match(
+        &player1,
+        &player2,
+        &100,
+        &token,
+        &String::from_str(&env, "m9n8o7p6"),
+        &Platform::Lichess,
+    );
+    client.deposit(&id, &player1);
+    client.deposit(&id, &player2);
+
+    advance_timestamp(&env, ADMIN_STALL_WINDOW_SECONDS + 1);
+
+    client.admin_resolve_stalled_match(&id, &admin, &Winner::Draw);
+
+    // The event-indexer watches for the standard "match/cancelled" topic to
+    // detect that a match has left the Active state; admin_resolve_stalled_match
+    // must publish it alongside its own "match/adm_stall" event.
+    let events = env.events().all();
+    let expected_topics = soroban_sdk::vec![
+        &env,
+        Symbol::new(&env, "match").into_val(&env),
+        symbol_short!("cancelled").into_val(&env),
+    ];
+    let matched = events
+        .iter()
+        .find(|(_, topics, _)| *topics == expected_topics);
+    assert!(
+        matched.is_some(),
+        "admin_resolve_stalled_match must emit a match/cancelled event"
+    );
+
+    let (_, _, data) = matched.unwrap();
+    let ev_match_id: u64 = TryFromVal::try_from_val(&env, &data).unwrap();
+    assert_eq!(ev_match_id, id);
+}

--- a/contracts/escrow/src/tests/fee_tiers.rs
+++ b/contracts/escrow/src/tests/fee_tiers.rs
@@ -85,6 +85,26 @@ fn test_set_fee_tiers_rejects_duplicate_max_stake() {
 }
 
 #[test]
+fn test_set_fee_tiers_rejects_fee_basis_points_over_10000() {
+    let (env, contract_id, _oracle, _p1, _p2, _token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    // 10_001 bps (> 100%) must be rejected — a tier fee can never exceed
+    // the total pot.
+    let t = tiers_vec(&env, &[(i128::MAX, 10_001)]);
+    let result = client.try_set_fee_tiers(&t);
+    assert_eq!(
+        result,
+        Err(Ok(Error::InvalidAmount)),
+        "fee_basis_points > 10_000 must be rejected"
+    );
+
+    // Exactly 10_000 bps (100%) is the allowed boundary.
+    let t_ok = tiers_vec(&env, &[(i128::MAX, 10_000)]);
+    assert!(client.try_set_fee_tiers(&t_ok).is_ok());
+}
+
+#[test]
 fn test_set_fee_tiers_empty_clears_schedule() {
     let (env, contract_id, _oracle, _p1, _p2, _token, _admin) = setup();
     let client = EscrowContractClient::new(&env, &contract_id);

--- a/contracts/escrow/src/tests/lifecycle.rs
+++ b/contracts/escrow/src/tests/lifecycle.rs
@@ -1938,6 +1938,36 @@ fn test_is_funded_returns_true_after_payout() {
 }
 
 #[test]
+fn test_is_currently_escrowed_false_for_completed_match() {
+    let (env, contract_id, oracle, player1, player2, token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let id = client.create_match(
+        &player1,
+        &player2,
+        &100,
+        &token,
+        &String::from_str(&env, "e5f6a7b8"),
+        &Platform::Lichess,
+    );
+
+    client.deposit(&id, &player1);
+    client.deposit(&id, &player2);
+    assert!(client.is_currently_escrowed(&id));
+
+    client.submit_result(&id, &Winner::Player1, &oracle);
+    assert_eq!(client.get_match(&id).state, MatchState::Completed);
+
+    // is_funded stays true (historical deposit flags), but
+    // is_currently_escrowed reflects that funds are no longer held.
+    assert!(client.is_funded(&id));
+    assert!(
+        !client.is_currently_escrowed(&id),
+        "is_currently_escrowed must be false once a match is Completed"
+    );
+}
+
+#[test]
 fn test_get_escrow_balance_zero_for_completed_match() {
     let (env, contract_id, oracle, player1, player2, token, _admin) = setup();
     let client = EscrowContractClient::new(&env, &contract_id);

--- a/contracts/escrow/src/tests/oracle_validation.rs
+++ b/contracts/escrow/src/tests/oracle_validation.rs
@@ -207,6 +207,34 @@ fn test_get_oracle_address_uninitialized_contract() {
 }
 
 #[test]
+fn test_update_oracle_rejects_self_address() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let oracle = Address::generate(&env);
+
+    let contract_id = env.register_contract(None, EscrowContract);
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    client.initialize(&oracle, &admin);
+
+    // The oracle must never be set to the contract's own address, since
+    // `require_auth` on a contract address without a custom account
+    // implementation can never succeed, permanently bricking result
+    // submission.
+    let result = client.try_update_oracle(&contract_id);
+    assert_eq!(
+        result,
+        Err(Ok(Error::InvalidAddress)),
+        "update_oracle must reject the contract's own address"
+    );
+
+    // Oracle must remain unchanged.
+    assert_eq!(client.get_oracle_address(), oracle);
+}
+
+#[test]
 fn test_submit_result_rejects_non_oracle() {
     let (env, contract_id, _oracle, _player1, _player2, _token, _admin, match_id) =
         setup_with_funded_match();


### PR DESCRIPTION
closes #1314
closes #1316
closes #1315  
closes #1317

Description:
set_fee_tiers validates that max_stake values are ordered but does not check that fee_basis_points on each tier is <= 10_000 (100%). A tier with > 10_000 bps would result in fee amounts exceeding the total pot.

Tasks:

Add if tier.fee_basis_points > 10_000 { return Err(Error::InvalidAmount); } per-tier validation
Add test for fee tier with 10_001 bps
Update doc comment on set_fee_tiers with the valid range


As documented, is_funded returns true for Completed matches because it checks deposit flags, not the current balance. However, this behavior can confuse callers who assume is_funded == true means the escrow still holds funds.
