### PR TITLE
feat: add deposit_batch (#1335) and max_protocol_fee cap (#1337)

### DIFF
--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -2312,6 +2312,35 @@ impl EscrowContract {
         Ok(outcomes)
     }
 
+    /// Deposit into multiple matches in a single transaction. Issue #1335.
+    ///
+    /// Follows the same pattern as `submit_result_batch`: each entry is
+    /// attempted independently and failures are collected rather than
+    /// aborting the whole batch.
+    ///
+    /// Returns a `Vec<Option<Error>>` where `None` means success and
+    /// `Some(e)` carries the error for that entry.
+    pub fn deposit_batch(
+        env: Env,
+        entries: Vec<(u64, Address)>,
+    ) -> Result<Vec<Option<Error>>, Error> {
+        if env
+            .storage()
+            .instance()
+            .get(&DataKey::Paused)
+            .unwrap_or(false)
+        {
+            return Err(Error::ContractPaused);
+        }
+
+        let mut outcomes = Vec::new(&env);
+        for (match_id, player) in entries.iter() {
+            let outcome = Self::deposit(env.clone(), match_id, player);
+            outcomes.push_back(outcome.err());
+        }
+        Ok(outcomes)
+    }
+
     /// Cancel a pending match and refund any deposits.
     /// Either player can cancel a pending match.
     pub fn cancel_match(env: Env, match_id: u64, caller: Address) -> Result<(), Error> {
@@ -6274,6 +6303,7 @@ impl EscrowContract {
                 protocol_fee_bps: 0,
                 fee_recipient: env.current_contract_address(),
                 minimum_stake: DEFAULT_MINIMUM_STAKE,
+                max_protocol_fee: None,
             })
     }
 
@@ -6322,6 +6352,12 @@ impl EscrowContract {
             .checked_mul(config.protocol_fee_bps as i128)
             .ok_or(Error::Overflow)?
             / 10_000;
+        // Apply per-match fee cap if set (issue #1337).
+        let fee = if let Some(cap) = config.max_protocol_fee {
+            fee.min(cap)
+        } else {
+            fee
+        };
         Ok(fee)
     }
 }

--- a/contracts/escrow/src/tests/cancellation_fee.rs
+++ b/contracts/escrow/src/tests/cancellation_fee.rs
@@ -21,6 +21,7 @@ fn test_cancellation_fee_deduction() {
         protocol_fee_bps: 0,
         fee_recipient: admin.clone(),
         minimum_stake: DEFAULT_MINIMUM_STAKE,
+                max_protocol_fee: None,
     });
 
     // Initial balances
@@ -82,6 +83,7 @@ fn test_cancellation_fee_with_custom_config() {
         protocol_fee_bps: 0,
         fee_recipient: new_treasury.clone(),
         minimum_stake: DEFAULT_MINIMUM_STAKE,
+                max_protocol_fee: None,
     };
 
     env.mock_all_auths();

--- a/contracts/escrow/src/tests/consensus.rs
+++ b/contracts/escrow/src/tests/consensus.rs
@@ -63,6 +63,7 @@ fn setup_consensus(
         protocol_fee_bps: 0,
         fee_recipient: admin.clone(),
         minimum_stake: crate::DEFAULT_MINIMUM_STAKE,
+                max_protocol_fee: None,
     });
 
     // Register approved oracles.

--- a/contracts/escrow/src/tests/deposit_batch_and_fee_cap.rs
+++ b/contracts/escrow/src/tests/deposit_batch_and_fee_cap.rs
@@ -1,0 +1,256 @@
+/// Tests for issues #1335 (deposit_batch) and #1337 (max_protocol_fee cap).
+use super::*;
+
+// ── Issue #1335: deposit_batch ────────────────────────────────────────────────
+
+#[test]
+fn test_deposit_batch_all_valid() {
+    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let match_a = client.create_match(
+        &player1,
+        &player2,
+        &100,
+        &token,
+        &String::from_str(&env, "batch_aa1b"),
+        &Platform::Lichess,
+    );
+    let match_b = client.create_match(
+        &player1,
+        &player2,
+        &100,
+        &token,
+        &String::from_str(&env, "batch_bb2c"),
+        &Platform::Lichess,
+    );
+
+    let entries: soroban_sdk::Vec<(u64, Address)> = soroban_sdk::vec![
+        &env,
+        (match_a, player1.clone()),
+        (match_b, player1.clone()),
+    ];
+
+    let results = client.deposit_batch(&entries);
+    assert_eq!(results.len(), 2);
+    assert_eq!(results.get(0).unwrap(), None);
+    assert_eq!(results.get(1).unwrap(), None);
+
+    assert!(client.get_match(&match_a).player1_deposited);
+    assert!(client.get_match(&match_b).player1_deposited);
+}
+
+#[test]
+fn test_deposit_batch_mixed_valid_and_invalid() {
+    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let match_id = client.create_match(
+        &player1,
+        &player2,
+        &100,
+        &token,
+        &String::from_str(&env, "batch_mix1"),
+        &Platform::Lichess,
+    );
+
+    // Second entry references a non-existent match.
+    let entries: soroban_sdk::Vec<(u64, Address)> = soroban_sdk::vec![
+        &env,
+        (match_id, player1.clone()),
+        (9999u64, player1.clone()),
+    ];
+
+    let results = client.deposit_batch(&entries);
+    assert_eq!(results.len(), 2);
+    assert_eq!(results.get(0).unwrap(), None);
+    assert_eq!(results.get(1).unwrap(), Some(Error::MatchNotFound));
+
+    // Valid entry was still processed.
+    assert!(client.get_match(&match_id).player1_deposited);
+}
+
+#[test]
+fn test_deposit_batch_already_funded_entry_fails_independently() {
+    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let match_id = client.create_match(
+        &player1,
+        &player2,
+        &100,
+        &token,
+        &String::from_str(&env, "batch_dup1"),
+        &Platform::Lichess,
+    );
+    let match_id2 = client.create_match(
+        &player1,
+        &player2,
+        &100,
+        &token,
+        &String::from_str(&env, "batch_dup2"),
+        &Platform::Lichess,
+    );
+
+    // Pre-deposit player1 into match_id so the batch entry is a duplicate.
+    client.deposit(&match_id, &player1);
+
+    let entries: soroban_sdk::Vec<(u64, Address)> = soroban_sdk::vec![
+        &env,
+        (match_id, player1.clone()),   // duplicate — should fail
+        (match_id2, player1.clone()),  // fresh — should succeed
+    ];
+
+    let results = client.deposit_batch(&entries);
+    assert_eq!(results.get(0).unwrap(), Some(Error::AlreadyFunded));
+    assert_eq!(results.get(1).unwrap(), None);
+}
+
+#[test]
+fn test_deposit_batch_returns_contract_paused_when_paused() {
+    let (env, contract_id, _oracle, player1, player2, token, admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let match_id = client.create_match(
+        &player1,
+        &player2,
+        &100,
+        &token,
+        &String::from_str(&env, "batch_pause"),
+        &Platform::Lichess,
+    );
+
+    client.pause(&admin);
+
+    let entries: soroban_sdk::Vec<(u64, Address)> = soroban_sdk::vec![
+        &env,
+        (match_id, player1.clone()),
+    ];
+
+    let result = client.try_deposit_batch(&entries);
+    assert_eq!(result, Err(Ok(Error::ContractPaused)));
+}
+
+// ── Issue #1337: max_protocol_fee cap ────────────────────────────────────────
+
+fn setup_with_fee(fee_bps: u32, max_fee: Option<i128>) -> (
+    Env, Address, Address, Address, Address, Address, Address,
+) {
+    let (env, contract_id, oracle, player1, player2, token, admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+    client.set_protocol_config(&ProtocolConfig {
+        vesting_duration_seconds: 0,
+        cancellation_fee_basis_points: 0,
+        treasury: admin.clone(),
+        stablecoin_only_mode: false,
+        maximum_stake: None,
+        match_timeout_seconds: DEFAULT_MATCH_TIMEOUT_SECONDS,
+        protocol_fee_bps: fee_bps,
+        fee_recipient: admin.clone(),
+        minimum_stake: DEFAULT_MINIMUM_STAKE,
+        max_protocol_fee: max_fee,
+    });
+    (env, contract_id, oracle, player1, player2, token, admin)
+}
+
+#[test]
+fn test_fee_cap_limits_large_fee() {
+    let (env, contract_id, oracle, player1, player2, token, admin) = setup_with_fee(1000, Some(50));
+    let client = EscrowContractClient::new(&env, &contract_id);
+    let asset = StellarAssetClient::new(&env, &token);
+    asset.mint(&player1, &900);
+    asset.mint(&player2, &900);
+
+    let match_id = client.create_match(
+        &player1, &player2, &1000, &token,
+        &String::from_str(&env, "cap_test1"), &Platform::Lichess,
+    );
+    client.deposit(&match_id, &player1);
+    client.deposit(&match_id, &player2);
+
+    let tc = TokenClient::new(&env, &token);
+    let p1_before = tc.balance(&player1);
+
+    client.submit_result(&match_id, &Winner::Player1, &oracle);
+    client.claim_vested_payout(&match_id, &player1);
+
+    // pot=2000, calculated_fee=200 (10%), capped at 50 → winner gets 1950
+    assert_eq!(tc.balance(&player1) - p1_before, 1950);
+    assert_eq!(tc.balance(&admin), 50);
+}
+
+#[test]
+fn test_fee_no_cap_full_percentage_deducted() {
+    let (env, contract_id, oracle, player1, player2, token, admin) = setup_with_fee(500, None);
+    let client = EscrowContractClient::new(&env, &contract_id);
+    let asset = StellarAssetClient::new(&env, &token);
+    asset.mint(&player1, &900);
+    asset.mint(&player2, &900);
+
+    let match_id = client.create_match(
+        &player1, &player2, &1000, &token,
+        &String::from_str(&env, "nocap_test1"), &Platform::Lichess,
+    );
+    client.deposit(&match_id, &player1);
+    client.deposit(&match_id, &player2);
+
+    let tc = TokenClient::new(&env, &token);
+    let p1_before = tc.balance(&player1);
+
+    client.submit_result(&match_id, &Winner::Player1, &oracle);
+    client.claim_vested_payout(&match_id, &player1);
+
+    // pot=2000, fee=100 (5%), no cap → winner gets 1900
+    assert_eq!(tc.balance(&player1) - p1_before, 1900);
+    assert_eq!(tc.balance(&admin), 100);
+}
+
+#[test]
+fn test_fee_cap_larger_than_calculated_has_no_effect() {
+    // When the cap is higher than the calculated fee, the calculated fee is used.
+    let (env, contract_id, oracle, player1, player2, token, admin) = setup_with_fee(100, Some(1000));
+    let client = EscrowContractClient::new(&env, &contract_id);
+    let asset = StellarAssetClient::new(&env, &token);
+    asset.mint(&player1, &900);
+    asset.mint(&player2, &900);
+
+    let match_id = client.create_match(
+        &player1, &player2, &1000, &token,
+        &String::from_str(&env, "highcap_test"), &Platform::Lichess,
+    );
+    client.deposit(&match_id, &player1);
+    client.deposit(&match_id, &player2);
+
+    let tc = TokenClient::new(&env, &token);
+    let p1_before = tc.balance(&player1);
+
+    client.submit_result(&match_id, &Winner::Player1, &oracle);
+    client.claim_vested_payout(&match_id, &player1);
+
+    // pot=2000, fee=20 (1%), cap=1000 → cap doesn't bind, winner gets 1980
+    assert_eq!(tc.balance(&player1) - p1_before, 1980);
+    assert_eq!(tc.balance(&admin), 20);
+}
+
+#[test]
+fn test_protocol_config_stores_and_retrieves_max_protocol_fee() {
+    let (env, contract_id, _oracle, _p1, _p2, _token, admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    client.set_protocol_config(&ProtocolConfig {
+        vesting_duration_seconds: 0,
+        cancellation_fee_basis_points: 0,
+        treasury: admin.clone(),
+        stablecoin_only_mode: false,
+        maximum_stake: None,
+        match_timeout_seconds: DEFAULT_MATCH_TIMEOUT_SECONDS,
+        protocol_fee_bps: 200,
+        fee_recipient: admin.clone(),
+        minimum_stake: DEFAULT_MINIMUM_STAKE,
+        max_protocol_fee: Some(75),
+    });
+
+    let config = client.get_protocol_config();
+    assert_eq!(config.max_protocol_fee, Some(75));
+    assert_eq!(config.protocol_fee_bps, 200);
+}

--- a/contracts/escrow/src/tests/fee_calculation_scenarios.rs
+++ b/contracts/escrow/src/tests/fee_calculation_scenarios.rs
@@ -15,6 +15,7 @@ fn test_cancellation_fee_calculation_correct() {
         protocol_fee_bps: 0,
         fee_recipient: admin.clone(),
         minimum_stake: DEFAULT_MINIMUM_STAKE,
+                max_protocol_fee: None,
     });
 
     let match_id = client.create_match(
@@ -46,6 +47,7 @@ fn test_zero_cancellation_fee_accepted() {
         protocol_fee_bps: 0,
         fee_recipient: admin.clone(),
         minimum_stake: DEFAULT_MINIMUM_STAKE,
+                max_protocol_fee: None,
     });
 
     let match_id = client.create_match(
@@ -76,6 +78,7 @@ fn test_high_cancellation_fee_allowed() {
         protocol_fee_bps: 0,
         fee_recipient: admin.clone(),
         minimum_stake: DEFAULT_MINIMUM_STAKE,
+                max_protocol_fee: None,
     });
 
     let match_id = client.create_match(
@@ -107,6 +110,7 @@ fn test_fee_applied_to_deposited_amount() {
         protocol_fee_bps: 0,
         fee_recipient: admin.clone(),
         minimum_stake: DEFAULT_MINIMUM_STAKE,
+                max_protocol_fee: None,
     });
 
     let stake = 100i128;
@@ -174,6 +178,7 @@ fn test_tier_based_fee_adjustment() {
         protocol_fee_bps: 0,
         fee_recipient: admin.clone(),
         minimum_stake: DEFAULT_MINIMUM_STAKE,
+                max_protocol_fee: None,
     });
 
     let bronze_match = client.create_match(

--- a/contracts/escrow/src/tests/lifecycle.rs
+++ b/contracts/escrow/src/tests/lifecycle.rs
@@ -914,6 +914,7 @@ fn test_concurrent_matches_remain_isolated() {
         protocol_fee_bps: 0,
         fee_recipient: admin.clone(),
         minimum_stake: DEFAULT_MINIMUM_STAKE,
+                max_protocol_fee: None,
     });
 
     let match_one = client.create_match(
@@ -2322,6 +2323,7 @@ fn test_update_protocol_config() {
         protocol_fee_bps: 0,
         fee_recipient: admin.clone(),
         minimum_stake: DEFAULT_MINIMUM_STAKE,
+                max_protocol_fee: None,
     });
 
     let config = client.get_protocol_config();
@@ -2345,6 +2347,7 @@ fn test_vesting_enforced() {
         protocol_fee_bps: 0,
         fee_recipient: _admin.clone(),
         minimum_stake: DEFAULT_MINIMUM_STAKE,
+                max_protocol_fee: None,
     });
 
     let id = client.create_match(

--- a/contracts/escrow/src/tests/mod.rs
+++ b/contracts/escrow/src/tests/mod.rs
@@ -15,6 +15,7 @@ mod admin_stall_resolution;
 mod balance_history_edge_cases;
 mod batch_submit;
 mod consensus;
+mod deposit_batch_and_fee_cap;
 mod dispute;
 mod events;
 mod fee_calculation_scenarios;
@@ -80,6 +81,7 @@ pub fn setup() -> (Env, Address, Address, Address, Address, Address, Address) {
         protocol_fee_bps: 0,
         fee_recipient: admin.clone(),
         minimum_stake: DEFAULT_MINIMUM_STAKE,
+                max_protocol_fee: None,
     });
 
     (

--- a/contracts/escrow/src/tests/multi_token.rs
+++ b/contracts/escrow/src/tests/multi_token.rs
@@ -52,6 +52,7 @@ fn setup_multi_token_fixture() -> (
         protocol_fee_bps: 0,
         fee_recipient: admin.clone(),
         minimum_stake: DEFAULT_MINIMUM_STAKE,
+                max_protocol_fee: None,
     });
 
     // Deploy two distinct tokens (e.g. USDC and XLM)

--- a/contracts/escrow/src/tests/protocol_config.rs
+++ b/contracts/escrow/src/tests/protocol_config.rs
@@ -19,6 +19,7 @@ fn custom_config(treasury: &Address) -> ProtocolConfig {
         protocol_fee_bps: 100,
         fee_recipient: treasury.clone(),
         minimum_stake: DEFAULT_MINIMUM_STAKE,
+                max_protocol_fee: None,
     }
 }
 
@@ -43,6 +44,7 @@ fn test_get_protocol_config_returns_config_set_during_initialize() {
         protocol_fee_bps: 0,
         fee_recipient: admin.clone(),
         minimum_stake: DEFAULT_MINIMUM_STAKE,
+                max_protocol_fee: None,
     };
 
     let actual = client.get_protocol_config();
@@ -67,6 +69,7 @@ fn test_get_protocol_config_reflects_update_after_set() {
         protocol_fee_bps: 200,
         fee_recipient: admin.clone(),
         minimum_stake: DEFAULT_MINIMUM_STAKE,
+                max_protocol_fee: None,
     };
 
     client.set_protocol_config(&updated);

--- a/contracts/escrow/src/tests/referral.rs
+++ b/contracts/escrow/src/tests/referral.rs
@@ -95,6 +95,7 @@ fn setup_referral_match(
         protocol_fee_bps: 0,
         fee_recipient: admin.clone(),
         minimum_stake: crate::DEFAULT_MINIMUM_STAKE,
+                max_protocol_fee: None,
     });
     client.set_referral_share_bps(&referral_share_bps);
 

--- a/contracts/escrow/src/tests/stablecoin.rs
+++ b/contracts/escrow/src/tests/stablecoin.rs
@@ -25,6 +25,7 @@ fn enable_stablecoin_mode(client: &EscrowContractClient, admin: &Address) {
         protocol_fee_bps: 0,
         fee_recipient: admin.clone(),
         minimum_stake: DEFAULT_MINIMUM_STAKE,
+                max_protocol_fee: None,
     });
 }
 
@@ -217,6 +218,7 @@ fn test_stablecoin_mode_can_be_toggled_off() {
         protocol_fee_bps: 0,
         fee_recipient: admin.clone(),
         minimum_stake: DEFAULT_MINIMUM_STAKE,
+                max_protocol_fee: None,
     });
 
     // Same token should now succeed.

--- a/contracts/escrow/src/tests/token_swap.rs
+++ b/contracts/escrow/src/tests/token_swap.rs
@@ -73,6 +73,7 @@ fn setup_swap_match(
         protocol_fee_bps: 0,
         fee_recipient: admin.clone(),
         minimum_stake: DEFAULT_MINIMUM_STAKE,
+                max_protocol_fee: None,
     });
 
     // Register token A (stake token) and token B (preferred payout token)

--- a/contracts/escrow/src/types.rs
+++ b/contracts/escrow/src/types.rs
@@ -65,6 +65,10 @@ pub struct ProtocolConfig {
     pub fee_recipient: Address,
     /// Minimum stake amount enforced in create_match (default 1).
     pub minimum_stake: i128,
+    /// Optional absolute cap on the protocol fee per match (in token units).
+    /// When set, `fee = min(calculated_fee, max_protocol_fee)`.
+    /// `None` means no cap (default).
+    pub max_protocol_fee: Option<i128>,
 }
 
 /// A single fee tier entry: matches with a stake up to `max_stake` are charged


### PR DESCRIPTION
closes #1335
closes #1337
closes #1336 
closes #1334 

## Summary

Resolves issues [#1335](https://github.com/StellarCheckMate/Checkmate-Escrow/issues/1335) and [#1337](https://github.com/StellarCheckMate/Checkmate-Escrow/issues/1337).

> Issues #1334 (referrer tracking) and #1336 (get_contract_version) are already implemented in main.

---

### #1337 — Protocol fee cap per match

**Problem:** The protocol fee is a flat percentage with no ceiling. Large stakes produce very large absolute fees, penalising high-stakes players disproportionately.

**Changes:**
- Added `max_protocol_fee: Option<i128>` field to `ProtocolConfig` in `types.rs`
- Applied cap in `compute_protocol_fee`: `fee = min(calculated_fee, max_protocol_fee)`
- All existing `ProtocolConfig` construction sites updated with `max_protocol_fee: None` (backward-compatible default)

---

### #1335 — Batch deposit

**Problem:** Tournaments require one `deposit` call per match. A batch function reduces transaction overhead.

**Changes:**
- Added `deposit_batch(entries: Vec<(match_id, player)>)` to `lib.rs`
- Follows the same pattern as the existing `submit_result_batch`: each entry is attempted independently, failures are collected rather than aborting the batch
- Returns `Vec<Option<Error>>` — `None` = success, `Some(e)` = error for that entry

---

### Tests

New file `tests/deposit_batch_and_fee_cap.rs` covering:
- Batch deposit: all valid, mixed valid/invalid, duplicate entry, paused contract
- Fee cap: cap binds on large fee, uncapped full percentage, cap above calculated fee has no effect, config round-trip