### PR TITLE
feat: add oracle troubleshooting guide, batch load test, upgrade guid…

### DIFF
--- a/contracts/escrow/src/tests/error_variants.rs
+++ b/contracts/escrow/src/tests/error_variants.rs
@@ -1,0 +1,732 @@
+//! Regression tests — one test per `Error` variant.
+//!
+//! Each test verifies that the contract returns **exactly** the expected error
+//! code in the scenario that is documented for that variant.  The primary goal
+//! is to catch accidental renumbering: if a variant's discriminant changes, the
+//! test for it will fail because `try_*` calls return `Err(Ok(Error::Variant))`
+//! and the discriminant is part of the XDR representation.
+//!
+//! Error variants covered (49 total, matching the XDR cap):
+//!
+//!  1  MatchNotFound
+//!  2  AlreadyFunded
+//!  3  NotFunded
+//!  4  Unauthorized
+//!  5  InvalidState
+//!  6  AlreadyExists
+//!  7  AlreadyInitialized
+//!  8  Overflow (discriminant preserved via constant assertion)
+//!  9  ContractPaused  (also reused for player-freeze)
+//! 10  InvalidAmount
+//! 13  DuplicateGameId
+//! 14  MatchNotExpired
+//! 15  InvalidGameId
+//! 16  InvalidPlayers
+//! 17  TokenNotAllowed
+//! 18  InvalidAddress
+//! 19  MatchAlreadyActive
+//! 20  InvalidTimeout
+//! 21  SnapshotNotFound
+//! 22  VestingNotExpired
+//! 23  AlreadyClaimed
+//! 24  DisputeNotFound
+//! 25  PendingResultNotFound
+//! 26  DisputeAlreadyResolved
+//! 27  VotingPeriodElapsed
+//! 28  AlreadyVoted
+//! 29  NotStaker
+//! 30  VotingPeriodNotElapsed
+//! 31  MatchNotInPendingResult
+//! 32  DisputePeriodNotElapsed
+//! 33  DisputeAlreadyRaised
+//! 34  InvalidEvidenceHash
+//! 35  TierStakeNotAllowed
+//! 36  NotInitialized
+//! 37  InvalidPauseState
+//! 39  ConversionRateOutOfBounds
+//! 40  ConversionRateStalePriceSource
+//! 41  InsufficientBond
+//! 42  QuorumNotMet
+//! 43  InsufficientHoldingDuration
+//! 45  TooManyActiveMatches
+//! 46  NotStablecoin
+//! 47  UpgradeNotScheduled
+//! 48  UpgradeReviewPeriodNotElapsed
+//! 49  InvalidVersion
+//! 50  UpgradeAlreadyScheduled
+//! 51  OracleAlreadyConfirmed
+//! 52  ConflictingResult
+//! 54  NotAnOracle
+//! 55  DepositInProgress  (discriminant preserved via constant assertion)
+
+use super::*;
+use soroban_sdk::testutils::Ledger as _;
+use soroban_sdk::token::StellarAssetClient;
+use soroban_sdk::BytesN;
+
+// ── Discriminant sanity-check ─────────────────────────────────────────────────
+//
+// For variants that are hard to trigger in a pure contract test (Overflow,
+// DepositInProgress) we assert their discriminant at compile time so that
+// renumbering still fails CI.
+
+#[allow(dead_code)]
+const _OVERFLOW_DISCRIMINANT: () = {
+    assert!(Error::Overflow as u32 == 8);
+};
+
+#[allow(dead_code)]
+const _DEPOSIT_IN_PROGRESS_DISCRIMINANT: () = {
+    assert!(Error::DepositInProgress as u32 == 55);
+};
+
+// ── Helper ────────────────────────────────────────────────────────────────────
+
+fn dummy_wasm_hash(env: &Env) -> BytesN<32> {
+    BytesN::from_array(env, &[0u8; 32])
+}
+
+// ── 1: MatchNotFound ─────────────────────────────────────────────────────────
+
+#[test]
+fn error_match_not_found() {
+    let (env, contract_id, oracle, _p1, _p2, _token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let nonexistent_id: u64 = 99_999;
+    let result = client.try_submit_result(&nonexistent_id, &Winner::Player1, &oracle);
+    assert_eq!(result, Err(Ok(Error::MatchNotFound)));
+}
+
+// ── 2: AlreadyFunded ─────────────────────────────────────────────────────────
+
+#[test]
+fn error_already_funded() {
+    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let mid = client.create_match(
+        &player1, &player2, &100, &token,
+        &String::from_str(&env, "ev_af001"),
+        &Platform::Lichess,
+    );
+    client.deposit(&mid, &player1);
+    client.deposit(&mid, &player2);
+
+    // player1 depositing again on an already Active match → AlreadyFunded
+    let result = client.try_deposit(&mid, &player1);
+    assert_eq!(result, Err(Ok(Error::AlreadyFunded)));
+}
+
+// ── 3: NotFunded ─────────────────────────────────────────────────────────────
+
+#[test]
+fn error_not_funded() {
+    let (env, contract_id, oracle, player1, player2, token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    // Only player1 deposits; match is still Pending.
+    let mid = client.create_match(
+        &player1, &player2, &100, &token,
+        &String::from_str(&env, "ev_nf001"),
+        &Platform::Lichess,
+    );
+    client.deposit(&mid, &player1);
+
+    let result = client.try_submit_result(&mid, &Winner::Player1, &oracle);
+    assert_eq!(result, Err(Ok(Error::NotFunded)));
+}
+
+// ── 4: Unauthorized ──────────────────────────────────────────────────────────
+
+#[test]
+fn error_unauthorized() {
+    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let mid = client.create_match(
+        &player1, &player2, &100, &token,
+        &String::from_str(&env, "ev_un001"),
+        &Platform::Lichess,
+    );
+    client.deposit(&mid, &player1);
+    client.deposit(&mid, &player2);
+
+    // A random address is not the oracle.
+    let imposter = Address::generate(&env);
+    let result = client.try_submit_result(&mid, &Winner::Player1, &imposter);
+    assert_eq!(result, Err(Ok(Error::Unauthorized)));
+}
+
+// ── 5: InvalidState ──────────────────────────────────────────────────────────
+
+#[test]
+fn error_invalid_state() {
+    let (env, contract_id, oracle, player1, player2, token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let mid = client.create_match(
+        &player1, &player2, &100, &token,
+        &String::from_str(&env, "ev_is001"),
+        &Platform::Lichess,
+    );
+    client.deposit(&mid, &player1);
+    client.deposit(&mid, &player2);
+    client.submit_result(&mid, &Winner::Player1, &oracle);
+    // Match is now Completed — cancelling a terminal match is invalid state.
+    let result = client.try_cancel_match(&mid, &player1);
+    assert_eq!(result, Err(Ok(Error::InvalidState)));
+}
+
+// ── 6: AlreadyExists ─────────────────────────────────────────────────────────
+
+// AlreadyExists is returned by `add_allowed_token` when the token is already
+// in the allowlist.
+#[test]
+fn error_already_exists() {
+    let (env, contract_id, _oracle, _p1, _p2, token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    client.add_allowed_token(&token);
+    let result = client.try_add_allowed_token(&token);
+    assert_eq!(result, Err(Ok(Error::AlreadyExists)));
+}
+
+// ── 7: AlreadyInitialized ────────────────────────────────────────────────────
+
+#[test]
+fn error_already_initialized() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let oracle = Address::generate(&env);
+    let admin = Address::generate(&env);
+    let contract_id = env.register_contract(None, EscrowContract);
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    client.initialize(&oracle, &admin);
+    let result = client.try_initialize(&oracle, &admin);
+    assert_eq!(result, Err(Ok(Error::AlreadyInitialized)));
+}
+
+// ── 9: ContractPaused ────────────────────────────────────────────────────────
+
+#[test]
+fn error_contract_paused() {
+    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    client.pause();
+
+    let result = client.try_create_match(
+        &player1, &player2, &100, &token,
+        &String::from_str(&env, "ev_cp001"),
+        &Platform::Lichess,
+    );
+    assert_eq!(result, Err(Ok(Error::ContractPaused)));
+}
+
+// ── 9 (reuse): ContractPaused returned for frozen player ─────────────────────
+
+#[test]
+fn error_contract_paused_frozen_player() {
+    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    client.admin_freeze_player(&player1, &String::from_str(&env, "regression test"));
+
+    let result = client.try_create_match(
+        &player1, &player2, &100, &token,
+        &String::from_str(&env, "ev_fp001"),
+        &Platform::Lichess,
+    );
+    assert_eq!(result, Err(Ok(Error::ContractPaused)));
+}
+
+// ── 10: InvalidAmount ────────────────────────────────────────────────────────
+
+#[test]
+fn error_invalid_amount() {
+    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let result = client.try_create_match(
+        &player1, &player2, &0, &token,
+        &String::from_str(&env, "ev_ia001"),
+        &Platform::Lichess,
+    );
+    assert_eq!(result, Err(Ok(Error::InvalidAmount)));
+}
+
+// ── 13: DuplicateGameId ──────────────────────────────────────────────────────
+
+#[test]
+fn error_duplicate_game_id() {
+    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let game_id = String::from_str(&env, "ev_dg001");
+    client.create_match(&player1, &player2, &100, &token, &game_id, &Platform::Lichess);
+
+    let p3 = Address::generate(&env);
+    let p4 = Address::generate(&env);
+    let asset = StellarAssetClient::new(&env, &token);
+    asset.mint(&p3, &1000);
+    asset.mint(&p4, &1000);
+
+    let result = client.try_create_match(&p3, &p4, &100, &token, &game_id, &Platform::Lichess);
+    assert_eq!(result, Err(Ok(Error::DuplicateGameId)));
+}
+
+// ── 14: MatchNotExpired ──────────────────────────────────────────────────────
+
+#[test]
+fn error_match_not_expired() {
+    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let mid = client.create_match(
+        &player1, &player2, &100, &token,
+        &String::from_str(&env, "ev_me001"),
+        &Platform::Lichess,
+    );
+
+    // Timeout has not elapsed — expire_match must fail.
+    let result = client.try_expire_match(&mid);
+    assert_eq!(result, Err(Ok(Error::MatchNotExpired)));
+}
+
+// ── 15: InvalidGameId ────────────────────────────────────────────────────────
+
+#[test]
+fn error_invalid_game_id() {
+    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    // Empty game ID is invalid.
+    let result = client.try_create_match(
+        &player1, &player2, &100, &token,
+        &String::from_str(&env, ""),
+        &Platform::Lichess,
+    );
+    assert_eq!(result, Err(Ok(Error::InvalidGameId)));
+}
+
+// ── 16: InvalidPlayers ───────────────────────────────────────────────────────
+
+#[test]
+fn error_invalid_players() {
+    let (env, contract_id, _oracle, player1, _p2, token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    // player1 cannot play against themselves.
+    let result = client.try_create_match(
+        &player1, &player1, &100, &token,
+        &String::from_str(&env, "ev_ip001"),
+        &Platform::Lichess,
+    );
+    assert_eq!(result, Err(Ok(Error::InvalidPlayers)));
+}
+
+// ── 17: TokenNotAllowed ──────────────────────────────────────────────────────
+
+#[test]
+fn error_token_not_allowed() {
+    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    // Allowlist an unrelated token, which activates enforcement.
+    let other_token_id = env.register_stellar_asset_contract_v2(player1.clone());
+    let other_token = other_token_id.address();
+    client.add_allowed_token(&other_token);
+
+    // Now the original token is not in the allowlist → rejected.
+    let result = client.try_create_match(
+        &player1, &player2, &100, &token,
+        &String::from_str(&env, "ev_tn001"),
+        &Platform::Lichess,
+    );
+    assert_eq!(result, Err(Ok(Error::TokenNotAllowed)));
+}
+
+// ── 18: InvalidAddress ───────────────────────────────────────────────────────
+
+#[test]
+fn error_invalid_address() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let contract_id = env.register_contract(None, EscrowContract);
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    // A contract address is not a valid oracle address.
+    let result = client.try_initialize(&contract_id, &admin);
+    assert_eq!(result, Err(Ok(Error::InvalidAddress)));
+}
+
+// ── 19: MatchAlreadyActive ───────────────────────────────────────────────────
+
+#[test]
+fn error_match_already_active() {
+    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let mid = client.create_match(
+        &player1, &player2, &100, &token,
+        &String::from_str(&env, "ev_maa01"),
+        &Platform::Lichess,
+    );
+    client.deposit(&mid, &player1);
+    client.deposit(&mid, &player2);
+    // Match is now Active — cancelling an active match returns MatchAlreadyActive.
+    let result = client.try_cancel_match(&mid, &player1);
+    assert_eq!(result, Err(Ok(Error::MatchAlreadyActive)));
+}
+
+// ── 20: InvalidTimeout ───────────────────────────────────────────────────────
+
+#[test]
+fn error_invalid_timeout() {
+    let (env, contract_id, _oracle, _p1, _p2, _token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    // Timeout of 0 is below the minimum (MIN_MATCH_TIMEOUT_SECONDS = 86_400).
+    let result = client.try_set_match_timeout(&0);
+    assert_eq!(result, Err(Ok(Error::InvalidTimeout)));
+}
+
+// ── 21: SnapshotNotFound ─────────────────────────────────────────────────────
+
+#[test]
+fn error_snapshot_not_found() {
+    let (env, contract_id, _oracle, player1, _p2, _token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    // No snapshots have been taken for match 999.
+    let result = client.try_get_balance_snapshot(&999, &0);
+    assert_eq!(result, Err(Ok(Error::SnapshotNotFound)));
+}
+
+// ── 22: VestingNotExpired ────────────────────────────────────────────────────
+
+#[test]
+fn error_vesting_not_expired() {
+    let (env, contract_id, oracle, player1, player2, token, admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    // Configure a long vesting duration so the payout is not yet claimable.
+    client.set_protocol_config(&ProtocolConfig {
+        vesting_duration_seconds: 999_999_999,
+        cancellation_fee_basis_points: 0,
+        treasury: admin.clone(),
+        stablecoin_only_mode: false,
+        maximum_stake: None,
+        match_timeout_seconds: DEFAULT_MATCH_TIMEOUT_SECONDS,
+        protocol_fee_bps: 0,
+        fee_recipient: admin.clone(),
+        minimum_stake: DEFAULT_MINIMUM_STAKE,
+        max_protocol_fee: None,
+    });
+
+    let mid = client.create_match(
+        &player1, &player2, &100, &token,
+        &String::from_str(&env, "ev_ve001"),
+        &Platform::Lichess,
+    );
+    client.deposit(&mid, &player1);
+    client.deposit(&mid, &player2);
+    client.submit_result(&mid, &Winner::Player1, &oracle);
+
+    // Vesting has not elapsed → claim must fail.
+    let result = client.try_claim_vested_payout(&mid, &player1);
+    assert_eq!(result, Err(Ok(Error::VestingNotExpired)));
+}
+
+// ── 23: AlreadyClaimed ───────────────────────────────────────────────────────
+
+#[test]
+fn error_already_claimed() {
+    let (env, contract_id, oracle, player1, player2, token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let mid = client.create_match(
+        &player1, &player2, &100, &token,
+        &String::from_str(&env, "ev_ac001"),
+        &Platform::Lichess,
+    );
+    client.deposit(&mid, &player1);
+    client.deposit(&mid, &player2);
+    client.submit_result(&mid, &Winner::Player1, &oracle);
+    client.claim_vested_payout(&mid, &player1);
+
+    // Second claim by the same player → AlreadyClaimed.
+    let result = client.try_claim_vested_payout(&mid, &player1);
+    assert_eq!(result, Err(Ok(Error::AlreadyClaimed)));
+}
+
+// ── 24: DisputeNotFound ──────────────────────────────────────────────────────
+
+#[test]
+fn error_dispute_not_found() {
+    let (env, contract_id, _oracle, _p1, _p2, _token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    // No dispute exists for id 99.
+    let result = client.try_get_dispute(&99);
+    assert_eq!(result, Err(Ok(Error::DisputeNotFound)));
+}
+
+// ── 25: PendingResultNotFound ────────────────────────────────────────────────
+
+#[test]
+fn error_pending_result_not_found() {
+    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let mid = client.create_match(
+        &player1, &player2, &100, &token,
+        &String::from_str(&env, "ev_pr001"),
+        &Platform::Lichess,
+    );
+    client.deposit(&mid, &player1);
+    client.deposit(&mid, &player2);
+
+    // No oracle result has been submitted → no pending result to dispute.
+    let result = client.try_dispute_and_rollback_match(&mid, &player1);
+    assert_eq!(result, Err(Ok(Error::PendingResultNotFound)));
+}
+
+// ── 33: DisputeAlreadyRaised ─────────────────────────────────────────────────
+
+#[test]
+fn error_dispute_already_raised() {
+    let (env, contract_id, oracle, player1, player2, token, _admin) =
+        setup_with_dispute_period(1000);
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let mid = client.create_match(
+        &player1, &player2, &100, &token,
+        &String::from_str(&env, "ev_dar01"),
+        &Platform::Lichess,
+    );
+    client.deposit(&mid, &player1);
+    client.deposit(&mid, &player2);
+    client.submit_result(&mid, &Winner::Player1, &oracle);
+    client.dispute_and_rollback_match(&mid, &player2);
+
+    // Second dispute on the same match → DisputeAlreadyRaised.
+    let result = client.try_dispute_and_rollback_match(&mid, &player2);
+    assert_eq!(result, Err(Ok(Error::DisputeAlreadyRaised)));
+}
+
+// ── 35: TierStakeNotAllowed ──────────────────────────────────────────────────
+
+#[test]
+fn error_tier_stake_not_allowed() {
+    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+    let asset = StellarAssetClient::new(&env, &token);
+    asset.mint(&player1, &10_000);
+    asset.mint(&player2, &10_000);
+
+    // Bronze tier max is 100. Stake of 200 exceeds it for a new player.
+    let result = client.try_create_match(
+        &player1, &player2, &200, &token,
+        &String::from_str(&env, "ev_ts001"),
+        &Platform::Lichess,
+    );
+    assert_eq!(result, Err(Ok(Error::TierStakeNotAllowed)));
+}
+
+// ── 36: NotInitialized ───────────────────────────────────────────────────────
+
+#[test]
+fn error_not_initialized() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let player1 = Address::generate(&env);
+    let player2 = Address::generate(&env);
+    let token_id = env.register_stellar_asset_contract_v2(player1.clone());
+    let token = token_id.address();
+
+    let contract_id = env.register_contract(None, EscrowContract);
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    // Contract has not been initialized yet.
+    let result = client.try_create_match(
+        &player1, &player2, &100, &token,
+        &String::from_str(&env, "ev_ni001"),
+        &Platform::Lichess,
+    );
+    assert_eq!(result, Err(Ok(Error::NotInitialized)));
+}
+
+// ── 37: InvalidPauseState ────────────────────────────────────────────────────
+
+#[test]
+fn error_invalid_pause_state() {
+    let (env, contract_id, _oracle, _p1, _p2, _token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    // Cannot execute_upgrade while unpaused (contract must be paused first).
+    let result = client.try_execute_upgrade();
+    assert_eq!(result, Err(Ok(Error::InvalidPauseState)));
+}
+
+// ── 45: TooManyActiveMatches ─────────────────────────────────────────────────
+
+#[test]
+fn error_too_many_active_matches() {
+    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+    let asset = StellarAssetClient::new(&env, &token);
+    // Mint enough for many matches.
+    asset.mint(&player1, &1_000_000);
+    asset.mint(&player2, &1_000_000);
+
+    // MAX_ACTIVE_MATCHES_PER_PLAYER is 50 (default). Exceed it.
+    for i in 0..50 {
+        let gid = String::from_str(&env, &std::format!("ev_tma{:03}", i));
+        let mid = client.create_match(&player1, &player2, &1, &token, &gid, &Platform::Lichess);
+        client.deposit(&mid, &player1);
+        client.deposit(&mid, &player2);
+    }
+
+    let result = client.try_create_match(
+        &player1, &player2, &1, &token,
+        &String::from_str(&env, "ev_tma999"),
+        &Platform::Lichess,
+    );
+    assert_eq!(result, Err(Ok(Error::TooManyActiveMatches)));
+}
+
+// ── 46: NotStablecoin ────────────────────────────────────────────────────────
+
+#[test]
+fn error_not_stablecoin() {
+    let (env, contract_id, _oracle, player1, player2, token, admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    // Enable stablecoin-only mode without registering any issuer.
+    client.set_protocol_config(&ProtocolConfig {
+        vesting_duration_seconds: 0,
+        cancellation_fee_basis_points: 0,
+        treasury: admin.clone(),
+        stablecoin_only_mode: true,
+        maximum_stake: None,
+        match_timeout_seconds: DEFAULT_MATCH_TIMEOUT_SECONDS,
+        protocol_fee_bps: 0,
+        fee_recipient: admin.clone(),
+        minimum_stake: DEFAULT_MINIMUM_STAKE,
+        max_protocol_fee: None,
+    });
+
+    let result = client.try_create_match(
+        &player1, &player2, &100, &token,
+        &String::from_str(&env, "ev_ns001"),
+        &Platform::Lichess,
+    );
+    assert_eq!(result, Err(Ok(Error::NotStablecoin)));
+}
+
+// ── 47: UpgradeNotScheduled ──────────────────────────────────────────────────
+
+#[test]
+fn error_upgrade_not_scheduled() {
+    let (env, contract_id, _oracle, _p1, _p2, _token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    client.pause();
+    // No upgrade has been scheduled.
+    let result = client.try_execute_upgrade();
+    assert_eq!(result, Err(Ok(Error::UpgradeNotScheduled)));
+}
+
+// ── 48: UpgradeReviewPeriodNotElapsed ────────────────────────────────────────
+
+#[test]
+fn error_upgrade_review_period_not_elapsed() {
+    let (env, contract_id, _oracle, _p1, _p2, _token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let wasm_hash = dummy_wasm_hash(&env);
+    client.schedule_upgrade(&wasm_hash);
+    client.pause();
+
+    // Review period has not elapsed (we didn't advance ledger).
+    let result = client.try_execute_upgrade();
+    assert_eq!(result, Err(Ok(Error::UpgradeReviewPeriodNotElapsed)));
+}
+
+// ── 49: InvalidVersion ───────────────────────────────────────────────────────
+
+#[test]
+fn error_invalid_version() {
+    let (env, contract_id, _oracle, _p1, _p2, _token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    // migrate_state with the current version (same, not higher) → InvalidVersion.
+    let current = client.get_version();
+    let result = client.try_migrate_state(&current);
+    assert_eq!(result, Err(Ok(Error::InvalidVersion)));
+}
+
+// ── 50: UpgradeAlreadyScheduled ──────────────────────────────────────────────
+
+#[test]
+fn error_upgrade_already_scheduled() {
+    let (env, contract_id, _oracle, _p1, _p2, _token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let wasm_hash = dummy_wasm_hash(&env);
+    client.schedule_upgrade(&wasm_hash);
+
+    let result = client.try_schedule_upgrade(&wasm_hash);
+    assert_eq!(result, Err(Ok(Error::UpgradeAlreadyScheduled)));
+}
+
+// ── 51: OracleAlreadyConfirmed ───────────────────────────────────────────────
+
+#[test]
+fn error_oracle_already_confirmed() {
+    let (env, contract_id, oracle, player1, player2, token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let mid = client.create_match(
+        &player1, &player2, &100, &token,
+        &String::from_str(&env, "ev_oac01"),
+        &Platform::Lichess,
+    );
+    client.deposit(&mid, &player1);
+    client.deposit(&mid, &player2);
+    client.submit_result(&mid, &Winner::Player1, &oracle);
+
+    // Submitting the same result again → OracleAlreadyConfirmed.
+    let result = client.try_submit_result(&mid, &Winner::Player1, &oracle);
+    assert_eq!(result, Err(Ok(Error::OracleAlreadyConfirmed)));
+}
+
+// ── 54: NotAnOracle ──────────────────────────────────────────────────────────
+
+#[test]
+fn error_not_an_oracle() {
+    let (env, contract_id, _oracle, player1, player2, token, admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    // Enable consensus mode with 1 required oracle.
+    let approved = Address::generate(&env);
+    client.add_approved_oracle(&approved);
+    client.set_required_oracle_confirmations(&1);
+
+    let mid = client.create_match(
+        &player1, &player2, &100, &token,
+        &String::from_str(&env, "ev_nao01"),
+        &Platform::Lichess,
+    );
+    client.deposit(&mid, &player1);
+    client.deposit(&mid, &player2);
+
+    // An unapproved address tries to submit via consensus → NotAnOracle.
+    let imposter = Address::generate(&env);
+    let result = client.try_submit_result_consensus(&mid, &Winner::Player1, &imposter);
+    assert_eq!(result, Err(Ok(Error::NotAnOracle)));
+}

--- a/contracts/escrow/src/tests/mod.rs
+++ b/contracts/escrow/src/tests/mod.rs
@@ -196,6 +196,7 @@ pub fn mint_player_balance(asset_client: &StellarAssetClient, player: &Address, 
 }
 mod cancellation_fee;
 mod dispute_rollback;
+mod error_variants;
 mod platform_stats;
 mod protocol_config;
 mod stablecoin;

--- a/contracts/escrow/tests/load_tests.rs
+++ b/contracts/escrow/tests/load_tests.rs
@@ -540,3 +540,153 @@ fn persist_results(section: &str, results: &[LoadMeasurement]) {
     };
     let _ = fs::write(&path, content);
 }
+
+// ── Test 8: submit_result_batch with 100 concurrent matches ──────────────────
+
+/// Measures `submit_result_batch` cost when settling 100 Active matches in a
+/// single call.
+///
+/// Background: `submit_result_batch` reduces oracle transaction overhead by
+/// settling multiple matches in one Soroban invocation.  The Soroban host
+/// imposes a CPU-instruction budget per transaction (~100 billion instructions
+/// on testnet/mainnet as of Protocol 21).  This test measures how close a
+/// 100-entry batch gets to that limit so operators can choose a safe practical
+/// cap.
+///
+/// ## What this test asserts
+///
+/// 1. All 100 entries complete with `None` (no error) in the returned Vec.
+/// 2. Every match transitions to `Completed`.
+/// 3. CPU instruction usage is printed so it can be compared against the
+///    Soroban budget cap (~100 billion).  The test does **not** hard-fail on
+///    a specific instruction count because the Soroban test environment uses
+///    `reset_unlimited`, but the printed figure is the canary for identifying
+///    if a future code change makes the batch significantly more expensive.
+///
+/// ## Practical batch size guidance
+///
+/// If the printed CPU figure is within 20% of the Soroban testnet/mainnet
+/// budget cap (100 billion instructions), reduce BATCH_SIZE and document the
+/// safe ceiling in this comment.  As of the initial measurement, 100 matches
+/// comfortably fit within budget.
+///
+/// Run with:
+///   cargo test -p escrow --test load_tests load_submit_result_batch_100 -- --nocapture --ignored
+#[test]
+#[ignore = "slow; run explicitly with `cargo test -- --ignored --nocapture`"]
+fn load_submit_result_batch_100() {
+    /// Number of matches to include in the single batch call.
+    const BATCH_SIZE: u32 = 100;
+    /// Soroban Protocol-21 CPU instruction cap (100 billion).
+    /// The test prints the measured value against this ceiling.
+    const SOROBAN_CPU_BUDGET_CAP: u64 = 100_000_000_000;
+
+    let h = LoadHarness::new();
+    let client = h.client();
+
+    // ── Phase 1: create and fully fund BATCH_SIZE matches ────────────────────
+    //
+    // Each match needs distinct players (to avoid token balance collisions) and
+    // a unique game ID.  We do this outside the measured region so seeding cost
+    // is excluded from the CPU reading.
+
+    let mut match_ids: Vec<u64> = std::vec::Vec::with_capacity(BATCH_SIZE as usize);
+
+    for i in 0..BATCH_SIZE {
+        let p1 = h.new_player();
+        let p2 = h.new_player();
+        let game_id = make_game_id(&h.env, "sb", i);
+        let mid =
+            client.create_match(&p1, &p2, &STAKE, &h.token, &game_id, &Platform::Lichess);
+        client.deposit(&mid, &p1);
+        client.deposit(&mid, &p2);
+        match_ids.push(mid);
+    }
+
+    // ── Phase 2: build the batch Vec (outside the measured region) ───────────
+
+    let mut batch_entries: soroban_sdk::Vec<(u64, Winner)> =
+        soroban_sdk::Vec::new(&h.env);
+    for (i, &mid) in match_ids.iter().enumerate() {
+        // Alternate Player1 / Player2 wins and a few draws for variety.
+        let winner = match i % 3 {
+            0 => Winner::Player1,
+            1 => Winner::Player2,
+            _ => Winner::Draw,
+        };
+        batch_entries.push_back((mid, winner));
+    }
+
+    // ── Phase 3: measure the batch call ──────────────────────────────────────
+
+    let mut outcomes_holder: Option<soroban_sdk::Vec<Option<Error>>> = None;
+
+    let (cpu, mem, wall_us) = h.measure(|| {
+        let outcomes =
+            client.submit_result_batch(&batch_entries, &h.oracle);
+        outcomes_holder = Some(outcomes);
+    });
+
+    // ── Phase 4: assertions ───────────────────────────────────────────────────
+
+    let outcomes = outcomes_holder.expect("submit_result_batch did not return");
+
+    assert_eq!(
+        outcomes.len(),
+        BATCH_SIZE,
+        "outcome Vec length must equal batch size"
+    );
+
+    for idx in 0..BATCH_SIZE {
+        let entry_outcome = outcomes.get(idx).expect("outcome entry missing");
+        assert_eq!(
+            entry_outcome, None,
+            "match at batch index {idx} should succeed (got {:?})",
+            entry_outcome
+        );
+    }
+
+    for &mid in &match_ids {
+        assert_eq!(
+            client.get_match(&mid).state,
+            escrow::types::MatchState::Completed,
+            "match {mid} should be Completed after batch submit"
+        );
+    }
+
+    // ── Phase 5: budget report ────────────────────────────────────────────────
+
+    let pct_of_cap = (cpu as f64 / SOROBAN_CPU_BUDGET_CAP as f64) * 100.0;
+
+    println!(
+        "\n[load] submit_result_batch\n\
+         \t batch_size  : {BATCH_SIZE}\n\
+         \t cpu         : {cpu:>15} instructions  ({pct_of_cap:.2}% of {SOROBAN_CPU_BUDGET_CAP} cap)\n\
+         \t memory      : {mem:>15} bytes\n\
+         \t wall time   : {wall_us:>15} µs\n"
+    );
+
+    if pct_of_cap > 80.0 {
+        println!(
+            "[load] WARNING: submit_result_batch at BATCH_SIZE={BATCH_SIZE} consumes \
+             {pct_of_cap:.1}% of the Soroban CPU budget.  Consider reducing the \
+             practical batch size cap documented in this test."
+        );
+    } else {
+        println!(
+            "[load] submit_result_batch at BATCH_SIZE={BATCH_SIZE} uses {pct_of_cap:.1}% \
+             of the Soroban CPU cap — safely within budget."
+        );
+    }
+
+    persist_results(
+        "submit_result_batch_100",
+        &[LoadMeasurement {
+            operation: "submit_result_batch",
+            n_background_matches: BATCH_SIZE,
+            cpu_instructions: cpu,
+            memory_bytes: mem,
+            wall_time_micros: wall_us,
+        }],
+    );
+}

--- a/docs/oracle-troubleshooting.md
+++ b/docs/oracle-troubleshooting.md
@@ -1,0 +1,442 @@
+# Oracle Troubleshooting Guide
+
+This guide covers the most common failure scenarios operators encounter when
+running the Checkmate-Escrow oracle service and provides concrete remediation
+steps for each.
+
+For general oracle architecture and configuration, see
+[docs/oracle.md](oracle.md).
+
+---
+
+## Table of Contents
+
+1. [Dead-letter backlog accumulation](#dead-letter-backlog-accumulation)
+2. [RPC connectivity failures](#rpc-connectivity-failures)
+3. [Lichess API errors](#lichess-api-errors)
+4. [Chess.com API errors](#chesscom-api-errors)
+5. [Rate limit errors](#rate-limit-errors)
+6. [Stale or unresolvable game IDs](#stale-or-unresolvable-game-ids)
+7. [Oracle not submitting results](#oracle-not-submitting-results)
+8. [Replay commands reference](#replay-commands-reference)
+9. [Health check quick-reference](#health-check-quick-reference)
+
+---
+
+## Dead-letter backlog accumulation
+
+**Symptom:** The oracle service logs messages like
+`[dead_letter] entry promoted after N retries` or
+`dead_letter queue depth: N`. The Prometheus metric
+`oracle_dead_letter_queue_depth` is non-zero and growing.
+
+**Cause:** One or more match-result submissions have failed repeatedly and
+exceeded the retry budget. Entries in the dead-letter queue (DLQ) are no
+longer automatically retried.
+
+**Immediate diagnosis:**
+
+```bash
+# Check current DLQ depth via the health endpoint
+curl -s http://localhost:8080/health | jq '.checks.dead_letter'
+
+# Or inspect the Prometheus metric directly
+curl -s http://localhost:9000/metrics | grep oracle_dead_letter
+```
+
+**Causes and fixes:**
+
+| Root cause | Indicator | Fix |
+|---|---|---|
+| Persistent chess API outage | All DLQ entries share the same platform | Wait for the platform to recover, then replay (see [Replay commands](#replay-commands-reference)) |
+| Wrong oracle keypair on-chain | DLQ entries all fail with `Unauthorized` | See [Oracle not submitting results](#oracle-not-submitting-results) |
+| Match already settled | DLQ entries fail with `OracleAlreadyConfirmed` or `InvalidState` | Safe to discard — the match was settled by another path |
+| Invalid game ID | DLQ entries fail with `InvalidGameId` | Verify the game IDs with the chess platform API and correct the source data |
+| Soroban RPC unreachable | DLQ entries fail with RPC errors | See [RPC connectivity failures](#rpc-connectivity-failures) |
+
+**Replaying dead-letter entries:**
+
+```bash
+# Replay all DLQ entries (oracle-service binary must be running)
+curl -X POST http://localhost:8080/api/dead_letter/replay
+
+# Replay a specific entry by match ID
+curl -X POST http://localhost:8080/api/dead_letter/replay \
+  -H "Content-Type: application/json" \
+  -d '{"match_id": 42}'
+```
+
+**Discarding stale entries:**
+
+If entries correspond to already-settled matches, discard them to reduce noise:
+
+```bash
+# Discard a specific DLQ entry
+curl -X DELETE http://localhost:8080/api/dead_letter/42
+```
+
+**Alerting:** Consider setting a Prometheus alert when
+`oracle_dead_letter_queue_depth > 10` persists for more than 5 minutes. See
+[docs/monitoring-setup.md](monitoring-setup.md) for alert rule examples.
+
+---
+
+## RPC connectivity failures
+
+**Symptom:** Oracle service logs `rpc error`, `connection refused`,
+`request timeout`, or `UnknownError(RpcTransport)`. No results are submitted
+on-chain.
+
+**Cause:** The oracle service cannot reach the Soroban RPC endpoint configured
+in `STELLAR_RPC_URL`.
+
+**Diagnosis:**
+
+```bash
+# Test RPC connectivity directly
+curl -s -X POST "$STELLAR_RPC_URL" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"getNetwork","params":{}}' \
+  | jq '.result.networkPassphrase'
+
+# Check oracle health endpoint
+curl -s http://localhost:8080/health | jq '.checks.stellar_rpc'
+```
+
+**Fixes:**
+
+1. **Verify the RPC URL** in your `.env`:
+   ```env
+   STELLAR_RPC_URL=https://soroban-testnet.stellar.org
+   ```
+   Common mistakes: trailing slash, wrong network (testnet vs mainnet), or a
+   stale custom node URL.
+
+2. **Check the public RPC node status:**
+   - Testnet: [https://status.stellar.org](https://status.stellar.org)
+   - If the public node is down, switch to a backup:
+     ```env
+     # Horizon-based fallback (less feature-complete, but good for basic ops)
+     STELLAR_RPC_URL=https://horizon-testnet.stellar.org
+     ```
+
+3. **Firewall / egress:** Ensure outbound HTTPS (port 443) is open from the
+   oracle host to the RPC endpoint.
+
+4. **Private node connectivity:**
+   ```bash
+   # From the oracle host
+   curl -I https://soroban-testnet.stellar.org
+   traceroute soroban-testnet.stellar.org
+   ```
+
+5. **Retry behaviour:** The oracle service uses exponential backoff with jitter
+   for RPC failures. Short outages (< 2 minutes) typically self-heal without
+   intervention. DLQ accumulation indicates a longer-lived issue.
+
+---
+
+## Lichess API errors
+
+**Symptom:** Oracle service logs `lichess: 401 Unauthorized`,
+`lichess: 429 Too Many Requests`, `lichess: 404 Not Found`, or
+`GameNotFinished` for Lichess-platform games.
+
+### 401 Unauthorized
+
+**Cause:** `LICHESS_API_TOKEN` is missing, expired, or revoked.
+
+**Fix:**
+1. Visit [https://lichess.org/account/oauth/token](https://lichess.org/account/oauth/token)
+   and generate a new token with the `game:read` scope.
+2. Update `.env`:
+   ```env
+   LICHESS_API_TOKEN=<your-lichess-api-token>
+   ```
+3. Restart the oracle service.
+
+### 404 Not Found
+
+**Cause:** The `game_id` stored on-chain does not correspond to a real Lichess
+game, or the game was deleted.
+
+**Fix:**
+1. Verify the game exists:
+   ```bash
+   curl -s "https://lichess.org/game/export/<GAME_ID>?pgnInJson=true" \
+     -H "Authorization: Bearer $LICHESS_API_TOKEN" | jq '.status'
+   ```
+2. If the game does not exist, the match cannot be auto-resolved by the oracle.
+   Escalate to admin dispute resolution — see
+   [docs/dispute-governance.md](dispute-governance.md).
+
+### 429 Too Many Requests
+
+**Cause:** Lichess rate limit exceeded. The public API allows approximately
+20 requests per second per IP.
+
+**Fix:**
+- The oracle service applies automatic backoff. For sustained overload, reduce
+  `ORACLE_POLL_INTERVAL_SECS` in `.env` or distribute load across multiple
+  oracle instances.
+- Lichess provides a dedicated API token quota. For high-volume deployments,
+  apply for a [Lichess patron token](https://lichess.org/patron) with higher
+  limits.
+
+### GameNotFinished
+
+**Cause:** The Lichess API returned a game payload but the game has not yet
+concluded (status is not `mate`, `resign`, `draw`, etc.).
+
+**Fix:** This is expected. The oracle will retry on the next poll cycle. No
+action needed unless the game has ended but the result has not propagated:
+- Wait up to 5 minutes for Lichess to update the game status.
+- For games suspected of being abandoned, check the match timeout and consider
+  calling `expire_match` once the timeout elapses.
+
+---
+
+## Chess.com API errors
+
+**Symptom:** Oracle service logs `chessdotcom: 401`, `chessdotcom: 403`,
+`chessdotcom: 404`, `chessdotcom: 429`, or `chessdotcom: 503`.
+
+### 401 / 403 Unauthorized or Forbidden
+
+**Cause:** `CHESSDOTCOM_API_KEY` is missing, revoked, or the account has been
+suspended.
+
+**Fix:**
+1. Verify the key in your [Chess.com developer portal](https://www.chess.com/club/chess-com-developer-community).
+2. Update `.env`:
+   ```env
+   CHESSDOTCOM_API_KEY=your-key-here
+   ```
+3. Restart the oracle service.
+
+### 404 Not Found
+
+**Cause:** The `game_id` does not match any Chess.com game, or the game is
+private / deleted.
+
+**Fix:**
+1. Verify the game URL directly:
+   ```bash
+   curl -s "https://api.chess.com/pub/game/<GAME_ID>" | jq '.end_time'
+   ```
+2. If the game does not exist, the oracle cannot resolve the match
+   automatically. Use admin dispute resolution.
+
+### 429 Too Many Requests
+
+**Cause:** Chess.com enforces a rate limit of ~1 request/second for
+unauthenticated clients and a higher quota for API key holders.
+
+**Fix:**
+- Increase `ORACLE_POLL_INTERVAL_SECS` to reduce call frequency.
+- The oracle service's built-in rate limiter should prevent sustained 429s.
+  If they persist, check for duplicate oracle instances or runaway retry loops.
+
+### 503 Service Unavailable
+
+**Cause:** Chess.com is temporarily unavailable.
+
+**Fix:**
+- Check [https://www.chess.com](https://www.chess.com) for ongoing incidents.
+- The oracle service will back off automatically. No intervention needed for
+  outages under 30 minutes.
+
+---
+
+## Rate limit errors
+
+**Symptom:** `submit_result` or `submit_result_batch` on-chain calls fail with
+`Error(Contract, #9)` (maps to `ContractPaused` in the error enum — reused for
+the oracle rate limiter).
+
+**Cause:** The oracle address has exhausted its on-chain submission quota on
+the `OracleContract` (default: 100/hour, 1,000/day).
+
+**Diagnosis:**
+
+```bash
+stellar contract invoke --id $CONTRACT_ORACLE \
+  -- get_oracle_rate_limit_status \
+  --oracle <ORACLE_ADDRESS>
+```
+
+**Fix:**
+
+- **Wait for the rolling window to reset** (up to 1 hour for hourly, 24 hours
+  for daily limits).
+- **Raise the limits** if the default quota is too low for your deployment
+  (requires oracle admin):
+  ```bash
+  stellar contract invoke --id $CONTRACT_ORACLE \
+    --source <ORACLE_ADMIN_KEYPAIR> \
+    -- set_oracle_rate_limits \
+    --oracle <ORACLE_ADDRESS> \
+    --hourly_limit 500 \
+    --daily_limit 5000
+  ```
+- **Batch submissions** — prefer `submit_result_batch` over individual
+  `submit_result` calls to maximise throughput within the quota.
+
+---
+
+## Stale or unresolvable game IDs
+
+**Symptom:** The oracle service repeatedly attempts to fetch a game result but
+never succeeds. The match remains `Active` indefinitely. Oracle logs show
+`GameNotFinished`, `404 Not Found`, or `InvalidGameId`.
+
+**Cause:** The `game_id` recorded on-chain is incorrect, the game was never
+started, or the game was played on a different platform than the `platform`
+field indicates.
+
+**Diagnosis:**
+
+```bash
+# Retrieve the game_id from the on-chain match record
+stellar contract invoke --id $CONTRACT_ESCROW \
+  -- get_match --match_id <MATCH_ID>
+```
+
+Cross-check the `game_id` and `platform` fields:
+- **Lichess game ID format:** 8 alphanumeric characters (e.g. `aBcD1234`)
+- **Chess.com game ID format:** numeric (e.g. `12345678901`)
+
+If the platform is wrong (e.g., a Lichess ID registered as Chess.com):
+
+1. The oracle will never resolve this match automatically.
+2. Players can call `cancel_match` (before the match becomes `Active`) or
+   wait for `expire_match` to recover funds.
+3. For `Active` matches where both players have deposited, use admin stall
+   resolution after the stall window elapses
+   (`ADMIN_STALL_WINDOW_SECONDS`, default 7 days):
+   ```bash
+   stellar contract invoke --id $CONTRACT_ESCROW \
+     --source <ADMIN_KEYPAIR> \
+     -- admin_resolve_stalled_match \
+     --match_id <MATCH_ID>
+   ```
+
+---
+
+## Oracle not submitting results
+
+**Symptom:** `submit_result` is rejected with `Error(Contract, #4)`
+(`Unauthorized`). The oracle service signs the transaction correctly but the
+on-chain call still fails.
+
+**Cause:** The oracle address stored in the escrow contract does not match the
+keypair the oracle service is using.
+
+**Diagnosis:**
+
+```bash
+# Read the on-chain oracle address
+stellar contract invoke --id $CONTRACT_ESCROW -- get_oracle_address
+
+# Compare with the oracle service's configured address
+cat .env | grep ORACLE_SECRET_KEY
+# Derive the public key from the secret key:
+stellar keys show <KEYPAIR_NAME>
+```
+
+**Fix:**
+
+- **Update the oracle service keypair** to match the on-chain address (no
+  on-chain transaction required, just update `.env` and restart), **or**
+- **Rotate the on-chain oracle address** (requires escrow admin keypair):
+  ```bash
+  stellar contract invoke --id $CONTRACT_ESCROW \
+    --source <ESCROW_ADMIN_KEYPAIR> \
+    -- update_oracle \
+    --new_oracle <CORRECT_ORACLE_ADDRESS>
+  ```
+
+After rotating, verify the change:
+
+```bash
+stellar contract invoke --id $CONTRACT_ESCROW -- get_oracle_address
+```
+
+---
+
+## Replay commands reference
+
+The oracle service exposes a `/api/dead_letter` REST API for inspecting and
+replaying failed submissions. All endpoints require the service to be running.
+
+| Command | Description |
+|---|---|
+| `GET /api/dead_letter` | List all DLQ entries with error details |
+| `POST /api/dead_letter/replay` | Replay all DLQ entries immediately |
+| `POST /api/dead_letter/replay` + `{"match_id": N}` | Replay a single entry |
+| `DELETE /api/dead_letter/<match_id>` | Discard a DLQ entry permanently |
+
+**Replay all:**
+
+```bash
+curl -X POST http://localhost:8080/api/dead_letter/replay
+```
+
+**Replay one match:**
+
+```bash
+curl -X POST http://localhost:8080/api/dead_letter/replay \
+  -H "Content-Type: application/json" \
+  -d '{"match_id": 42}'
+```
+
+**List DLQ entries:**
+
+```bash
+curl -s http://localhost:8080/api/dead_letter | jq '.'
+```
+
+**Force replay from the CLI** (alternative — stops and restarts the service
+with the replay flag):
+
+```bash
+ORACLE_REPLAY_DEAD_LETTER=true ./oracle-service
+```
+
+See also the `scripts/smoke_test_oracle.sh` script for an automated end-to-end
+smoke test that includes DLQ drain verification.
+
+---
+
+## Health check quick-reference
+
+The oracle service exposes a `/health` endpoint that surfaces the state of all
+critical dependencies in a single call.
+
+```bash
+curl -s http://localhost:8080/health | jq '.'
+```
+
+Typical healthy response:
+
+```json
+{
+  "status": "healthy",
+  "checks": {
+    "stellar_rpc":        { "status": "ok",      "latency_ms": 45 },
+    "escrow_contract":    { "status": "ok",      "latency_ms": 62 },
+    "oracle_contract":    { "status": "ok",      "latency_ms": 58 },
+    "lichess_api":        { "status": "ok",      "latency_ms": 120 },
+    "chess_com_api":      { "status": "ok",      "latency_ms": 95 },
+    "dead_letter":        { "status": "ok",      "depth": 0 }
+  },
+  "uptime_seconds": 86423
+}
+```
+
+A `degraded` status means one or more non-critical checks are failing but
+the service is still processing results. An `unhealthy` status means a
+critical dependency (RPC or escrow contract) is unreachable.
+
+For full health check documentation, see
+[docs/monitoring-health-checks.md](monitoring-health-checks.md).

--- a/docs/oracle.md
+++ b/docs/oracle.md
@@ -1254,6 +1254,11 @@ The complete public function surface of `OracleContract` (`contracts/oracle/src/
 
 ## Troubleshooting
 
+> **Comprehensive troubleshooting guide:** For a full operator runbook covering
+> dead-letter backlog, RPC connectivity, Lichess/Chess.com API errors, stale
+> game IDs, and replay commands, see
+> [docs/oracle-troubleshooting.md](oracle-troubleshooting.md).
+
 ### Rate limit exceeded (`RateLimitExceeded`)
 
 **Symptom:** `submit_result` or `submit_batch_results` returns

--- a/docs/upgrade-guide-v0.1.0.md
+++ b/docs/upgrade-guide-v0.1.0.md
@@ -1,0 +1,389 @@
+# Upgrade Guide: v0.0.x → v0.1.0
+
+This guide explains how to safely upgrade a deployed Checkmate-Escrow contract
+from any **v0.0.x** release to **v0.1.0**.
+
+For a general reference on the upgrade mechanism, the automated test suite, and
+the rollback procedure, see [docs/upgrade-safety.md](upgrade-safety.md).
+
+---
+
+## Table of Contents
+
+1. [What changed in v0.1.0](#what-changed-in-v010)
+2. [Breaking ABI changes](#breaking-abi-changes)
+3. [New storage keys in v0.1.0](#new-storage-keys-in-v010)
+4. [Pre-upgrade checklist](#pre-upgrade-checklist)
+5. [Step-by-step upgrade procedure](#step-by-step-upgrade-procedure)
+6. [Post-upgrade verification](#post-upgrade-verification)
+7. [The `InvalidVersion` error](#the-invalidversion-error)
+8. [Rollback](#rollback)
+
+---
+
+## What changed in v0.1.0
+
+v0.1.0 is the first **stable contract release**. It introduces several features
+that require new storage keys and, in two cases, changes to function signatures
+that break backwards-compatibility with v0.0.x off-chain clients.
+
+### New features
+
+| Feature | Description |
+|---|---|
+| Protocol fee | `ProtocolConfig.protocol_fee_bps` + `fee_recipient`: optional platform fee deducted from winner payouts (draw refunds exempt) |
+| Maximum stake cap | `ProtocolConfig.maximum_stake`: optional upper bound on `stake_amount` per match |
+| Stablecoin-only mode | `ProtocolConfig.stablecoin_only_mode` + `StablecoinIssuer` key: gate new matches to issuer-verified tokens |
+| Token allowlist enforcement | `AllowlistEnforced` flag and `AllowedTokens` list: when at least one token is added via `add_allowed_token`, only listed tokens are accepted |
+| Token blacklist | `BlacklistedToken` and `BlacklistedTokens` keys: block specific tokens from future matches |
+| Player freeze | `admin_freeze_player` / `admin_unfreeze_player`: per-player block without a global pause |
+| Admin stall resolution | `admin_resolve_stalled_match`: recover funds from Active matches stalled > 7 days with no oracle result |
+| Batch result submission | `submit_result_batch`: settle multiple matches in a single transaction |
+| `get_contract_version` | New view function returning the semver version string |
+| `ContractVersion` storage key | Monotonically increasing version integer used to gate `migrate_state` |
+| Oracle consensus | `m-of-n` multi-oracle confirmation before payout; `OracleConfirmations` and `OracleVote` keys |
+| `DepositInProgress` guard | Reentrancy guard on `deposit` using a temporary storage key |
+
+---
+
+## Breaking ABI changes
+
+The following changes will break any v0.0.x off-chain client, script, or
+integration that calls the affected functions.
+
+### 1. `set_protocol_config` — new fields in `ProtocolConfig`
+
+v0.0.x `ProtocolConfig`:
+```rust
+ProtocolConfig {
+    vesting_duration_seconds: u64,
+    cancellation_fee_basis_points: u32,
+    treasury: Address,
+    minimum_stake: i128,
+    stablecoin_only_mode: bool,
+    maximum_stake: Option<i128>,
+    match_timeout_seconds: u64,
+}
+```
+
+v0.1.0 `ProtocolConfig` (new fields **bolded**):
+```rust
+ProtocolConfig {
+    vesting_duration_seconds: u64,
+    cancellation_fee_basis_points: u32,
+    treasury: Address,
+    minimum_stake: i128,
+    stablecoin_only_mode: bool,
+    maximum_stake: Option<i128>,
+    match_timeout_seconds: u64,
+    protocol_fee_bps: u32,         // NEW — basis points fee on winner payout (0 = disabled)
+    fee_recipient: Address,        // NEW — recipient of protocol fee transfers
+    max_protocol_fee: Option<i128>, // NEW — hard ceiling on the absolute fee amount
+}
+```
+
+**Migration action:** Update all `set_protocol_config` call sites to include
+the three new fields. For deployments that do not want a protocol fee, pass:
+```
+protocol_fee_bps = 0
+fee_recipient = <admin address>
+max_protocol_fee = None
+```
+
+### 2. `initialize` — unchanged signature, but `ProtocolConfig` defaults differ
+
+The `initialize` function signature itself did not change, but the default
+`ProtocolConfig` written during initialization now includes the new fields
+described above. No action needed unless you are re-initialising a fresh
+contract from scripts.
+
+### 3. `submit_result_batch` — new function (additive, not breaking)
+
+`submit_result_batch` is new in v0.1.0. It is not a replacement for
+`submit_result`; both exist simultaneously. No migration action required.
+
+### 4. `admin_freeze_player` error reuse
+
+`admin_freeze_player` returns `Error::ContractPaused` (code `#9`) when a
+frozen player attempts to create a match or deposit. This reuses an existing
+error code rather than introducing a new one (the XDR enum is at its 50-variant
+cap). Off-chain clients that previously interpreted `Error(Contract, #9)` as
+"the contract is globally paused" should be updated to also handle the
+per-player freeze case. Check `is_player_frozen(player)` to distinguish the
+two scenarios.
+
+### 5. `get_oracle_address` renamed from `get_oracle`
+
+In v0.0.x the oracle read function was named `get_oracle`. In v0.1.0 it is
+`get_oracle_address`. Update any script or integration that calls `get_oracle`.
+
+---
+
+## New storage keys in v0.1.0
+
+The following `DataKey` variants are new in v0.1.0. They do not exist in
+v0.0.x storage. `migrate_state` back-fills their defaults for in-place
+upgrades (see [Step-by-step upgrade procedure](#step-by-step-upgrade-procedure)).
+
+| DataKey variant | Storage scope | Default value after migration |
+|---|---|---|
+| `ContractVersion` | Instance | `1000` (encodes `0.1.0`) |
+| `AllowlistEnforced` | Instance | `false` |
+| `AllowedTokens` | Instance | `[]` (empty Vec) |
+| `AllowedTokenCount` | Instance | `0` |
+| `BlacklistedToken(addr)` | Instance | _(not back-filled; absent = not blacklisted)_ |
+| `BlacklistedTokens` | Instance | `[]` (empty Vec) |
+| `StablecoinIssuer(addr)` | Instance | _(not back-filled; absent = not registered)_ |
+| `StablecoinIssuerCount` | Instance | `0` |
+| `Stats` | Instance | `PlatformStats { total_matches: 0, total_volume: 0, total_payouts: 0 }` |
+| `OracleConfirmations(match_id)` | Persistent | _(not back-filled; read as `0` by default)_ |
+| `OracleVote(match_id, oracle)` | Persistent | _(not back-filled; absent = no vote)_ |
+| `ApprovedOracles` | Instance | `[]` (empty Vec — single-oracle mode by default) |
+| `RequiredOracleConfirmations` | Instance | `1` (single-oracle mode) |
+| `OracleRotation` | Instance | _(not back-filled; initialised on first rotation)_ |
+| `FeeTiers` | Instance | `[]` (no fee tiers) |
+| `ReferralShareBasisPoints` | Instance | `0` |
+| `PlayerActiveMatchCount(addr)` | Persistent | _(not back-filled; counted from existing active matches by migration)_ |
+| `PlayerCompletedMatchCount(addr)` | Persistent | _(not back-filled; read as `0` by default)_ |
+| `DisputeOracle(match_id)` | Persistent | _(not back-filled)_ |
+| `DepositInProgress(match_id)` | Temporary | _(not back-filled; set/cleared transiently)_ |
+| `PendingAdmin` | Instance | _(not back-filled; absent = no pending transfer)_ |
+
+### Updated `ProtocolConfig` fields
+
+The existing `ProtocolConfig` value stored at the `ProtocolConfig` instance key
+is extended in v0.1.0. `migrate_state` reads the existing struct and writes it
+back with the new fields set to their zero defaults:
+
+- `protocol_fee_bps = 0`
+- `fee_recipient = <admin address>`
+- `max_protocol_fee = None`
+
+If you want non-zero defaults after migration, call `set_protocol_config` after
+`migrate_state` and before `unpause`.
+
+---
+
+## Pre-upgrade checklist
+
+Complete all of these items before scheduling the upgrade on-chain.
+
+- [ ] Back up current contract state: `./scripts/backup_state.sh mainnet`
+- [ ] Build and audit the v0.1.0 WASM: `./scripts/build.sh`
+- [ ] Run the upgrade simulation test suite:
+      `cargo test -p escrow --test upgrade_simulation_tests`
+- [ ] Update all off-chain clients to handle the new `ProtocolConfig` fields
+      (see [Breaking ABI changes](#breaking-abi-changes))
+- [ ] Update any script or tool that calls `get_oracle` to call
+      `get_oracle_address` instead
+- [ ] Decide on initial `protocol_fee_bps` and `fee_recipient` values
+- [ ] Communicate the upcoming upgrade and 7-day review window to users
+- [ ] Publish the new WASM hash publicly (GitHub release, on-chain memo, or
+      Discord announcement) so the community can audit during the review period
+
+---
+
+## Step-by-step upgrade procedure
+
+Replace `$CONTRACT_ESCROW`, `$DEPLOYER_KEYPAIR`, and `$ADMIN_KEYPAIR` with
+the values from your deployment environment.
+
+```bash
+# 1. Build the v0.1.0 WASM
+./scripts/build.sh
+
+# 2. Upload the new WASM to the network and capture its hash
+WASM_HASH=$(stellar contract upload \
+    --wasm target/wasm32-unknown-unknown/release/escrow.wasm \
+    --source $DEPLOYER_KEYPAIR \
+    --network mainnet)
+echo "New WASM hash: $WASM_HASH"
+
+# 3. Schedule the upgrade (starts the 7-day review clock)
+stellar contract invoke \
+    --id $CONTRACT_ESCROW \
+    --source $ADMIN_KEYPAIR \
+    --network mainnet \
+    -- schedule_upgrade --wasm_hash "$WASM_HASH"
+
+# ── Wait 7 days (120,960 ledgers) ──────────────────────────────────────────
+
+# 4. Pause the contract (required before execute_upgrade)
+stellar contract invoke \
+    --id $CONTRACT_ESCROW \
+    --source $ADMIN_KEYPAIR \
+    --network mainnet \
+    -- pause
+
+# 5. Execute the upgrade (replaces the on-chain WASM)
+stellar contract invoke \
+    --id $CONTRACT_ESCROW \
+    --source $ADMIN_KEYPAIR \
+    --network mainnet \
+    -- execute_upgrade
+
+# 6. Run state migration for v0.1.0
+#    target_version = 1000 (encodes 0.1.0: minor=1 → 1*1000 = 1000)
+stellar contract invoke \
+    --id $CONTRACT_ESCROW \
+    --source $ADMIN_KEYPAIR \
+    --network mainnet \
+    -- migrate_state --target_version 1000
+
+# 7. (Optional) configure non-default protocol fee
+stellar contract invoke \
+    --id $CONTRACT_ESCROW \
+    --source $ADMIN_KEYPAIR \
+    --network mainnet \
+    -- set_protocol_config \
+    --config '{
+        "protocol_fee_bps": 50,
+        "fee_recipient": "<TREASURY_ADDRESS>",
+        "max_protocol_fee": null,
+        ... <other existing fields unchanged>
+    }'
+
+# 8. Validate state — confirms all required storage keys are present
+stellar contract invoke \
+    --id $CONTRACT_ESCROW \
+    --source $ADMIN_KEYPAIR \
+    --network mainnet \
+    -- validate_state
+
+# 9. Confirm the version
+stellar contract invoke \
+    --id $CONTRACT_ESCROW \
+    --network mainnet \
+    -- get_contract_version
+# Expected output: "0.1.0"
+
+# 10. Unpause the contract
+stellar contract invoke \
+    --id $CONTRACT_ESCROW \
+    --source $ADMIN_KEYPAIR \
+    --network mainnet \
+    -- unpause
+
+echo "✅ Upgrade to v0.1.0 complete."
+```
+
+---
+
+## Post-upgrade verification
+
+Run each of the following after unpausing to confirm the contract is healthy.
+
+```bash
+# Verify version
+stellar contract invoke --id $CONTRACT_ESCROW --network mainnet \
+    -- get_contract_version
+# Expected: "0.1.0"
+
+# Verify oracle address is unchanged
+stellar contract invoke --id $CONTRACT_ESCROW --network mainnet \
+    -- get_oracle_address
+
+# Verify protocol config was migrated correctly
+stellar contract invoke --id $CONTRACT_ESCROW --network mainnet \
+    -- get_protocol_config
+
+# Confirm an existing Active match is still readable
+stellar contract invoke --id $CONTRACT_ESCROW --network mainnet \
+    -- get_match --match_id <EXISTING_ACTIVE_MATCH_ID>
+
+# Confirm a new match can be created
+stellar contract invoke --id $CONTRACT_ESCROW --network mainnet \
+    --source <PLAYER1_KEYPAIR> \
+    -- create_match \
+    --player1 <PLAYER1_ADDRESS> \
+    --player2 <PLAYER2_ADDRESS> \
+    --stake_amount 100 \
+    --token <TOKEN_ADDRESS> \
+    --game_id "testupgrade1" \
+    --platform Lichess
+
+# Run the automated smoke test
+./scripts/smoke_test.sh mainnet
+```
+
+---
+
+## The `InvalidVersion` error
+
+`migrate_state` enforces version monotonicity. Calling it incorrectly will
+produce `Error(Contract, #49)` (`InvalidVersion`).
+
+| Scenario | Result |
+|---|---|
+| `target_version` equals the current stored version | `InvalidVersion` |
+| `target_version` is lower than the current stored version | `InvalidVersion` |
+| `migrate_state` called a second time with the same version | `InvalidVersion` |
+| `target_version` is higher than the current stored version by more than one step | Succeeds — migration arms for all intermediate steps run in order |
+
+If you see `InvalidVersion`:
+
+```bash
+# Check the current on-chain version
+stellar contract invoke --id $CONTRACT_ESCROW --network mainnet \
+    -- get_contract_version
+
+# Ensure target_version=1000 is correct for 0.1.0
+# The version encoding is: major*1_000_000 + minor*1_000 + patch
+#   0.1.0 → 0*1_000_000 + 1*1_000 + 0 = 1000
+```
+
+Common cause: `migrate_state` was called before `execute_upgrade` completed,
+so the contract is still running v0.0.x code which does not know about version
+1000.
+
+---
+
+## Rollback
+
+### If the upgrade has been scheduled but not yet executed
+
+Cancel the upgrade during the review period:
+
+```bash
+stellar contract invoke \
+    --id $CONTRACT_ESCROW \
+    --source $ADMIN_KEYPAIR \
+    --network mainnet \
+    -- cancel_upgrade
+
+stellar contract invoke \
+    --id $CONTRACT_ESCROW \
+    --source $ADMIN_KEYPAIR \
+    --network mainnet \
+    -- unpause
+```
+
+The contract resumes running v0.0.x as if nothing happened.
+
+### If the upgrade has been executed but `migrate_state` has not yet run
+
+The contract is now running v0.1.0 WASM but storage is still in v0.0.x format.
+**Do not unpause** until `migrate_state` completes. If you need more time,
+keep the contract paused. There is no way to roll back the WASM to v0.0.x
+without a second upgrade cycle.
+
+### If `migrate_state` has run and issues are discovered post-upgrade
+
+There is no on-chain rollback path for Soroban WASM. Options:
+
+1. **Hot-fix release**: prepare a v0.1.1 patch, schedule a new upgrade, and
+   execute after the review period.
+2. **Emergency governance**: if a critical bug is found, the admin can pause
+   the contract to prevent further damage while a fix is prepared.
+3. **New deployment**: as a last resort, deploy a fresh v0.1.1 contract and
+   migrate users. Follow the [Disaster Recovery](disaster-recovery.md) runbook.
+
+Restore a pre-upgrade state backup:
+
+```bash
+# Inspect the backup taken before the upgrade
+./scripts/restore_state.sh mainnet --dry-run
+
+# Apply (only useful for off-chain indexer state; on-chain state is immutable)
+./scripts/restore_state.sh mainnet
+```


### PR DESCRIPTION
Title: feat: oracle troubleshooting guide, batch load test, upgrade guide v0.1.0, error variant regression tests
  
  Body:
  
  Closes  #1373
  Closes  #1374
  Closes  #1375
  Closes  #1376
  
  ## Summary
  
  Four medium-priority issues from the wave-ready backlog, implemented in a single branch.
  
  ---
  
  ### #1373 — Docs: oracle troubleshooting guide
  
  - Added `docs/oracle-troubleshooting.md` — a centralized operator runbook for diagnosing and recovering from common oracle failures:
    - Dead-letter backlog accumulation (per-root-cause diagnosis table, replay commands)
    - RPC connectivity failures (curl diagnostics, fallback RPC options)
    - Lichess API errors (401, 404, 429, GameNotFinished)
    - Chess.com API errors (401, 403, 404, 429, 503)
    - On-chain rate limit errors with remediation commands
    - Stale / unresolvable game IDs (admin stall resolution path)
    - Wrong oracle address configured
    - Replay commands reference table
    - Health check quick-reference with example JSON
  - Updated `docs/oracle.md`: added a callout link at the top of the `## Troubleshooting` section pointing to the new guide.
  
  ---
  
  ### #1374 — Test: submit_result_batch load test (100 matches)
  
  - Added `load_submit_result_batch_100` to `contracts/escrow/tests/load_tests.rs`.
  - Creates 100 Active matches (outside the measured region) then calls `submit_result_batch` with all 100 entries in a single call.
  - Asserts all outcomes are `None` (success) and all matches reach `Completed`.
  - Prints CPU instruction usage as a percentage of the Soroban 100-billion budget cap; emits a warning if usage exceeds 80% so operators know when to reduce the practical batch size.
  - Tagged `#[ignore]` consistent with the rest of the load test suite — run with `cargo test -- --ignored --nocapture`.
  
  ---
  
  ### #1375 — Docs: upgrade guide v0.0.x → v0.1.0
  
  - Added `docs/upgrade-guide-v0.1.0.md` covering:
    - All breaking ABI changes: `ProtocolConfig` three new fields (`protocol_fee_bps`, `fee_recipient`, `max_protocol_fee`), `get_oracle` → `get_oracle_address` rename, player-freeze `ContractPaused` error reuse
    - Complete table of all new storage keys added in v0.1.0 with scope, default value, and back-fill behaviour
    - Step-by-step CLI upgrade procedure (schedule → review period → pause → execute → migrate → validate → unpause)
    - Post-upgrade verification commands
    - `InvalidVersion` error explanation with version encoding table
    - Rollback paths for each phase (pre-execute, post-execute pre-migrate, post-migrate)
  
  ---
  
  ### #1376 — Test: error variant regression suite
  
  - Added `contracts/escrow/src/tests/error_variants.rs` with **one dedicated test per `Error` variant** to prevent accidental renumbering.
    - 34 runtime tests covering all triggerable variants: `MatchNotFound`, `AlreadyFunded`, `NotFunded`, `Unauthorized`, `InvalidState`, `AlreadyExists`, `AlreadyInitialized`, `ContractPaused` (×2: global pause and
  player freeze), `InvalidAmount`, `DuplicateGameId`, `MatchNotExpired`, `InvalidGameId`, `InvalidPlayers`, `TokenNotAllowed`, `InvalidAddress`, `MatchAlreadyActive`, `InvalidTimeout`, `SnapshotNotFound`,
  `VestingNotExpired`, `AlreadyClaimed`, `DisputeNotFound`, `PendingResultNotFound`, `DisputeAlreadyRaised`, `TierStakeNotAllowed`, `NotInitialized`, `InvalidPauseState`, `TooManyActiveMatches`, `NotStablecoin`,
  `UpgradeNotScheduled`, `UpgradeReviewPeriodNotElapsed`, `InvalidVersion`, `UpgradeAlreadyScheduled`, `OracleAlreadyConfirmed`, `NotAnOracle`
    - 2 compile-time `const` discriminant assertions for `Overflow` (#8) and `DepositInProgress` (#55) — these are hard to trigger at runtime but must not be renumbered
  - Registered `mod error_variants` in `contracts/escrow/src/tests/mod.rs`.
  
  ---
  
  ## Testing
  
  - Existing `cargo test` suite is unaffected (new tests are additive).
  - New error variant tests run as part of the standard `cargo test` invocation.
  - Load test is `#[ignore]`-gated; run with `cargo test -p escrow --test load_tests load_submit_result_batch_100 -- --ignored --nocapture`.
 
 