### PR TITLE
Fix/josunday002 four issues

### DIFF
--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -4304,8 +4304,10 @@ impl EscrowContract {
             .unwrap_or(0);
 
         let mut collected = 0u32;
+        let mut truncated = false;
         for match_id in 0..count {
             if collected >= MAX_UNBOUNDED_MATCH_RESULTS {
+                truncated = true;
                 break;
             }
             if let Some(m) = env
@@ -4318,6 +4320,15 @@ impl EscrowContract {
                     collected = collected.saturating_add(1);
                 }
             }
+        }
+
+        if truncated {
+            // Silent data loss otherwise: callers of the deprecated unbounded
+            // getters have no other signal that results were capped.
+            env.events().publish(
+                (Symbol::new(env, "match"), symbol_short!("truncated")),
+                (state, MAX_UNBOUNDED_MATCH_RESULTS),
+            );
         }
 
         Ok(matches)

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -233,6 +233,14 @@ impl EscrowContract {
         if caller != admin {
             return Err(Error::Unauthorized);
         }
+        let already_paused: bool = env
+            .storage()
+            .instance()
+            .get(&DataKey::Paused)
+            .unwrap_or(false);
+        if already_paused {
+            return Err(Error::InvalidPauseState);
+        }
         env.storage().instance().set(&DataKey::Paused, &true);
         env.events()
             .publish((Symbol::new(&env, "admin"), symbol_short!("paused")), ());
@@ -250,6 +258,14 @@ impl EscrowContract {
             .ok_or(Error::Unauthorized)?;
         if caller != admin {
             return Err(Error::Unauthorized);
+        }
+        let already_paused: bool = env
+            .storage()
+            .instance()
+            .get(&DataKey::Paused)
+            .unwrap_or(false);
+        if !already_paused {
+            return Err(Error::InvalidPauseState);
         }
         env.storage().instance().set(&DataKey::Paused, &false);
         env.events()

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -1832,7 +1832,26 @@ impl EscrowContract {
 
         let mut outcomes = Vec::new(&env);
         for (match_id, winner) in results.iter() {
-            let outcome = Self::settle_result(&env, match_id, winner);
+            // A match already settled (Completed/PendingResult) in a prior
+            // call means this oracle is re-confirming a result it already
+            // submitted. Surface that explicitly instead of letting it fall
+            // through to the generic InvalidState from settle_result.
+            let already_settled = env
+                .storage()
+                .persistent()
+                .get::<DataKey, Match>(&DataKey::Match(match_id))
+                .is_some_and(|m| {
+                    matches!(
+                        m.state,
+                        MatchState::Completed | MatchState::PendingResult
+                    )
+                });
+
+            let outcome = if already_settled {
+                Err(Error::OracleAlreadyConfirmed)
+            } else {
+                Self::settle_result(&env, match_id, winner)
+            };
             outcomes.push_back(outcome.err());
         }
         Ok(outcomes)

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -2668,7 +2668,9 @@ impl EscrowContract {
     /// (which compares against ledger-sequence deltas).
     fn current_match_timeout(env: &Env) -> u32 {
         let seconds = Self::get_config(env).match_timeout_seconds;
-        (seconds / SECONDS_PER_LEDGER) as u32
+        // Ceiling division: floor division here would underestimate the
+        // ledger delta required, allowing the timeout to trigger early.
+        ((seconds + SECONDS_PER_LEDGER - 1) / SECONDS_PER_LEDGER) as u32
     }
 
     /// Get the cached count of completed matches for a player (O(1) lookup).

--- a/contracts/escrow/src/tests/admin.rs
+++ b/contracts/escrow/src/tests/admin.rs
@@ -495,6 +495,27 @@ fn test_is_paused_cycle() {
     assert!(!client.is_paused());
 }
 
+// Guard against redundant pause/unpause calls writing duplicate state and
+// emitting duplicate events.
+#[test]
+fn test_pause_when_already_paused_returns_invalid_pause_state() {
+    let (env, contract_id, _oracle, _player1, _player2, _token, admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    client.pause(&admin);
+    let result = client.try_pause(&admin);
+    assert_eq!(result, Err(Ok(Error::InvalidPauseState)));
+}
+
+#[test]
+fn test_unpause_when_not_paused_returns_invalid_pause_state() {
+    let (env, contract_id, _oracle, _player1, _player2, _token, admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let result = client.try_unpause(&admin);
+    assert_eq!(result, Err(Ok(Error::InvalidPauseState)));
+}
+
 // #593 - propose_admin stores the pending admin and emits an event
 #[test]
 fn test_propose_admin_stores_pending_admin_and_emits_event() {

--- a/contracts/escrow/src/tests/batch_submit.rs
+++ b/contracts/escrow/src/tests/batch_submit.rs
@@ -97,6 +97,44 @@ fn test_submit_result_batch_partial_failure() {
 }
 
 #[test]
+fn test_submit_result_batch_already_confirmed_match() {
+    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let match_a = client.create_match(
+        &player1,
+        &player2,
+        &100,
+        &token,
+        &String::from_str(&env, "a1b2c3d4"),
+        &Platform::Lichess,
+    );
+    client.deposit(&match_a, &player1);
+    client.deposit(&match_a, &player2);
+
+    let oracle = client.get_oracle();
+
+    // First submission settles the match.
+    let first = client.submit_result_batch(
+        &soroban_sdk::vec![&env, (match_a, Winner::Player1)],
+        &oracle,
+    );
+    assert_eq!(first.get(0).unwrap(), None);
+    assert_eq!(client.get_match(&match_a).state, MatchState::Completed);
+
+    // Re-submitting a result for the same (already-settled) match must be
+    // reported as OracleAlreadyConfirmed rather than a generic InvalidState.
+    let second = client.submit_result_batch(
+        &soroban_sdk::vec![&env, (match_a, Winner::Player1)],
+        &oracle,
+    );
+    assert_eq!(
+        second.get(0).unwrap(),
+        Some(Error::OracleAlreadyConfirmed)
+    );
+}
+
+#[test]
 fn test_submit_result_batch_empty() {
     let (env, contract_id, _oracle, ..) = setup();
     let client = EscrowContractClient::new(&env, &contract_id);

--- a/contracts/escrow/src/tests/lifecycle.rs
+++ b/contracts/escrow/src/tests/lifecycle.rs
@@ -2495,6 +2495,53 @@ fn test_expire_match_before_and_after_timeout() {
     );
 }
 
+/// Regression test for the ledger-conversion off-by-one: `match_timeout_seconds`
+/// that does not divide evenly by `SECONDS_PER_LEDGER` (5) must round the
+/// ledger timeout UP, not down, or `expire_match` becomes callable one ledger
+/// too early.
+#[test]
+fn test_expire_match_timeout_ceiling_division_boundary() {
+    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    // 86_403 seconds / 5 = 17_280.6 -> floor = 17_280 ledgers, ceil = 17_281.
+    client.set_match_timeout(&(MIN_MATCH_TIMEOUT_SECONDS + 3));
+    env.ledger().set_sequence_number(100);
+
+    let id = client.create_match(
+        &player1,
+        &player2,
+        &100,
+        &token,
+        &String::from_str(&env, "e1c204ab"),
+        &Platform::Lichess,
+    );
+    client.deposit(&id, &player1);
+
+    env.deployer().extend_ttl_for_contract_instance(
+        contract_id.clone(),
+        MATCH_TTL_LEDGERS,
+        MATCH_TTL_LEDGERS,
+    );
+    env.deployer()
+        .extend_ttl_for_code(contract_id.clone(), MATCH_TTL_LEDGERS, MATCH_TTL_LEDGERS);
+
+    // At the floor boundary (17_280 ledgers elapsed) the match must NOT be
+    // expired yet — this is exactly the case the old floor-division bug got wrong.
+    env.ledger().set_sequence_number(100 + 17_280);
+    let floor_boundary_result = client.try_expire_match(&id);
+    assert_eq!(
+        floor_boundary_result,
+        Err(Ok(Error::MatchNotExpired)),
+        "expire_match must not succeed at the floor-division boundary"
+    );
+
+    // One ledger later (the true ceiling boundary), it must succeed.
+    env.ledger().set_sequence_number(100 + 17_281);
+    client.expire_match(&id);
+    assert_eq!(client.get_match(&id).state, MatchState::Cancelled);
+}
+
 // #1176 — cancel_match must be rejected once both players have deposited (Active state)
 #[test]
 fn test_cancel_match_rejects_when_active() {

--- a/contracts/escrow/src/tests/pagination.rs
+++ b/contracts/escrow/src/tests/pagination.rs
@@ -88,6 +88,66 @@ fn test_player_match_pagination_zero_limit_and_offset_beyond_end() {
     assert_eq!(partial_page.get(1).unwrap(), match_ids[9]);
 }
 
+/// Regression test: the deprecated unbounded `get_pending_matches()` must cap
+/// its result at `MAX_UNBOUNDED_MATCH_RESULTS` and emit a truncation event so
+/// callers have a signal that results were silently capped, instead of
+/// looking like a complete result set.
+#[test]
+fn test_get_pending_matches_emits_truncation_event_when_capped() {
+    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    // Seed one real match to get a well-formed template, then clone it
+    // directly into storage well past the cap — far cheaper than driving
+    // `create_match` MAX_UNBOUNDED_MATCH_RESULTS+ times.
+    let template_id = client.create_match(
+        &player1,
+        &player2,
+        &100,
+        &token,
+        &String::from_str(&env, "5f6a7b8c"),
+        &Platform::Lichess,
+    );
+
+    let total: u64 = 10_005;
+    env.as_contract(&contract_id, || {
+        let template: Match = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Match(template_id))
+            .unwrap();
+
+        for id in 0..total {
+            let mut m = template.clone();
+            m.id = id;
+            m.state = MatchState::Pending;
+            env.storage().persistent().set(&DataKey::Match(id), &m);
+        }
+        env.storage().instance().set(&DataKey::MatchCount, &total);
+    });
+
+    let results = client.get_pending_matches();
+    assert_eq!(
+        results.len(),
+        10_000,
+        "unbounded getter must cap at MAX_UNBOUNDED_MATCH_RESULTS"
+    );
+
+    let events = env.events().all();
+    let expected_topics = vec![
+        &env,
+        Symbol::new(&env, "match").into_val(&env),
+        symbol_short!("truncated").into_val(&env),
+    ];
+    let matched = events
+        .iter()
+        .find(|(_, topics, _)| *topics == expected_topics);
+    assert!(
+        matched.is_some(),
+        "truncation must emit a match/truncated event"
+    );
+}
+
 /// Test #579: player history index excludes unrelated matches for other players
 #[test]
 fn test_player_history_index_excludes_unrelated_matches() {


### PR DESCRIPTION
closes #1318
closes #1319 
closes #1320 
closes #1321 
Description:
pause can be called when the contract is already paused, and unpause when it is not paused, writing the same value to storage and emitting duplicate events. This wastes gas and pollutes the event log.

Tasks:

Add state guard in pause: if already paused, return Err(Error::InvalidPauseState)
Add state guard in unpause: if not paused, return Err(Error::InvalidPauseState)
Update tests that may call pause/unpause without checking preconditions


The deprecated get_pending_matches() and get_active_matches() functions silently truncate to MAX_UNBOUNDED_MATCH_RESULTS (10,000) with no indication to callers that results were truncated. This can cause silent data loss for operators.