### PR TITLE
fix(escrow): floor dispute bond to minimum of 1 stroop

### DIFF
--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -3241,7 +3241,11 @@ impl EscrowContract {
             return Err(Error::DisputeAlreadyRaised);
         }
 
-        // Calculate and collect dispute bond
+        // Calculate and collect dispute bond. The bond is floored to a minimum
+        // of 1 stroop so that tiny stakes (e.g. 1 stroop at the default 100 bps)
+        // cannot round down to a zero-cost dispute, which would let an attacker
+        // spam the dispute system for free. Small matches stay disputable, they
+        // just pay the 1-stroop minimum.
         let bond_basis_points: u32 = env
             .storage()
             .instance()
@@ -3253,8 +3257,10 @@ impl EscrowContract {
             .checked_mul(bond_basis_points as i128)
             .ok_or(Error::Overflow)?
             .checked_div(10_000)
-            .ok_or(Error::Overflow)?;
+            .ok_or(Error::Overflow)?
+            .max(1);
 
+        // Defense in depth: never allow a zero (or negative) bond through.
         if dispute_bond <= 0 {
             return Err(Error::InsufficientBond);
         }

--- a/contracts/escrow/src/tests/dispute.rs
+++ b/contracts/escrow/src/tests/dispute.rs
@@ -20,10 +20,22 @@ fn create_funded_active_match(
     token: &Address,
     game_id: &str,
 ) -> u64 {
+    create_funded_active_match_with_stake(client, env, player1, player2, token, game_id, 100)
+}
+
+fn create_funded_active_match_with_stake(
+    client: &EscrowContractClient,
+    env: &Env,
+    player1: &Address,
+    player2: &Address,
+    token: &Address,
+    game_id: &str,
+    stake: i128,
+) -> u64 {
     let id = client.create_match(
         player1,
         player2,
-        &100,
+        &stake,
         token,
         &String::from_str(env, game_id),
         &Platform::Lichess,
@@ -804,6 +816,79 @@ fn test_dispute_requires_bond() {
 
     let dispute = client.get_dispute(&dispute_id);
     assert_eq!(dispute.dispute_bond, 1);
+}
+
+#[test]
+fn test_dispute_bond_minimum_one_for_tiny_stake() {
+    let (env, contract_id, oracle, player1, player2, token, _admin) =
+        setup_with_dispute_period(200);
+    let client = EscrowContractClient::new(&env, &contract_id);
+    let token_client = TokenClient::new(&env, &token);
+
+    // Default dispute bond is 100 bps (1% of stake).
+    client.set_dispute_bond_basis_points(&100);
+
+    // Minimum-stake match: 1 stroop per side. 1 * 100 / 10_000 rounds down
+    // to 0, so the bond must be floored up to 1 stroop — a dispute is never
+    // free, even on the smallest possible match.
+    let match_id = create_funded_active_match_with_stake(
+        &client,
+        &env,
+        &player1,
+        &player2,
+        &token,
+        "tiny0001",
+        1,
+    );
+
+    env.ledger().set_sequence_number(1000);
+    client.submit_result(&match_id, &Winner::Player1, &oracle);
+
+    let initial_p2_balance = token_client.balance(&player2);
+    let dispute_id =
+        client.dispute_oracle_result(&match_id, &player2, &String::from_str(&env, "evidence"));
+
+    let dispute = client.get_dispute(&dispute_id);
+    assert_eq!(dispute.dispute_bond, 1, "bond must be floored to 1 stroop");
+
+    // Exactly 1 stroop was collected: no zero-cost disputes.
+    let after_bond_balance = token_client.balance(&player2);
+    assert_eq!(initial_p2_balance - after_bond_balance, 1);
+    assert_eq!(token_client.balance(&contract_id), 3); // 2 stake + 1 bond
+}
+
+#[test]
+fn test_dispute_bond_minimum_one_for_sub_unit_stake() {
+    let (env, contract_id, oracle, player1, player2, token, _admin) =
+        setup_with_dispute_period(200);
+    let client = EscrowContractClient::new(&env, &contract_id);
+    let token_client = TokenClient::new(&env, &token);
+
+    client.set_dispute_bond_basis_points(&100);
+
+    // 99 * 100 / 10_000 = 0.99 → floors to 0, must be floored up to 1.
+    let match_id = create_funded_active_match_with_stake(
+        &client,
+        &env,
+        &player1,
+        &player2,
+        &token,
+        "tiny0099",
+        99,
+    );
+
+    env.ledger().set_sequence_number(1000);
+    client.submit_result(&match_id, &Winner::Player1, &oracle);
+
+    let initial_p2_balance = token_client.balance(&player2);
+    let dispute_id =
+        client.dispute_oracle_result(&match_id, &player2, &String::from_str(&env, "evidence"));
+
+    let dispute = client.get_dispute(&dispute_id);
+    assert_eq!(dispute.dispute_bond, 1);
+
+    let after_bond_balance = token_client.balance(&player2);
+    assert_eq!(initial_p2_balance - after_bond_balance, 1);
 }
 
 #[test]

--- a/docs/dispute-governance.md
+++ b/docs/dispute-governance.md
@@ -11,7 +11,7 @@ The dispute resolution system governs how contested match results are handled th
 **Purpose**: Prevent spam and create skin-in-the-game for disputers.
 
 **Implementation**:
-- Required bond: `match_stake * dispute_bond_basis_points / 10_000`
+- Required bond: `match_stake * dispute_bond_basis_points / 10_000`, floored to a minimum of **1 stroop** so disputes are never free (prevents zero-cost spam on tiny stakes while keeping small matches disputable)
 - Default: 1% of match stake (100 basis points)
 - Refunded on successful overturn (dispute result = Overturned)
 - Forfeited to treasury on upheld outcome (dispute result = Upheld)
@@ -379,7 +379,7 @@ quorum_basis_points: 1500              // 15% quorum
 
 | Error | Triggered By | Recovery |
 |-------|--------------|----------|
-| `InsufficientBond` | Bond calculation results in <= 0 | Increase stake or reduce bond % |
+| `InsufficientBond` | Bond calculation results in <= 0 (defense-in-depth; the bond is normally floored to a minimum of 1 stroop) | Increase stake or reduce bond % |
 | `QuorumNotMet` | total_votes < quorum_threshold | Wait for more votes or admin intervention |
 | `InsufficientHoldingDuration` | Voter acquired tokens too recently | Wait for holding duration to elapse |
 | `OracleSlashFailed` | Oracle contract rejects slash call | Verify oracle is registered, admin auth |


### PR DESCRIPTION
Closes #1390 
Closes #1391 
Closes #1392 
Closes #1393 

## Summary

Fixes #1393 — the dispute bond is calculated as `stake * dispute_bond_bps / 10_000`, and for very small stakes (e.g. **1 stroop** at the default **100 bps**) integer division rounds it down to **0**, allowing zero-cost dispute submissions that can spam the dispute system for free.

This PR floors the calculated bond to a minimum of **1 stroop**, so a dispute is never free while keeping small matches fully disputable.

## Changes

- **`contracts/escrow/src/lib.rs`**: `dispute_oracle_result` now applies `.max(1)` to the computed bond. The existing `<= 0` guard stays as defense-in-depth.
- **`contracts/escrow/src/tests/dispute.rs`**:
  - Refactor: extracted `create_funded_active_match_with_stake` helper (existing `create_funded_active_match` delegates to it with stake 100).
  - `test_dispute_bond_minimum_one_for_tiny_stake`: 1-stroop match → bond is exactly 1 stroop, and 1 stroop is actually transferred.
  - `test_dispute_bond_minimum_one_for_sub_unit_stake`: 99-stroop match (0.99 → rounds to 0) → bond floored to 1.
- **`docs/dispute-governance.md`**: documented the 1-stroop minimum in the bond requirement section and updated the `InsufficientBond` error row.

## Testing

Verified locally:
- `cargo test --lib dispute`: **74 passed, 0 failed** (includes both new minimum-bond tests).

## Checklist

- [x] `max(1, calculated_bond)` floor added
- [x] Test: bond for minimum stake (1 stroop) is at least 1
- [x] Test: sub-unit stake (99 stroops) is floored to 1
- [x] Minimum bond behavior documented
- [x] Docs updated in lockstep with code per repo conventions

Closes #1393