### PR TITLE
Fix double-deposit, batch NotFunded reporting, and expire_match blacklist bypass

### DIFF
--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -1633,12 +1633,17 @@ impl EscrowContract {
             .get(&DataKey::Match(match_id))
             .ok_or(Error::MatchNotFound)?;
 
-        if m.state != MatchState::Active {
-            return Err(Error::InvalidState);
+        // A still-Pending match is inherently not (fully) funded — surface
+        // `NotFunded` for it specifically, rather than the generic
+        // `InvalidState`, so `submit_result_batch` callers can distinguish
+        // "needs more deposits" from other invalid transitions (Completed,
+        // Cancelled, PendingResult, Paused).
+        if m.state == MatchState::Pending || !m.player1_deposited || !m.player2_deposited {
+            return Err(Error::NotFunded);
         }
 
-        if !m.player1_deposited || !m.player2_deposited {
-            return Err(Error::NotFunded);
+        if m.state != MatchState::Active {
+            return Err(Error::InvalidState);
         }
 
         Self::remove_active_match_indexed(env, &m.player1, match_id);

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -2095,6 +2095,19 @@ impl EscrowContract {
 
         let is_multi_token = m.token_b.is_some() && m.conversion_rate.is_some_and(|r| r > 0);
 
+        // The match's token(s) may have been blacklisted after creation but
+        // before expiry. Refuse to attempt a refund transfer into a token
+        // contract that's since been flagged as broken or malicious — that
+        // could fail unpredictably or panic instead of cleanly erroring, and
+        // leaves the match state untouched so it can be resolved another way
+        // (e.g. admin intervention) rather than getting stuck mid-transfer.
+        let token_b_for_check = m.token_b.clone().unwrap_or_else(|| m.token.clone());
+        if Self::is_token_blacklisted(env.clone(), m.token.clone())
+            || (is_multi_token && Self::is_token_blacklisted(env.clone(), token_b_for_check))
+        {
+            return Err(Error::TokenNotAllowed);
+        }
+
         if m.player1_deposited {
             let client_a = token::Client::new(&env, &m.token);
             client_a.transfer(&env.current_contract_address(), &m.player1, &m.stake_amount);

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -1471,6 +1471,18 @@ impl EscrowContract {
             .get(&DataKey::Match(match_id))
             .ok_or(Error::MatchNotFound)?;
 
+        // Explicit "already fully funded" guard, independent of `state`: even
+        // if some future code path left `state` as `Pending` while both
+        // deposits had already landed, this still closes the door on a
+        // double-count. Checked before the state check so the caller gets
+        // the more specific `AlreadyFunded` instead of `InvalidState`.
+        if m.player1_deposited && m.player2_deposited {
+            env.storage()
+                .temporary()
+                .remove(&DataKey::DepositInProgress(match_id));
+            return Err(Error::AlreadyFunded);
+        }
+
         if m.state != MatchState::Pending {
             // Clear guard before returning on error.
             env.storage()

--- a/contracts/escrow/src/tests/batch_submit.rs
+++ b/contracts/escrow/src/tests/batch_submit.rs
@@ -62,7 +62,7 @@ fn test_submit_result_batch_partial_failure() {
     client.deposit(&match_a, &player2);
 
     // match_b only has one deposit, so it's still Pending — submit_result
-    // will fail with InvalidState (not yet Active).
+    // fails with NotFunded (not yet fully funded).
     let match_b = client.create_match(
         &player1,
         &player2,
@@ -88,12 +88,72 @@ fn test_submit_result_batch_partial_failure() {
 
     assert_eq!(outcomes.len(), 3);
     assert_eq!(outcomes.get(0).unwrap(), None);
-    assert_eq!(outcomes.get(1).unwrap(), Some(Error::InvalidState));
+    assert_eq!(outcomes.get(1).unwrap(), Some(Error::NotFunded));
     assert_eq!(outcomes.get(2).unwrap(), Some(Error::MatchNotFound));
 
     // The successful match settled, and the failing matches were left untouched.
     assert_eq!(client.get_match(&match_a).state, MatchState::Completed);
     assert_eq!(client.get_match(&match_b).state, MatchState::Pending);
+}
+
+// #1308 — NotFunded must be reported per-entry for every unfunded match in a
+// batch, not just skipped or mislabeled as InvalidState.
+#[test]
+fn test_submit_result_batch_mixed_funded_and_unfunded_reports_not_funded() {
+    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    // Fully funded — should settle successfully.
+    let funded = client.create_match(
+        &player1,
+        &player2,
+        &100,
+        &token,
+        &String::from_str(&env, "batch_funded1"),
+        &Platform::Lichess,
+    );
+    client.deposit(&funded, &player1);
+    client.deposit(&funded, &player2);
+
+    // No deposits at all — still Pending.
+    let unfunded_none = client.create_match(
+        &player1,
+        &player2,
+        &100,
+        &token,
+        &String::from_str(&env, "batch_unfunded_none"),
+        &Platform::Lichess,
+    );
+
+    // Only one side deposited — still Pending.
+    let unfunded_partial = client.create_match(
+        &player1,
+        &player2,
+        &100,
+        &token,
+        &String::from_str(&env, "batch_unfunded_partial"),
+        &Platform::Lichess,
+    );
+    client.deposit(&unfunded_partial, &player1);
+
+    let oracle = client.get_oracle();
+    let batch = soroban_sdk::vec![
+        &env,
+        (funded, Winner::Player1),
+        (unfunded_none, Winner::Player1),
+        (unfunded_partial, Winner::Player2),
+    ];
+
+    let outcomes = client.submit_result_batch(&batch, &oracle);
+
+    assert_eq!(outcomes.len(), 3);
+    assert_eq!(outcomes.get(0).unwrap(), None);
+    assert_eq!(outcomes.get(1).unwrap(), Some(Error::NotFunded));
+    assert_eq!(outcomes.get(2).unwrap(), Some(Error::NotFunded));
+
+    assert_eq!(client.get_match(&funded).state, MatchState::Completed);
+    assert_eq!(client.get_match(&unfunded_none).state, MatchState::Pending);
+    assert_eq!(client.get_match(&unfunded_partial).state, MatchState::Pending);
 }
 
 #[test]

--- a/contracts/escrow/src/tests/invariants.rs
+++ b/contracts/escrow/src/tests/invariants.rs
@@ -351,6 +351,47 @@ fn test_escrow_balance_is_zero_in_all_terminal_states() {
     );
 }
 
+// #1309 — get_escrow_balance must not report a stale non-zero value after
+// cancel_match refunds a partially-funded match (only one player deposited).
+#[test]
+fn test_escrow_balance_is_zero_after_cancel_for_every_deposit_state() {
+    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    // No deposits at all.
+    let no_deposit_id = client.create_match(
+        &player1,
+        &player2,
+        &100,
+        &token,
+        &String::from_str(&env, "cancel_bal_none"),
+        &Platform::Lichess,
+    );
+    client.cancel_match(&no_deposit_id, &player1);
+    assert_eq!(
+        client.get_escrow_balance(&no_deposit_id),
+        0,
+        "escrow balance must be 0 after cancelling a match with no deposits"
+    );
+
+    // Single (partial) deposit — the scenario the issue calls out explicitly.
+    let partial_deposit_id = client.create_match(
+        &player1,
+        &player2,
+        &100,
+        &token,
+        &String::from_str(&env, "cancel_bal_partial"),
+        &Platform::Lichess,
+    );
+    client.deposit(&partial_deposit_id, &player1);
+    client.cancel_match(&partial_deposit_id, &player1);
+    assert_eq!(
+        client.get_escrow_balance(&partial_deposit_id),
+        0,
+        "escrow balance must be 0 after cancelling a partially-funded match"
+    );
+}
+
 #[test]
 fn test_snapshot_count_monotonic() {
     let (env, contract_id, oracle, player1, player2, token, _admin) = setup();

--- a/contracts/escrow/src/tests/lifecycle.rs
+++ b/contracts/escrow/src/tests/lifecycle.rs
@@ -1568,6 +1568,61 @@ fn test_expire_match_refunds_depositor_after_timeout() {
     assert_eq!(p1_balance_after - p1_balance_before, 100);
 }
 
+// #1307 — expire_match must not attempt a refund transfer into a token
+// that's been blacklisted since the match was created; it should fail
+// cleanly with TokenNotAllowed instead of calling into the (potentially
+// broken/malicious) token contract.
+#[test]
+fn test_expire_match_with_delisted_token_returns_token_not_allowed() {
+    let (env, contract_id, _oracle, player1, player2, token, admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    client.set_match_timeout(&MIN_MATCH_TIMEOUT_SECONDS);
+    env.ledger().set_sequence_number(100);
+
+    let id = client.create_match(
+        &player1,
+        &player2,
+        &100,
+        &token,
+        &String::from_str(&env, "expire_delisted"),
+        &Platform::Lichess,
+    );
+
+    client.deposit(&id, &player1);
+    let p1_balance_before = token::Client::new(&env, &token).balance(&player1);
+
+    // Token gets blacklisted mid-flight, after the deposit was already made.
+    let _ = admin;
+    client.add_token_to_blacklist(&token, &String::from_str(&env, "compromised"));
+
+    env.deployer().extend_ttl_for_contract_instance(
+        contract_id.clone(),
+        MATCH_TTL_LEDGERS,
+        MATCH_TTL_LEDGERS,
+    );
+    env.deployer()
+        .extend_ttl_for_code(contract_id.clone(), MATCH_TTL_LEDGERS, MATCH_TTL_LEDGERS);
+    env.deployer().extend_ttl_for_contract_instance(
+        token.clone(),
+        MATCH_TTL_LEDGERS,
+        MATCH_TTL_LEDGERS,
+    );
+    env.deployer()
+        .extend_ttl_for_code(token.clone(), MATCH_TTL_LEDGERS, MATCH_TTL_LEDGERS);
+
+    env.ledger().set_sequence_number(100 + 17_280);
+
+    let result = client.try_expire_match(&id);
+    assert_eq!(result, Err(Ok(Error::TokenNotAllowed)));
+
+    // No refund happened, and the match is untouched (still Pending) so it
+    // can be resolved another way (e.g. admin intervention).
+    let p1_balance_after = token::Client::new(&env, &token).balance(&player1);
+    assert_eq!(p1_balance_after, p1_balance_before);
+    assert_eq!(client.get_match(&id).state, MatchState::Pending);
+}
+
 #[test]
 fn test_expire_match_fails_before_timeout() {
     let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();

--- a/contracts/escrow/src/tests/lifecycle.rs
+++ b/contracts/escrow/src/tests/lifecycle.rs
@@ -1574,7 +1574,7 @@ fn test_expire_match_refunds_depositor_after_timeout() {
 // broken/malicious) token contract.
 #[test]
 fn test_expire_match_with_delisted_token_returns_token_not_allowed() {
-    let (env, contract_id, _oracle, player1, player2, token, admin) = setup();
+    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
     let client = EscrowContractClient::new(&env, &contract_id);
 
     client.set_match_timeout(&MIN_MATCH_TIMEOUT_SECONDS);
@@ -1593,7 +1593,6 @@ fn test_expire_match_with_delisted_token_returns_token_not_allowed() {
     let p1_balance_before = token::Client::new(&env, &token).balance(&player1);
 
     // Token gets blacklisted mid-flight, after the deposit was already made.
-    let _ = admin;
     client.add_token_to_blacklist(&token, &String::from_str(&env, "compromised"));
 
     env.deployer().extend_ttl_for_contract_instance(

--- a/contracts/escrow/src/tests/lifecycle.rs
+++ b/contracts/escrow/src/tests/lifecycle.rs
@@ -2372,6 +2372,37 @@ fn test_double_deposit_rejected() {
     assert_eq!(result, Err(Ok(Error::AlreadyFunded)));
 }
 
+// #1306 — deposit must reject re-deposit attempts once a match is already
+// fully funded (both players deposited, match Active), for either player,
+// with the specific `AlreadyFunded` error rather than a generic one.
+#[test]
+fn test_redeposit_on_fully_funded_active_match_rejected() {
+    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let match_id = client.create_match(
+        &player1,
+        &player2,
+        &100,
+        &token,
+        &String::from_str(&env, "redeposit_active"),
+        &Platform::Lichess,
+    );
+
+    client.deposit(&match_id, &player1);
+    client.deposit(&match_id, &player2);
+    assert_eq!(client.get_match(&match_id).state, MatchState::Active);
+
+    let result_p1 = client.try_deposit(&match_id, &player1);
+    assert_eq!(result_p1, Err(Ok(Error::AlreadyFunded)));
+
+    let result_p2 = client.try_deposit(&match_id, &player2);
+    assert_eq!(result_p2, Err(Ok(Error::AlreadyFunded)));
+
+    // No double-counting: escrow still holds exactly one stake per player.
+    assert_eq!(client.get_escrow_balance(&match_id), 200);
+}
+
 // ── Issue #900: combined before/after timeout test ───────────────────────────
 
 /// Verifies that `expire_match` fails before the timeout elapses and succeeds


### PR DESCRIPTION
## Summary

- **#1306** — `deposit()` now explicitly rejects a re-deposit once a match is already fully funded (`player1_deposited && player2_deposited`) with `Error::AlreadyFunded`, checked ahead of the state check so the caller gets the specific error rather than a generic `InvalidState`.
- **#1308** — `settle_result()` (shared by `submit_result` and `submit_result_batch`) checked `state != Active` before checking the deposit flags, so a still-`Pending` match returned `InvalidState` instead of `NotFunded` — an existing test even asserted this as expected behavior. Reordered the checks so an unfunded match always reports `NotFunded` per-entry in the batch output.
- **#1307** — `expire_match()` called `token::Client::transfer()` unconditionally, with no check for a token that's been blacklisted after the match was created. Added the same `is_token_blacklisted()` guard already used at `create_match` time, returning `TokenNotAllowed` and leaving the match untouched instead of risking an unpredictable failure/panic on refund.
- **#1309** — Investigated and confirmed `get_escrow_balance()` already returns 0 correctly after `cancel_match`, since `escrow_balance_of()` zeroes the result once `state` is `Completed`/`Cancelled` regardless of the (stale) per-player deposit flags. No production code change was needed; added the regression test the issue asked for to lock this in.

## Fixes
- Closes #1306
- Closes #1308
- Closes #1307
- Closes #1309

## Test plan
- [ ] `cargo test -p escrow` (not run in this environment — please verify in CI)
- Added/updated unit tests for each issue: `test_redeposit_on_fully_funded_active_match_rejected`, `test_submit_result_batch_mixed_funded_and_unfunded_reports_not_funded` (plus corrected `test_submit_result_batch_partial_failure`), `test_expire_match_with_delisted_token_returns_token_not_allowed`, `test_escrow_balance_is_zero_after_cancel_for_every_deposit_state`