### PR TITLE
Add admin view for frozen players

### DIFF
--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -866,6 +866,29 @@ impl EscrowContract {
             .unwrap_or_else(|| soroban_sdk::vec![&env])
     }
 
+    /// Lists all currently frozen players — admin only.
+    ///
+    /// This authenticated view provides an explicit administrative audit path
+    /// without requiring callers to read the contract's persistent storage.
+    pub fn admin_list_frozen_players(env: Env, caller: Address) -> Result<soroban_sdk::Vec<Address>, Error> {
+        extend_instance_ttl(&env);
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(Error::Unauthorized)?;
+        caller.require_auth();
+        if caller != admin {
+            return Err(Error::Unauthorized);
+        }
+
+        Ok(env
+            .storage()
+            .persistent()
+            .get(&PlayerFreezeKey::FrozenPlayers)
+            .unwrap_or_else(|| soroban_sdk::vec![&env]))
+    }
+
     /// Internal helper — rejects `player` with `Error::ContractPaused` when
     /// frozen. Used by `create_match` (all variants) and `deposit`.
     fn require_player_not_frozen(env: &Env, player: &Address) -> Result<(), Error> {

--- a/contracts/escrow/src/tests/player_freeze.rs
+++ b/contracts/escrow/src/tests/player_freeze.rs
@@ -208,6 +208,37 @@ fn test_admin_unfreeze_player_removes_from_list() {
     assert!(!client.is_player_frozen(&player1));
 }
 
+// ── admin_list_frozen_players ──────────────────────────────────────────────────
+
+#[test]
+fn test_admin_list_frozen_players_requires_admin_auth() {
+    let (env, contract_id, _oracle, player1, _p2, _token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    client.admin_freeze_player(&player1, &reason(&env, "audit"));
+    env.set_auths(&[]);
+
+    let result = client.try_admin_list_frozen_players(&_admin);
+    assert!(result.is_err(), "frozen-player audit must require admin auth");
+}
+
+#[test]
+fn test_admin_list_frozen_players_returns_current_ordered_list() {
+    let (env, contract_id, _oracle, player1, player2, _token, admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+    let player3 = Address::generate(&env);
+
+    client.admin_freeze_player(&player1, &reason(&env, "r1"));
+    client.admin_freeze_player(&player2, &reason(&env, "r2"));
+    client.admin_freeze_player(&player3, &reason(&env, "r3"));
+    client.admin_unfreeze_player(&player2);
+
+    let list = client.admin_list_frozen_players(&admin);
+    assert_eq!(list.len(), 2);
+    assert_eq!(list.get(0).unwrap(), player1);
+    assert_eq!(list.get(1).unwrap(), player3);
+}
+
 // ── get_frozen_players ────────────────────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
Closes #1398
Closes #1399
Closes #1400

Expose an authenticated admin listing so frozen-player audits do not require raw storage access, with coverage for authorization and list consistency.

🤖 Generated with Codebuff

## Summary

Brief description of what this PR does and why.

## Related Issue

Closes #<!-- issue number -->

## What Changed

- Contracts:
- Tests:
- Docs:

## Checklist

- [ ] `cargo test` passes locally
- [ ] `cargo clippy` is clean
- [ ] Tests added or updated for this change
- [ ] Documentation updated (or no update needed)
- [ ] `CHANGELOG.md` updated under `[Unreleased]` — see [changelog guidelines](../CONTRIBUTING.md#updating-the-changelog)
