### PR TITLE
feat: add sandboxed E2E lifecycle suite against release WASM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,9 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:
-          targets: wasm32-unknown-unknown
+          # wasm32v1-none is the Soroban target used for the E2E suite: core
+          # wasm 1.0 only, which the host validator accepts.
+          targets: wasm32-unknown-unknown, wasm32v1-none
 
       - name: Cache cargo
         uses: actions/cache@v4
@@ -71,6 +73,12 @@ jobs:
 
       - name: Run upgrade simulation tests
         run: cargo test -p escrow --test upgrade_simulation_tests
+
+      - name: Build release WASM
+        run: cargo build --target wasm32v1-none --release -p escrow -p oracle
+
+      - name: Run E2E tests against release WASM
+        run: cargo test -p e2e-tests
 
   frontend-build:
     name: Frontend Build

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,21 @@
 [workspace]
-members = ["contracts/escrow", "contracts/oracle", "oracle-service", "services/event-indexer"]
+members = [
+    "contracts/escrow",
+    "contracts/oracle",
+    "oracle-service",
+    "services/event-indexer",
+    "e2e-tests",
+]
+# Default members exclude e2e-tests: it is a host-only test harness that reads
+# the release WASM artifacts from disk, so plain `cargo build` / `cargo test`
+# must not try to run it without the WASM build. Run it explicitly with
+# `cargo test -p e2e-tests` after `cargo build --target wasm32v1-none --release`.
+default-members = [
+    "contracts/escrow",
+    "contracts/oracle",
+    "oracle-service",
+    "services/event-indexer",
+]
 resolver = "2"
 
 [workspace.package]

--- a/contracts/oracle/src/lib.rs
+++ b/contracts/oracle/src/lib.rs
@@ -16,7 +16,7 @@
 /// - `#9` — `RateLimitExceeded` — Oracle exceeded hourly/daily submission quota
 ///
 /// See [`docs/error-codes.md`](../../docs/error-codes.md) for all 21 error codes with causes and recovery actions.
-mod errors;
+pub mod errors;
 pub mod types;
 
 use errors::Error;

--- a/docs/e2e-testing.md
+++ b/docs/e2e-testing.md
@@ -1,9 +1,123 @@
 # End-to-End Testing Guide
 
-This guide explains how to run the Checkmate-Escrow end-to-end (E2E) test suite
-against the Stellar testnet using real wallets and real contract deployments.
+Checkmate-Escrow has two end-to-end test suites:
 
-## What the E2E tests cover
+1. **Sandboxed lifecycle suite** (`e2e-tests/`) — deploys the *release WASM
+   artifacts* into an in-process Soroban host and drives a complete match from
+   creation to payout. It is fully automated, deterministic, and runs on every
+   PR in CI.
+2. **Testnet suite** (`oracle-service/tests/e2e_tests.rs`) — exercises the
+   off-chain oracle pipeline (RPC, Lichess/Chess.com fetches, persistence)
+   against real testnet endpoints and wallets.
+
+## Sandboxed lifecycle suite (`e2e-tests/`)
+
+### Why it exists
+
+The unit tests in `contracts/escrow` and `contracts/oracle` register the
+contracts natively (compiled into the test binary). They are fast and cover
+the state machine well, but they do not prove that the **deployed artifact** —
+the release WASM that would actually be shipped to a network — behaves
+correctly, nor that the two contracts work together. The sandboxed suite
+closes that gap: it deploys `target/wasm32v1-none/release/{escrow,oracle}.wasm`
+into the sandboxed Soroban host and drives the exact flow the off-chain oracle
+service drives in production.
+
+### The gold-standard lifecycle
+
+`e2e-tests/tests/lifecycle.rs` runs the full flow end to end for every payout
+branch:
+
+1. **Deploy** — `escrow.wasm` and `oracle.wasm` (the release bytecode) are
+   registered in the sandbox, together with a Stellar asset contract that
+   plays the role of the stake token.
+2. **Initialize** — escrow is configured with the oracle service account as
+   its trusted oracle; the oracle contract gets the same account as admin.
+3. **Create match** — `create_match` with a realistic Lichess `game_id`
+   (`"abcd1234"`). The match is `Pending` and escrow holds nothing.
+4. **Deposit** — player1 then player2 transfer their stakes in. The match
+   activates, `is_funded` flips to `true`, and the contract balance is exactly
+   `2 × stake`.
+5. **Oracle records the result** — the oracle service calls
+   `oracle.submit_result` (game_id, platform, winner, response time, and
+   confidence), which stores a `ResultEntry` for the audit log.
+6. **Settle** — the oracle calls `escrow.submit_result` from the escrow-side
+   oracle address; the match becomes `Completed` and the payout vests.
+7. **Claim** — each player calls `claim_vested_payout` (the test config
+   disables the vesting delay). The winner receives `2 × stake`, the loser
+   receives nothing, and the contract retains a zero balance.
+
+Assertions cover state transitions, the contract's token balance at each
+stage, player balances after payout, stored oracle results, and the loser's
+inability to claim.
+
+| Test | Outcome | Verifies |
+|------|---------|----------|
+| `test_full_lifecycle_player1_wins` | `Winner::Player1` | winner ends with `initial + stake`, loser cannot claim |
+| `test_full_lifecycle_player2_wins` | `Winner::Player2` | winner ends with `initial + stake`, loser cannot claim |
+| `test_full_lifecycle_draw` | `Winner::Draw` | each player gets exactly their stake back |
+
+### Negative paths
+
+- `test_non_oracle_cannot_submit_result` — an impostor account cannot settle a
+  match; it stays `Active` and both stakes stay in escrow.
+- `test_oracle_duplicate_submit_rejected` — the oracle contract refuses a
+  second result submission for the same match (`AlreadySubmitted`).
+- `test_claim_before_settlement_rejected` — a player cannot claim a payout
+  before the oracle settles the match.
+- `test_submit_result_on_unfunded_match_rejected` — the oracle cannot settle a
+  match that was never fully funded (`NotFunded`).
+
+> **Note on events:** event emission (`match/created`, `match/activated`,
+> `match/completed`, `oracle/result`, …) is asserted in the unit tests in
+> `contracts/*`. The soroban-sdk test host does not reliably surface events
+> published by WASM-registered contracts through `env.events()` in this SDK
+> version, so the E2E suite validates observable effects instead — the state
+> and balance assertions above pin the same behavior end to end.
+
+### How to run
+
+Contracts are built for **`wasm32v1-none`** — the Soroban target that emits
+core wasm 1.0 only. Do not build with `wasm32-unknown-unknown` for the E2E
+suite: on recent Rust that target enables reference-types / multi-value
+instructions, which the Soroban host validator rejects at deployment — the E2E
+suite would catch exactly this.
+
+```bash
+# Full suite: build release WASM → unit tests → E2E tests
+scripts/test.sh
+
+# Or manually:
+rustup target add wasm32v1-none
+cargo build --target wasm32v1-none --release -p escrow -p oracle
+cargo test              # unit tests
+cargo test -p e2e-tests # E2E tests against the release WASM
+```
+
+The E2E tests read the compiled artifacts from `target/wasm32v1-none/release/`
+at runtime, so the WASM build must run first. If the artifacts are missing,
+the tests fail with a clear message instead of silently testing stale
+bytecode. `e2e-tests` is a workspace member but not a *default* member, so
+plain `cargo build` / `cargo test` compile only the contracts — run the
+harness explicitly with `cargo test -p e2e-tests`.
+
+### CI
+
+`.github/workflows/ci.yml` builds the release WASM in the `test` job and then
+runs both `cargo test` and `cargo test -p e2e-tests`, so every push to `main`
+and every PR is validated against the deployable artifacts.
+
+### What the sandboxed suite does not cover
+
+- **Live network behavior** — fees, sequencing, and real ledger effects are
+  covered by the testnet suite below and by `scripts/smoke_test.sh`.
+- **Off-chain oracle HTTP fetch** — the Lichess / Chess.com API calls live in
+  `oracle-service/` and are exercised by the testnet suite.
+- **Multi-oracle consensus** — the m-of-n voting path in the oracle contract
+  (see [docs/oracle.md](oracle.md)) is covered by unit tests in
+  `contracts/oracle/src/tests.rs`.
+
+## Testnet suite (`oracle-service/tests/e2e_tests.rs`)
 
 The E2E test suite (`oracle-service/tests/e2e_tests.rs`) exercises the full
 oracle pipeline with no mocks:

--- a/docs/oracle.md
+++ b/docs/oracle.md
@@ -88,6 +88,11 @@ The two contracts are separate:
   admin-gated read interfaces. It additionally supports a genuine multi-oracle
   consensus path — see [m-of-n Oracle Consensus](#m-of-n-oracle-consensus).
 
+The complete pipeline — deploying the release WASM artifacts, creating a
+match, depositing both stakes, recording the result, settling, and claiming
+the payout — is exercised end to end by the sandboxed lifecycle suite in
+`e2e-tests/`; see [docs/e2e-testing.md](e2e-testing.md).
+
 ---
 
 ## m-of-n Oracle Consensus

--- a/e2e-tests/Cargo.toml
+++ b/e2e-tests/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "e2e-tests"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }
+escrow = { path = "../contracts/escrow" }
+oracle = { path = "../contracts/oracle" }

--- a/e2e-tests/src/lib.rs
+++ b/e2e-tests/src/lib.rs
@@ -1,0 +1,118 @@
+//! E2E test harness for the Checkmate Escrow + Oracle contracts.
+//!
+//! Unlike the unit tests in `contracts/*` (which register the contracts
+//! natively, compiled into the test binary), these tests deploy the *release
+//! WASM artifacts* — the exact bytecode that would be shipped to a live
+//! network — into the sandboxed Soroban host and drive the complete match
+//! lifecycle through the generated contract clients:
+//!
+//! create match → deposit ×2 → oracle records the result → escrow settles →
+//! players claim the vested payout.
+
+use escrow::EscrowContractClient;
+use oracle::OracleContractClient;
+use soroban_sdk::{
+    testutils::Address as _,
+    token::{Client as TokenClient, StellarAssetClient},
+    Address, Env,
+};
+
+/// Stake used for every match in these tests.
+pub const STAKE: i128 = 100;
+
+/// Amount of the stake token minted to each player.
+pub const MINT_AMOUNT: i128 = 1_000;
+
+/// A fully deployed and initialized world: escrow + oracle contracts (both
+/// loaded from release WASM), a Stellar asset contract as the stake token,
+/// and two funded players.
+///
+/// The clients carry a (phantom) lifetime from soroban-sdk's generated client
+/// types; since the harness never uses the per-client auth-mock builders, the
+/// world is constructed with `'static`.
+pub struct World<'a> {
+    pub env: Env,
+    pub escrow: EscrowContractClient<'a>,
+    pub oracle: OracleContractClient<'a>,
+    pub token: Address,
+    pub token_client: TokenClient<'a>,
+    /// The oracle service account: admin of the oracle contract and the
+    /// address the escrow contract trusts to submit results.
+    pub oracle_admin: Address,
+    pub admin: Address,
+    pub player1: Address,
+    pub player2: Address,
+}
+
+/// Load a release WASM artifact built by `scripts/test.sh`.
+///
+/// The tests deliberately run against the compiled bytecode rather than the
+/// in-crate Rust code so that what gets validated is what would be deployed.
+pub fn load_wasm(name: &str) -> Vec<u8> {
+    // wasm32v1-none is the Soroban target (core wasm 1.0 only). Building for
+    // wasm32-unknown-unknown on recent Rust emits reference-types /
+    // multi-value instructions that the Soroban host validator rejects at
+    // deployment — the E2E suite would catch exactly this.
+    let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join(format!("../target/wasm32v1-none/release/{name}.wasm"));
+    std::fs::read(&path).unwrap_or_else(|e| {
+        panic!(
+            "E2E tests need the release WASM artifact at {}. Build it first with \
+             `cargo build --target wasm32v1-none --release -p escrow -p oracle` \
+             (or `scripts/test.sh`). Error: {e}",
+            path.display()
+        )
+    })
+}
+
+/// Deploy the escrow and oracle contracts from their release WASM artifacts,
+/// deploy a Stellar asset contract, initialize everything, and fund the
+/// players.
+pub fn deploy_and_fund() -> World<'static> {
+    let mut env = Env::default();
+    // Don't write test_snapshots/*.json files to disk when the env is dropped.
+    env.set_config(soroban_sdk::testutils::EnvTestConfig { capture_snapshot_at_drop: false });
+    env.mock_all_auths();
+
+    // Deploy the actual release bytecode — this is what gets shipped.
+    let escrow_wasm = load_wasm("escrow");
+    let oracle_wasm = load_wasm("oracle");
+    let escrow_id = env.register_contract_wasm(None, escrow_wasm.as_slice());
+    let oracle_id = env.register_contract_wasm(None, oracle_wasm.as_slice());
+
+    let oracle_admin = Address::generate(&env);
+    let admin = Address::generate(&env);
+    let player1 = Address::generate(&env);
+    let player2 = Address::generate(&env);
+
+    // USDC-style Stellar asset, minted to both players.
+    let token = env.register_stellar_asset_contract_v2(admin.clone()).address();
+    let token_client = TokenClient::new(&env, &token);
+    let asset_client = StellarAssetClient::new(&env, &token);
+    asset_client.mint(&player1, &MINT_AMOUNT);
+    asset_client.mint(&player2, &MINT_AMOUNT);
+
+    // The escrow contract trusts `oracle_admin` — the oracle service account
+    // that the off-chain oracle uses to submit results.
+    let escrow = EscrowContractClient::new(&env, &escrow_id);
+    escrow.initialize(&oracle_admin, &admin);
+
+    // Disable vesting so payouts can be claimed immediately in the test; the
+    // default protocol config vests winnings over 3 days.
+    escrow.set_protocol_config(&escrow::types::ProtocolConfig {
+        vesting_duration_seconds: 0,
+        cancellation_fee_basis_points: 0,
+        treasury: admin.clone(),
+        stablecoin_only_mode: false,
+        maximum_stake: None,
+        match_timeout_seconds: escrow::DEFAULT_MATCH_TIMEOUT_SECONDS,
+        protocol_fee_bps: 0,
+        fee_recipient: admin.clone(),
+        minimum_stake: escrow::DEFAULT_MINIMUM_STAKE,
+    });
+
+    let oracle = OracleContractClient::new(&env, &oracle_id);
+    oracle.initialize(&oracle_admin);
+
+    World { env, escrow, oracle, token, token_client, oracle_admin, admin, player1, player2 }
+}

--- a/e2e-tests/tests/lifecycle.rs
+++ b/e2e-tests/tests/lifecycle.rs
@@ -1,0 +1,282 @@
+//! End-to-end tests: deploy the release WASM contracts and drive the complete
+//! match lifecycle — create match → deposit ×2 → oracle records result →
+//! escrow settles → players claim the vested payout — verifying state and
+//! balances at every step.
+
+use e2e_tests::{deploy_and_fund, MINT_AMOUNT, STAKE, World};
+use escrow::{
+    errors::Error as EscrowError,
+    types::{MatchState, Platform as EscrowPlatform, Winner as EscrowWinner},
+};
+use oracle::{
+    errors::Error as OracleError,
+    types::{Platform as OraclePlatform, Winner as OracleWinner},
+};
+use soroban_sdk::{testutils::Address as _, Address, String};
+
+/// Realistic Lichess game id (exactly 8 alphanumeric chars).
+const GAME_ID: &str = "abcd1234";
+
+/// How long the oracle took to fetch + verify the result, in ms.
+const RESPONSE_TIME_MS: u64 = 250;
+
+/// Confidence score the oracle attaches to the result (0-100).
+const CONFIDENCE: Option<u8> = Some(95);
+
+/// Drives the full lifecycle for a given outcome and asserts every invariant
+/// along the way:
+///
+/// 1. deploy (done in `deploy_and_fund`) — release WASM, not in-crate code
+/// 2. create match → `Pending`
+/// 3. deposit ×2 → `Active`, escrow holds `2 × stake`
+/// 4. oracle records the verified result
+/// 5. escrow settles → `Completed`, payout vests
+/// 6. players claim → winner takes the pot, contract retains nothing
+fn assert_full_lifecycle(winner: EscrowWinner, oracle_result: OracleWinner) {
+    let World {
+        env,
+        escrow,
+        oracle,
+        token,
+        token_client,
+        oracle_admin,
+        player1,
+        player2,
+        ..
+    } = deploy_and_fund();
+
+    // ── 1. Create match ──────────────────────────────────────────────────
+    let id = escrow.create_match(
+        &player1,
+        &player2,
+        &STAKE,
+        &token,
+        &String::from_str(&env, GAME_ID),
+        &EscrowPlatform::Lichess,
+    );
+    assert_eq!(id, 0, "first match should be assigned id 0");
+
+    let pending = escrow.get_match(&id);
+    assert_eq!(pending.state, MatchState::Pending, "match starts Pending");
+    assert_eq!(escrow.get_escrow_balance(&id), 0, "nothing in escrow yet");
+
+    // ── 2. Both players deposit ──────────────────────────────────────────
+    escrow.deposit(&id, &player1);
+    assert!(!escrow.is_funded(&id), "not funded after only player1 deposits");
+    assert_eq!(escrow.get_escrow_balance(&id), STAKE);
+
+    escrow.deposit(&id, &player2);
+    assert!(escrow.is_funded(&id), "funded once both players deposit");
+    assert_eq!(escrow.get_escrow_balance(&id), 2 * STAKE);
+    assert_eq!(escrow.get_match(&id).state, MatchState::Active);
+
+    // The escrow contract holds 2× stake; players are down their stakes.
+    assert_eq!(token_client.balance(&escrow.address), 2 * STAKE);
+    assert_eq!(token_client.balance(&player1), MINT_AMOUNT - STAKE);
+    assert_eq!(token_client.balance(&player2), MINT_AMOUNT - STAKE);
+
+    // ── 3. Oracle records the verified result ────────────────────────────
+    oracle.submit_result(
+        &id,
+        &String::from_str(&env, GAME_ID),
+        &OraclePlatform::Lichess,
+        &oracle_result,
+        &RESPONSE_TIME_MS,
+        &CONFIDENCE,
+    );
+    assert!(oracle.has_result(&id), "oracle stores the result");
+    let entry = oracle.get_result(&id);
+    assert_eq!(entry.game_id, String::from_str(&env, GAME_ID));
+    assert_eq!(entry.result, oracle_result);
+    assert_eq!(entry.confidence, CONFIDENCE);
+
+    // ── 4. Oracle settles the match in escrow → payout vests ─────────────
+    escrow.submit_result(&id, &winner, &oracle_admin, &CONFIDENCE);
+    let settled = escrow.get_match(&id);
+    assert_eq!(settled.state, MatchState::Completed, "match completes on settle");
+    assert_eq!(settled.winner, winner);
+    assert_eq!(escrow.get_escrow_balance(&id), 0);
+
+    // ── 5. Players claim the vested payout ───────────────────────────────
+    match winner {
+        EscrowWinner::Player1 => {
+            escrow.claim_vested_payout(&id, &player1);
+            // The loser cannot claim anything — the pot goes to the winner.
+            assert_eq!(
+                escrow.try_claim_vested_payout(&id, &player2),
+                Err(Ok(EscrowError::Unauthorized)),
+                "loser must not be able to claim a payout"
+            );
+            assert_eq!(token_client.balance(&player1), MINT_AMOUNT + STAKE);
+            assert_eq!(token_client.balance(&player2), MINT_AMOUNT - STAKE);
+        }
+        EscrowWinner::Player2 => {
+            escrow.claim_vested_payout(&id, &player2);
+            assert_eq!(
+                escrow.try_claim_vested_payout(&id, &player1),
+                Err(Ok(EscrowError::Unauthorized)),
+                "loser must not be able to claim a payout"
+            );
+            assert_eq!(token_client.balance(&player1), MINT_AMOUNT - STAKE);
+            assert_eq!(token_client.balance(&player2), MINT_AMOUNT + STAKE);
+        }
+        EscrowWinner::Draw => {
+            escrow.claim_vested_payout(&id, &player1);
+            escrow.claim_vested_payout(&id, &player2);
+            assert_eq!(token_client.balance(&player1), MINT_AMOUNT);
+            assert_eq!(token_client.balance(&player2), MINT_AMOUNT);
+        }
+        EscrowWinner::None => unreachable!("tests only settle real outcomes"),
+    }
+
+    assert_eq!(token_client.balance(&escrow.address), 0, "contract must not retain funds after payout");
+}
+
+#[test]
+fn test_full_lifecycle_player1_wins() {
+    assert_full_lifecycle(EscrowWinner::Player1, OracleWinner::Player1);
+}
+
+#[test]
+fn test_full_lifecycle_player2_wins() {
+    assert_full_lifecycle(EscrowWinner::Player2, OracleWinner::Player2);
+}
+
+#[test]
+fn test_full_lifecycle_draw() {
+    assert_full_lifecycle(EscrowWinner::Draw, OracleWinner::Draw);
+}
+
+/// An impostor account must not be able to settle a match: the match stays
+/// Active and the funds stay in escrow.
+#[test]
+fn test_non_oracle_cannot_submit_result() {
+    let World { env, escrow, token, token_client, player1, player2, .. } = deploy_and_fund();
+
+    let id = escrow.create_match(
+        &player1,
+        &player2,
+        &STAKE,
+        &token,
+        &String::from_str(&env, "efgh5678"),
+        &EscrowPlatform::Lichess,
+    );
+    escrow.deposit(&id, &player1);
+    escrow.deposit(&id, &player2);
+
+    let impostor = Address::generate(&env);
+    let result = escrow.try_submit_result(&id, &EscrowWinner::Player1, &impostor, &None);
+    assert_eq!(
+        result,
+        Err(Ok(EscrowError::Unauthorized)),
+        "non-oracle submit_result must be rejected"
+    );
+
+    // Match untouched — still Active with both stakes still in escrow.
+    assert_eq!(escrow.get_match(&id).state, MatchState::Active);
+    assert_eq!(token_client.balance(&escrow.address), 2 * STAKE);
+}
+
+/// The oracle contract must refuse a second result submission for the same
+/// match — no overwriting a recorded result.
+#[test]
+fn test_oracle_duplicate_submit_rejected() {
+    let World { env, escrow, oracle, token, player1, player2, .. } = deploy_and_fund();
+
+    let id = escrow.create_match(
+        &player1,
+        &player2,
+        &STAKE,
+        &token,
+        &String::from_str(&env, "ijkl9012"),
+        &EscrowPlatform::Lichess,
+    );
+
+    oracle.submit_result(
+        &id,
+        &String::from_str(&env, "ijkl9012"),
+        &OraclePlatform::Lichess,
+        &OracleWinner::Player1,
+        &RESPONSE_TIME_MS,
+        &CONFIDENCE,
+    );
+    assert!(oracle.has_result(&id), "first submission is recorded");
+
+    let result = oracle.try_submit_result(
+        &id,
+        &String::from_str(&env, "ijkl9012"),
+        &OraclePlatform::Lichess,
+        &OracleWinner::Player2,
+        &RESPONSE_TIME_MS,
+        &CONFIDENCE,
+    );
+    assert_eq!(
+        result,
+        Err(Ok(OracleError::AlreadySubmitted)),
+        "a second submission for the same match must be rejected"
+    );
+
+    // The originally recorded result is untouched.
+    assert_eq!(oracle.get_result(&id).result, OracleWinner::Player1);
+}
+
+/// A player cannot claim a payout before the oracle settles the match.
+#[test]
+fn test_claim_before_settlement_rejected() {
+    let World { env, escrow, token, player1, player2, .. } = deploy_and_fund();
+
+    let id = escrow.create_match(
+        &player1,
+        &player2,
+        &STAKE,
+        &token,
+        &String::from_str(&env, "mnop3456"),
+        &EscrowPlatform::Lichess,
+    );
+    escrow.deposit(&id, &player1);
+    escrow.deposit(&id, &player2);
+    assert_eq!(escrow.get_match(&id).state, MatchState::Active);
+
+    let result = escrow.try_claim_vested_payout(&id, &player1);
+    assert_eq!(
+        result,
+        Err(Ok(EscrowError::InvalidState)),
+        "claiming before settlement must be rejected"
+    );
+}
+
+/// The oracle cannot settle a match that was never fully funded.
+#[test]
+fn test_submit_result_on_unfunded_match_rejected() {
+    let World {
+        env,
+        escrow,
+        oracle_admin,
+        token,
+        token_client,
+        player1,
+        player2,
+        ..
+    } = deploy_and_fund();
+
+    let id = escrow.create_match(
+        &player1,
+        &player2,
+        &STAKE,
+        &token,
+        &String::from_str(&env, "qrst7890"),
+        &EscrowPlatform::Lichess,
+    );
+    // Only player1 deposits — match stays Pending and unfunded.
+    escrow.deposit(&id, &player1);
+
+    let result = escrow.try_submit_result(&id, &EscrowWinner::Player1, &oracle_admin, &CONFIDENCE);
+    assert_eq!(
+        result,
+        Err(Ok(EscrowError::NotFunded)),
+        "settling an unfunded match must be rejected"
+    );
+
+    assert_eq!(escrow.get_match(&id).state, MatchState::Pending);
+    assert_eq!(token_client.balance(&escrow.address), STAKE);
+}

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,6 +1,17 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-echo "Running tests..."
+echo "Building release WASM artifacts..."
+# wasm32v1-none is the Soroban target: core wasm 1.0 only. Building for
+# wasm32-unknown-unknown on recent Rust emits reference-types / multi-value
+# instructions that the Soroban host validator rejects at deployment — the
+# E2E suite would catch exactly this.
+cargo build --target wasm32v1-none --release -p escrow -p oracle
+
+echo "Running unit tests..."
 cargo test
+
+echo "Running E2E tests against the release WASM..."
+cargo test -p e2e-tests
+
 echo "All tests passed."


### PR DESCRIPTION
Closes #1381
Closes #1382
Closes #1383
Closes #1384


## Summary

Adds a **fully automated, sandboxed E2E lifecycle suite** (`e2e-tests/`) that closes the gap called out in `docs/e2e-testing.md`: until now the E2E story was a testnet suite that exercises the off-chain oracle pipeline but **never deploys a contract and drives a match through to payout**. This suite deploys the actual **release WASM artifacts** (`escrow.wasm`, `oracle.wasm`) into the in-process Soroban host and drives the complete lifecycle:

> deploy → initialize → create match → deposit ×2 → oracle records result → escrow settles → players claim vested payout

for every payout branch, asserting state transitions, contract/player token balances at each step, stored oracle results, and the loser's inability to claim.

## What's in the PR

- **`e2e-tests/`** — new workspace crate (host-only, not a default member):
  - `src/lib.rs` — harness that registers the release WASM plus a Stellar asset token, initializes both contracts (vesting disabled so claims are immediate), and funds two players.
  - `tests/lifecycle.rs` — 7 tests:
    - `test_full_lifecycle_{player1_wins,player2_wins,draw}` — the gold-standard flow with balance/state assertions at every stage.
    - `test_non_oracle_cannot_submit_result` — impostor settlement rejected; funds stay escrowed.
    - `test_oracle_duplicate_submit_rejected` — a second oracle submission for the same match is refused (`AlreadySubmitted`).
    - `test_claim_before_settlement_rejected` — no claiming before the oracle settles.
    - `test_submit_result_on_unfunded_match_rejected` — settling an unfunded match is refused (`NotFunded`).
- **`scripts/test.sh`** — now a full pipeline: build release WASM → unit tests → E2E tests.
- **CI** — the `test` job builds the release WASM and runs `cargo test -p e2e-tests`, so every push/PR is validated against the deployable artifacts.
- **`contracts/oracle`** — `mod errors` → `pub mod errors` so the E2E crate can assert on oracle errors.
- **Docs** — `docs/e2e-testing.md` rewritten to describe both suites; `docs/oracle.md` points to the lifecycle suite.

## Adapted to the current contract architecture

The suite targets the current contracts (soroban-sdk 21.7.5), which differ from the earlier draft E2E work (that one targeted the pre-consensus contracts and no longer compiles against main):

- `escrow.submit_result` now takes a `confidence` parameter, and payouts **vest** — players receive funds via `claim_vested_payout` (the test's protocol config sets `vesting_duration_seconds: 0` for immediate claims).
- `oracle.submit_result` is now `(match_id, game_id, platform, result, response_time_ms, confidence)`; the oracle contract records the result for the audit log while escrow enforces match existence and oracle authorization — mirroring how `oracle-service` drives payouts in production.

## Why `wasm32v1-none`

The suite registers the compiled bytecode in the sandbox host. `wasm32-unknown-unknown` on recent Rust emits reference-types / multi-value instructions that the Soroban host validator rejects at deployment; `wasm32v1-none` (core wasm 1.0 only) is the deployable target — exactly the kind of artifact-level failure this suite is meant to catch.

## Testing status

⚠️ **Not yet executed** — the dev environment has no Rust toolchain, so the suite has not been compiled or run locally; **CI is the validator**. What was verified statically:

- `bash -n scripts/test.sh` — OK; `ci.yml` parses as YAML.
- `scripts/check_api_refs.sh` and `scripts/doc_conformance/check.py` report only **pre-existing** drift (2 stale API names in `docs/match-lifecycle.md`, 7 function-coverage gaps in `docs/architecture.md`) — confirmed identical on `main` before this branch; this PR introduces no new findings.
- New Rust files are written to rustfmt defaults (`cargo fmt --all --check` gates them in CI).

If CI flags anything, the assertions pin exact behavior so fixes should be quick and surgical.

## Related

- `docs/e2e-testing.md` — full coverage description and run instructions
- `docs/oracle.md` — oracle contract role and the E2E pointer
