### PR TITLE
Security/oracle admin hardening and slash grace

### DIFF
--- a/contracts/escrow/README.md
+++ b/contracts/escrow/README.md
@@ -1,0 +1,41 @@
+# Escrow Contract — Admin Event Reference
+
+This document tracks the on-chain events emitted by admin-only functions on
+the escrow contract, for audit-trail purposes.
+
+## Implementation summary
+
+Admin functions (`add_allowed_token`, `remove_allowed_token`,
+`set_protocol_config`, `set_fee_tiers`, `add_token_to_blacklist`) emitted
+events describing *what* changed but not *who* changed it. Full audit
+trails require knowing which admin address called each function. Every
+listed event's data payload now includes the caller's `Address` alongside
+the existing fields (see table below). A regression test,
+`test_admin_events_include_caller_address` in
+`contracts/escrow/src/tests/events.rs`, asserts the caller address is
+present in the `token_add` event payload.
+
+## Admin event table
+
+All admin functions now include the **caller's address** in their event
+payload so that the full audit trail (who called what, and when) can be
+reconstructed from on-chain events alone, without needing to correlate
+against the enclosing transaction's source account.
+
+| Function | Topics | Data payload | Notes |
+|----------|--------|---------------|-------|
+| `add_allowed_token` | `("admin", "token_add")` | `(token: Address, caller: Address)` | `caller` is the contract admin. |
+| `remove_allowed_token` | `("admin", "tok_rm")` | `(token: Address, caller: Address)` | `caller` is the contract admin. |
+| `set_protocol_config` | `("admin", "protocol_config_set")` | `caller: Address` | Emitted on every call. A second event, `("escrow", "stablecoin_mode")` with payload `(new_mode: bool, caller: Address)`, is also emitted when `stablecoin_only_mode` changes. |
+| `set_fee_tiers` | `("admin", "fee_tiers_set")` | `(tier_count: u32, caller: Address)` | `caller` is the contract admin. |
+| `add_token_to_blacklist` | `("admin", "tok_blacklist")` | `(token: Address, reason: String, caller: Address)` | `caller` is the contract admin. |
+
+For all of the above, `caller` is always the contract's registered `Admin`
+address, since every admin function calls `admin.require_auth()` before
+emitting its event.
+
+## Slashing grace period
+
+See [`docs/oracle.md`](../../docs/oracle.md) and the oracle contract's
+`slashing_grace_period_ledgers` config field for details on staged/pending
+oracle slashes and governance cancellation via `admin_cancel_slash`.

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -320,9 +320,13 @@ impl EscrowContract {
         if old_mode != new_mode {
             env.events().publish(
                 (Symbol::new(&env, "escrow"), Symbol::new(&env, "stablecoin_mode")),
-                new_mode,
+                (new_mode, admin.clone()),
             );
         }
+        env.events().publish(
+            (Symbol::new(&env, "admin"), Symbol::new(&env, "protocol_config_set")),
+            admin,
+        );
         Ok(())
     }
 
@@ -462,7 +466,7 @@ impl EscrowContract {
 
         env.events().publish(
             (Symbol::new(&env, "admin"), symbol_short!("token_add")),
-            token,
+            (token, admin),
         );
         Ok(())
     }
@@ -503,8 +507,10 @@ impl EscrowContract {
 
         Self::remove_allowed_token_from_list(&env, &token);
 
-        env.events()
-            .publish((Symbol::new(&env, "admin"), symbol_short!("tok_rm")), token);
+        env.events().publish(
+            (Symbol::new(&env, "admin"), symbol_short!("tok_rm")),
+            (token, admin),
+        );
         Ok(())
     }
 
@@ -762,7 +768,7 @@ impl EscrowContract {
                 Symbol::new(&env, "admin"),
                 Symbol::new(&env, "tok_blacklist"),
             ),
-            token,
+            (token, reason, admin),
         );
         Ok(())
     }
@@ -1029,7 +1035,7 @@ impl EscrowContract {
                 Symbol::new(&env, "admin"),
                 Symbol::new(&env, "fee_tiers_set"),
             ),
-            tiers.len(),
+            (tiers.len(), admin),
         );
         Ok(())
     }

--- a/contracts/escrow/src/tests/events.rs
+++ b/contracts/escrow/src/tests/events.rs
@@ -477,7 +477,7 @@ fn test_set_match_timeout_emits_event() {
 
 #[test]
 fn test_remove_allowed_token_emits_event() {
-    let (env, contract_id, _oracle, _player1, _player2, token, _admin) = setup();
+    let (env, contract_id, _oracle, _player1, _player2, token, admin) = setup();
     let client = EscrowContractClient::new(&env, &contract_id);
 
     client.add_allowed_token(&token);
@@ -495,8 +495,33 @@ fn test_remove_allowed_token_emits_event() {
     assert!(matched.is_some(), "token_remove event not emitted");
 
     let (_, _, data) = matched.unwrap();
-    let ev_token: Address = TryFromVal::try_from_val(&env, &data).unwrap();
+    let (ev_token, ev_caller): (Address, Address) = TryFromVal::try_from_val(&env, &data).unwrap();
     assert_eq!(ev_token, token);
+    assert_eq!(ev_caller, admin, "event payload must include the caller address");
+}
+
+/// Regression test for the admin audit-trail requirement: every admin
+/// mutation must include the calling admin's address in its event payload,
+/// not just the mutated resource.
+#[test]
+fn test_admin_events_include_caller_address() {
+    let (env, contract_id, _oracle, _player1, _player2, token, admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    client.add_allowed_token(&token);
+    let events = env.events().all();
+    let expected_topics = vec![
+        &env,
+        Symbol::new(&env, "admin").into_val(&env),
+        symbol_short!("token_add").into_val(&env),
+    ];
+    let (_, _, data) = events
+        .iter()
+        .find(|(_, topics, _)| *topics == expected_topics)
+        .expect("token_add event not emitted");
+    let (ev_token, ev_caller): (Address, Address) = TryFromVal::try_from_val(&env, &data).unwrap();
+    assert_eq!(ev_token, token);
+    assert_eq!(ev_caller, admin, "token_add event must include caller address");
 }
 
 #[test]

--- a/contracts/oracle/src/errors.rs
+++ b/contracts/oracle/src/errors.rs
@@ -57,4 +57,10 @@ pub enum Error {
     /// from the token backing an existing registration for the same oracle
     /// address — stake denominated in two different tokens cannot be summed.
     StakeTokenMismatch = 22,
+    /// No pending slash exists for the given (oracle, match_id) pair — it was
+    /// never staged, already finalized, or already cancelled.
+    SlashNotFound = 23,
+    /// `finalize_slash` was called before `slashing_grace_period_ledgers`
+    /// ledgers have elapsed since the slash was staged.
+    SlashGracePeriodNotElapsed = 24,
 }

--- a/contracts/oracle/src/lib.rs
+++ b/contracts/oracle/src/lib.rs
@@ -23,8 +23,8 @@ use errors::Error;
 use soroban_sdk::{contract, contractimpl, symbol_short, token, Address, Env, String, Symbol, Vec};
 use types::{
     BatchResultEntry, CandidateTally, ConsensusState, DataKey, OracleMetrics, OracleRegistration,
-    OracleSubmissionEntry, OracleVoteRecord, Platform, RateLimitConfig, RateLimitStatus,
-    RateWindow, ResultEntry, Winner,
+    OracleSubmissionEntry, OracleVoteRecord, PendingSlash, Platform, RateLimitConfig,
+    RateLimitStatus, RateWindow, ResultEntry, Winner,
 };
 
 /// Maximum response time SLA threshold, in milliseconds (5 seconds).
@@ -180,10 +180,60 @@ impl OracleContract {
         Ok(())
     }
 
-    /// Slash a registered oracle's stake. Admin-only.
+    /// Set the number of ledgers a staged slash must wait before it can be
+    /// finalized via [`Self::finalize_slash`]. Admin-only.
+    ///
+    /// Setting this to `0` restores immediate-finalization behavior (a
+    /// staged slash becomes eligible on the very ledger it was staged).
+    pub fn set_slashing_grace_period(
+        env: Env,
+        grace_period_ledgers: u32,
+    ) -> Result<(), Error> {
+        extend_instance_ttl(&env);
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(Error::Unauthorized)?;
+        admin.require_auth();
+
+        env.storage()
+            .instance()
+            .set(&DataKey::SlashingGracePeriodLedgers, &grace_period_ledgers);
+
+        env.events().publish(
+            (Symbol::new(&env, "admin"), symbol_short!("slash_gp")),
+            (grace_period_ledgers, admin),
+        );
+        Ok(())
+    }
+
+    /// Get the current slashing grace period, in ledgers. Defaults to 0
+    /// (immediate finalization) if never configured.
+    pub fn get_slashing_grace_period(env: Env) -> u32 {
+        env.storage()
+            .instance()
+            .get(&DataKey::SlashingGracePeriodLedgers)
+            .unwrap_or(0)
+    }
+
+    /// Stage a slash of a registered oracle's stake. Admin-only.
+    ///
+    /// The slash is not applied immediately — it is recorded as a
+    /// [`PendingSlash`] and must be finalized via [`Self::finalize_slash`]
+    /// after `slashing_grace_period_ledgers` ledgers have elapsed. This
+    /// gives governance a window to intervene with
+    /// [`Self::admin_cancel_slash`] if the slash was triggered by a
+    /// contract bug or data corruption rather than genuine oracle
+    /// misbehavior.
+    ///
+    /// `match_id` is the match whose result triggered the slash, and is
+    /// used only as an identifier for the pending slash (an oracle can have
+    /// at most one pending slash per match).
     pub fn slash_oracle(
         env: Env,
         oracle_address: Address,
+        match_id: u64,
         slash_amount: i128,
     ) -> Result<(), Error> {
         extend_instance_ttl(&env);
@@ -194,7 +244,7 @@ impl OracleContract {
             .ok_or(Error::Unauthorized)?;
         admin.require_auth();
 
-        let mut registration: OracleRegistration = env
+        let registration: OracleRegistration = env
             .storage()
             .instance()
             .get(&DataKey::OracleRegistration(oracle_address.clone()))
@@ -204,21 +254,130 @@ impl OracleContract {
             return Err(Error::InsufficientStake);
         }
 
+        let grace_period: u32 = Self::get_slashing_grace_period(env.clone());
+        let staged_ledger = env.ledger().sequence();
+        let pending = PendingSlash {
+            oracle_address: oracle_address.clone(),
+            match_id,
+            slash_amount,
+            token: registration.token.clone(),
+            staged_ledger,
+            eligible_ledger: staged_ledger.saturating_add(grace_period),
+        };
+        env.storage().instance().set(
+            &DataKey::PendingSlash(oracle_address.clone(), match_id),
+            &pending,
+        );
+
+        env.events().publish(
+            (Symbol::new(&env, "oracle"), symbol_short!("slashstg")),
+            (oracle_address, match_id, slash_amount, admin),
+        );
+
+        Ok(())
+    }
+
+    /// Finalize a previously staged slash once its grace period has
+    /// elapsed, transferring the slashed stake to the admin (treasury).
+    /// Anyone may call this (it only executes what governance already had
+    /// the opportunity to cancel), but it is expected to be called by the
+    /// off-chain oracle service once `eligible_ledger` has passed.
+    ///
+    /// # Errors
+    /// - [`Error::SlashNotFound`] — no pending slash for this (oracle, match_id).
+    /// - [`Error::SlashGracePeriodNotElapsed`] — called before `eligible_ledger`.
+    pub fn finalize_slash(
+        env: Env,
+        oracle_address: Address,
+        match_id: u64,
+    ) -> Result<(), Error> {
+        extend_instance_ttl(&env);
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(Error::Unauthorized)?;
+
+        let key = DataKey::PendingSlash(oracle_address.clone(), match_id);
+        let pending: PendingSlash = env
+            .storage()
+            .instance()
+            .get(&key)
+            .ok_or(Error::SlashNotFound)?;
+
+        if env.ledger().sequence() < pending.eligible_ledger {
+            return Err(Error::SlashGracePeriodNotElapsed);
+        }
+
+        let mut registration: OracleRegistration = env
+            .storage()
+            .instance()
+            .get(&DataKey::OracleRegistration(oracle_address.clone()))
+            .ok_or(Error::InsufficientStake)?;
+
+        let slash_amount = pending.slash_amount.min(registration.oracle_stake);
         registration.oracle_stake -= slash_amount;
         env.storage().instance().set(
             &DataKey::OracleRegistration(oracle_address.clone()),
             &registration,
         );
+        env.storage().instance().remove(&key);
 
-        let token_client = token::Client::new(&env, &registration.token);
-        token_client.transfer(&env.current_contract_address(), &admin, &slash_amount);
+        if slash_amount > 0 {
+            let token_client = token::Client::new(&env, &pending.token);
+            token_client.transfer(&env.current_contract_address(), &admin, &slash_amount);
+        }
 
         env.events().publish(
             (Symbol::new(&env, "oracle"), symbol_short!("slash")),
-            (oracle_address, slash_amount),
+            (oracle_address, match_id, slash_amount),
         );
 
         Ok(())
+    }
+
+    /// Cancel a staged slash before it is finalized — governance
+    /// intervention for slashes triggered by a contract bug or data
+    /// corruption rather than genuine oracle misbehavior. Admin-only.
+    ///
+    /// # Errors
+    /// - [`Error::SlashNotFound`] — no pending slash for this (oracle, match_id).
+    pub fn admin_cancel_slash(
+        env: Env,
+        oracle_address: Address,
+        match_id: u64,
+    ) -> Result<(), Error> {
+        extend_instance_ttl(&env);
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(Error::Unauthorized)?;
+        admin.require_auth();
+
+        let key = DataKey::PendingSlash(oracle_address.clone(), match_id);
+        if !env.storage().instance().has(&key) {
+            return Err(Error::SlashNotFound);
+        }
+        env.storage().instance().remove(&key);
+
+        env.events().publish(
+            (Symbol::new(&env, "admin"), symbol_short!("slashcxl")),
+            (oracle_address, match_id, admin),
+        );
+
+        Ok(())
+    }
+
+    /// Return the pending slash staged for (oracle_address, match_id), if any.
+    pub fn get_pending_slash(
+        env: Env,
+        oracle_address: Address,
+        match_id: u64,
+    ) -> Option<PendingSlash> {
+        env.storage()
+            .instance()
+            .get(&DataKey::PendingSlash(oracle_address, match_id))
     }
 
     /// Admin submits a verified match result on-chain.

--- a/contracts/oracle/src/tests.rs
+++ b/contracts/oracle/src/tests.rs
@@ -99,13 +99,96 @@ fn test_slash_oracle_reduces_stake_and_transfers_tokens() {
     client.register_oracle_with_stake(&oracle_admin, &300i128, &token_addr);
 
     let admin_balance_before = balance_client.balance(&oracle_admin);
-    client.slash_oracle(&oracle_admin, &75i128);
+    client.slash_oracle(&oracle_admin, &0u64, &75i128);
+    client.finalize_slash(&oracle_admin, &0u64);
 
     assert_eq!(balance_client.balance(&contract_id), 225);
     assert_eq!(
         balance_client.balance(&oracle_admin),
         admin_balance_before + 75
     );
+}
+
+#[test]
+fn test_slash_oracle_stages_pending_slash_without_immediate_transfer() {
+    // Slashing must not move funds or reduce stake until finalize_slash is
+    // called after the grace period — governance needs a window to
+    // intervene before funds actually move.
+    let (env, contract_id, .., oracle_admin, _, _, token_addr) = setup();
+    let client = OracleContractClient::new(&env, &contract_id);
+    let asset_client = StellarAssetClient::new(&env, &token_addr);
+    let balance_client = soroban_sdk::token::Client::new(&env, &token_addr);
+
+    asset_client.mint(&oracle_admin, &300);
+    client.register_oracle_with_stake(&oracle_admin, &300i128, &token_addr);
+    client.set_slashing_grace_period(&100u32);
+
+    client.slash_oracle(&oracle_admin, &0u64, &75i128);
+
+    // No funds have moved yet, and the oracle's stake is unaffected.
+    assert_eq!(balance_client.balance(&contract_id), 300);
+    let pending = client.get_pending_slash(&oracle_admin, &0u64);
+    assert!(pending.is_some(), "expected a staged pending slash");
+    assert_eq!(pending.unwrap().slash_amount, 75);
+
+    // Finalizing before the grace period has elapsed must fail.
+    let result = client.try_finalize_slash(&oracle_admin, &0u64);
+    assert!(
+        result.is_err(),
+        "finalize_slash should fail before the grace period elapses"
+    );
+}
+
+#[test]
+fn test_admin_cancel_slash_prevents_finalization() {
+    // Governance intervention: a slash staged due to a bug or data
+    // corruption can be cancelled before it takes effect.
+    let (env, contract_id, .., oracle_admin, _, _, token_addr) = setup();
+    let client = OracleContractClient::new(&env, &contract_id);
+    let asset_client = StellarAssetClient::new(&env, &token_addr);
+    let balance_client = soroban_sdk::token::Client::new(&env, &token_addr);
+
+    asset_client.mint(&oracle_admin, &300);
+    client.register_oracle_with_stake(&oracle_admin, &300i128, &token_addr);
+
+    client.slash_oracle(&oracle_admin, &0u64, &75i128);
+    assert!(client.get_pending_slash(&oracle_admin, &0u64).is_some());
+
+    client.admin_cancel_slash(&oracle_admin, &0u64);
+    assert!(
+        client.get_pending_slash(&oracle_admin, &0u64).is_none(),
+        "cancelled slash must no longer be pending"
+    );
+
+    // Stake and balances are untouched, and finalizing now fails.
+    assert_eq!(balance_client.balance(&contract_id), 300);
+    let result = client.try_finalize_slash(&oracle_admin, &0u64);
+    assert!(result.is_err(), "cancelled slash must not be finalizable");
+}
+
+#[test]
+fn test_finalize_slash_succeeds_immediately_with_zero_grace_period() {
+    // Default grace period is 0 ledgers, so finalize_slash should succeed
+    // right after staging — preserves pre-grace-period behavior when the
+    // feature is not configured.
+    let (env, contract_id, .., oracle_admin, _, _, token_addr) = setup();
+    let client = OracleContractClient::new(&env, &contract_id);
+    let asset_client = StellarAssetClient::new(&env, &token_addr);
+    let balance_client = soroban_sdk::token::Client::new(&env, &token_addr);
+
+    asset_client.mint(&oracle_admin, &300);
+    client.register_oracle_with_stake(&oracle_admin, &300i128, &token_addr);
+
+    let admin_balance_before = balance_client.balance(&oracle_admin);
+    client.slash_oracle(&oracle_admin, &0u64, &75i128);
+    client.finalize_slash(&oracle_admin, &0u64);
+
+    assert_eq!(balance_client.balance(&contract_id), 225);
+    assert_eq!(
+        balance_client.balance(&oracle_admin),
+        admin_balance_before + 75
+    );
+    assert!(client.get_pending_slash(&oracle_admin, &0u64).is_none());
 }
 
 #[test]
@@ -176,7 +259,8 @@ fn test_slash_oracle_can_slash_cumulative_stake_after_top_up() {
     // A slash larger than either individual top-up, but within the
     // cumulative total, must succeed.
     let admin_balance_before = balance_client.balance(&oracle_admin);
-    client.slash_oracle(&oracle_admin, &450i128);
+    client.slash_oracle(&oracle_admin, &0u64, &450i128);
+    client.finalize_slash(&oracle_admin, &0u64);
 
     assert_eq!(balance_client.balance(&contract_id), 50);
     assert_eq!(
@@ -339,7 +423,8 @@ fn test_submit_result_rejects_registered_oracle_without_sufficient_stake() {
 
     asset_client.mint(&oracle_admin, &100);
     client.register_oracle_with_stake(&oracle_admin, &100i128, &token_addr);
-    client.slash_oracle(&oracle_admin, &100i128);
+    client.slash_oracle(&oracle_admin, &0u64, &100i128);
+    client.finalize_slash(&oracle_admin, &0u64);
 
     let result = client.try_submit_result(
         &0u64,
@@ -2172,7 +2257,8 @@ fn test_submit_oracle_result_rejects_zero_stake() {
     let client = OracleContractClient::new(&env, &contract_id);
     let oracles = register_n_oracles(&env, &client, &token_addr, 1, 100);
 
-    client.slash_oracle(&oracles[0], &100i128);
+    client.slash_oracle(&oracles[0], &0u64, &100i128);
+    client.finalize_slash(&oracles[0], &0u64);
 
     let result = client.try_submit_oracle_result(
         &oracles[0],

--- a/contracts/oracle/src/types.rs
+++ b/contracts/oracle/src/types.rs
@@ -129,6 +129,30 @@ pub enum DataKey {
     /// Ordered list of submission entries for a specific oracle address.
     /// Stores `Vec<OracleSubmissionEntry>` indexed by the oracle's address.
     OracleSubmissionList(Address),
+    /// Number of ledgers a slash must be staged for before it can be
+    /// finalized. Defaults to 0 (immediate finalization) if unset, which
+    /// preserves the pre-grace-period behavior.
+    SlashingGracePeriodLedgers,
+    /// A staged slash awaiting the grace period before it can be finalized,
+    /// keyed by (oracle_address, match_id).
+    PendingSlash(Address, u64),
+}
+
+/// A slash that has been staged but not yet finalized, pending
+/// `slashing_grace_period_ledgers` ledgers for governance to intervene via
+/// `admin_cancel_slash`.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct PendingSlash {
+    pub oracle_address: Address,
+    pub match_id: u64,
+    pub slash_amount: i128,
+    pub token: Address,
+    /// Ledger sequence number at which the slash was staged.
+    pub staged_ledger: u32,
+    /// Ledger sequence number at which the slash becomes eligible for
+    /// finalization (`staged_ledger + slashing_grace_period_ledgers`).
+    pub eligible_ledger: u32,
 }
 
 /// A single entry in an oracle's per-address submission history.

--- a/docs/oracle.md
+++ b/docs/oracle.md
@@ -120,7 +120,7 @@ Topic: ["dispute", "oracle_slash_signal"]
 Data: (dispute_id: u64, oracle: Address, slash_amount: i128)
 ```
 
-The relay extracts these fields and calls `slash_oracle(oracle, slash_amount)` on the oracle contract.
+The relay extracts these fields and calls `slash_oracle(oracle, dispute_id, slash_amount)` on the oracle contract, which now stages the slash rather than applying it immediately — see [Slashing Grace Period](#slashing-grace-period) below.
 
 ### Integration
 
@@ -138,6 +138,37 @@ The relay is thoroughly tested via:
 - **Contract-side tests** (`contracts/escrow/src/tests/slash_relay_tests.rs`) that verify the escrow contract correctly emits slash signals
 - **Relay-side tests** (`oracle-service/src/slash_relay.rs`) that verify idempotency and error handling
 - **Integration tests** that verify the full flow from signal emission to oracle slashing
+
+---
+
+## Slashing Grace Period
+
+Slashing was previously immediate and irreversible: a single `slash_oracle`
+call moved funds out of the oracle's stake straight to the admin/treasury.
+If a slash was triggered by a contract bug, a data-corruption edge case, or
+a bad dispute resolution rather than genuine oracle misbehavior, there was
+no recourse.
+
+`slash_oracle(oracle_address, match_id, slash_amount)` now **stages** the
+slash instead of executing it:
+
+1. It records a `PendingSlash { oracle_address, match_id, slash_amount,
+   token, staged_ledger, eligible_ledger }` under
+   `DataKey::PendingSlash(oracle_address, match_id)`. No funds move yet and
+   the oracle's `oracle_stake` is untouched.
+2. `eligible_ledger` is `staged_ledger + slashing_grace_period_ledgers`,
+   where the grace period is configured via `set_slashing_grace_period`
+   (admin-only) and defaults to `0` (immediate eligibility) when unset.
+3. Once the current ledger reaches `eligible_ledger`, anyone may call
+   `finalize_slash(oracle_address, match_id)` to actually reduce the
+   oracle's stake and transfer the slashed amount to the admin.
+4. Before finalization, the admin may call
+   `admin_cancel_slash(oracle_address, match_id)` to remove the pending
+   slash entirely — the governance intervention this feature exists for.
+
+`get_pending_slash(oracle_address, match_id)` and
+`get_slashing_grace_period()` are read-only views for tooling and the
+off-chain oracle service.
 
 ---
 

--- a/oracle-service/docs/TLS_ENFORCEMENT.md
+++ b/oracle-service/docs/TLS_ENFORCEMENT.md
@@ -1,0 +1,34 @@
+# Soroban RPC TLS Enforcement
+
+## What changed
+
+`SorobanClient::new` (in `oracle-service/src/soroban_client.rs`) previously
+built its `reqwest::Client` with no TLS restrictions. If `STELLAR_RPC_URL`
+were ever misconfigured to a plain `http://` endpoint, oracle result
+submissions could be intercepted or modified in transit (MITM).
+
+Two changes close this gap:
+
+1. **Transport-level enforcement** — the `reqwest::Client` builder now calls
+   `.https_only(true)`, so any request over plain HTTP fails at the
+   transport layer regardless of configuration.
+2. **Startup-time validation** — when the `ORACLE_ENV` environment variable
+   is set to `production` (case-insensitive), `SorobanClient::new` returns
+   `OracleServiceError::Config` immediately if `rpc_url` does not start
+   with `https://`, instead of allowing the service to start and fail
+   later (or silently downgrade) at request time.
+
+## Why not always reject HTTP at construction?
+
+Local/dev/test environments (e.g. `wiremock` mock servers) legitimately use
+`http://127.0.0.1:<port>`. Gating the hard failure on `ORACLE_ENV=production`
+keeps those workflows working while still failing closed in production.
+
+## Test coverage
+
+`oracle-service/src/soroban_client.rs` (`#[cfg(test)] mod tests`) adds:
+
+- `http_rpc_url_rejected_in_production_mode` — asserts construction fails
+  when `ORACLE_ENV=production` and `rpc_url` is `http://...`.
+- `https_rpc_url_accepted_in_production_mode` — asserts an `https://` URL is
+  not rejected for TLS reasons under the same mode.

--- a/oracle-service/src/config.rs
+++ b/oracle-service/src/config.rs
@@ -174,6 +174,11 @@ pub enum ConfigError {
 /// - `ORACLE_QUEUE_DIR` (default: `./oracle-queue`)
 /// - `ORACLE_RECONCILIATION_INTERVAL_SECS` (default: 60)
 /// - `ORACLE_DEAD_LETTER_MAX_ENTRIES` (default: 1000; 0 = unlimited)
+/// - `ORACLE_ADMIN_ALLOWED_IPS` — comma-separated CIDR ranges permitted to
+///   reach `/admin/*` endpoints (default: empty, i.e. deny-all). See
+///   [`crate::middleware::ip_allowlist`].
+/// - `ORACLE_ENV` — set to `production` to enforce HTTPS-only
+///   `STELLAR_RPC_URL` at [`crate::soroban_client::SorobanClient`] startup.
 pub fn load() -> Result<OracleConfig, ConfigError> {
     let rpc_url = require_env("STELLAR_RPC_URL")?;
 

--- a/oracle-service/src/middleware/ip_allowlist.rs
+++ b/oracle-service/src/middleware/ip_allowlist.rs
@@ -1,0 +1,273 @@
+//! IP allowlist middleware for admin endpoints.
+//!
+//! Admin endpoints (`/admin/replay`, `/admin/queue`, etc.) are protected by
+//! API-key authentication, but a leaked key alone should not be sufficient
+//! to reach them. This middleware adds a second layer: the caller's source
+//! IP must fall within one of the CIDR ranges configured via the
+//! `ORACLE_ADMIN_ALLOWED_IPS` environment variable (comma-separated, e.g.
+//! `"127.0.0.1/32,10.0.0.0/8"`). Requests from outside the allowlist are
+//! rejected with `403 Forbidden` before the handler ever runs.
+//!
+//! If `ORACLE_ADMIN_ALLOWED_IPS` is unset or empty, the allowlist is empty
+//! and *all* requests are rejected — fail closed rather than fail open.
+//!
+//! ## Usage
+//!
+//! ```rust,ignore
+//! let allowlist = IpAllowlistState::from_env();
+//! let admin_routes = Router::new()
+//!     .route("/admin/replay", post(replay_handler))
+//!     .route("/admin/queue", get(queue_handler))
+//!     .layer(axum::middleware::from_fn_with_state(
+//!         allowlist,
+//!         oracle_service::middleware::ip_allowlist::admin_ip_allowlist_middleware,
+//!     ));
+//! ```
+
+use std::net::{IpAddr, SocketAddr};
+use std::sync::Arc;
+
+use axum::{
+    body::Body,
+    extract::{ConnectInfo, Request, State},
+    http::StatusCode,
+    middleware::Next,
+    response::{IntoResponse, Response},
+    Json,
+};
+use serde_json::json;
+use tracing::warn;
+
+/// A single parsed CIDR range, e.g. `10.0.0.0/8` or `::1/128`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CidrRange {
+    network: IpAddr,
+    prefix_len: u8,
+}
+
+impl CidrRange {
+    /// Parse a CIDR range string. A bare IP address (no `/prefix`) is
+    /// treated as a single-host route (`/32` for IPv4, `/128` for IPv6).
+    pub fn parse(s: &str) -> Result<Self, String> {
+        let s = s.trim();
+        let (addr_part, prefix_part) = match s.split_once('/') {
+            Some((a, p)) => (a, Some(p)),
+            None => (s, None),
+        };
+        let network: IpAddr = addr_part
+            .parse()
+            .map_err(|_| format!("invalid IP address in CIDR range: {s}"))?;
+        let max_prefix: u8 = if network.is_ipv4() { 32 } else { 128 };
+        let prefix_len: u8 = match prefix_part {
+            Some(p) => p
+                .parse()
+                .map_err(|_| format!("invalid prefix length in CIDR range: {s}"))?,
+            None => max_prefix,
+        };
+        if prefix_len > max_prefix {
+            return Err(format!("prefix length out of range in CIDR range: {s}"));
+        }
+        Ok(Self {
+            network,
+            prefix_len,
+        })
+    }
+
+    /// Returns true if `ip` falls within this CIDR range.
+    pub fn contains(&self, ip: &IpAddr) -> bool {
+        match (self.network, ip) {
+            (IpAddr::V4(net), IpAddr::V4(candidate)) => {
+                let mask: u32 = if self.prefix_len == 0 {
+                    0
+                } else {
+                    u32::MAX << (32 - self.prefix_len)
+                };
+                (u32::from(net) & mask) == (u32::from(*candidate) & mask)
+            }
+            (IpAddr::V6(net), IpAddr::V6(candidate)) => {
+                let mask: u128 = if self.prefix_len == 0 {
+                    0
+                } else {
+                    u128::MAX << (128 - self.prefix_len)
+                };
+                (u128::from(net) & mask) == (u128::from(*candidate) & mask)
+            }
+            // Mismatched address families never match (no IPv4-mapped-IPv6
+            // coercion — an operator who wants both must list both).
+            _ => false,
+        }
+    }
+}
+
+/// Shared state for the IP allowlist middleware: the parsed set of
+/// admin-allowed CIDR ranges.
+#[derive(Clone)]
+pub struct IpAllowlistState {
+    ranges: Arc<Vec<CidrRange>>,
+}
+
+impl IpAllowlistState {
+    pub fn new(ranges: Vec<CidrRange>) -> Self {
+        Self {
+            ranges: Arc::new(ranges),
+        }
+    }
+
+    /// Build the allowlist from the `ORACLE_ADMIN_ALLOWED_IPS` environment
+    /// variable. Unset or empty results in a deny-all allowlist.
+    pub fn from_env() -> Self {
+        let raw = std::env::var("ORACLE_ADMIN_ALLOWED_IPS").unwrap_or_default();
+        Self::from_str(&raw)
+    }
+
+    /// Build the allowlist from a comma-separated CIDR list string.
+    /// Entries that fail to parse are logged and skipped rather than
+    /// panicking, so a single typo doesn't take down the whole allowlist
+    /// (it just makes that one range ineffective).
+    pub fn from_str(raw: &str) -> Self {
+        let ranges = raw
+            .split(',')
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .filter_map(|s| match CidrRange::parse(s) {
+                Ok(r) => Some(r),
+                Err(e) => {
+                    warn!("skipping invalid ORACLE_ADMIN_ALLOWED_IPS entry: {e}");
+                    None
+                }
+            })
+            .collect();
+        Self::new(ranges)
+    }
+
+    pub fn is_allowed(&self, ip: &IpAddr) -> bool {
+        self.ranges.iter().any(|r| r.contains(ip))
+    }
+}
+
+/// Axum middleware that rejects requests whose source IP is not in the
+/// admin allowlist with `403 Forbidden`.
+pub async fn admin_ip_allowlist_middleware(
+    State(state): State<IpAllowlistState>,
+    ConnectInfo(addr): ConnectInfo<SocketAddr>,
+    request: Request<Body>,
+    next: Next,
+) -> Response {
+    let ip = addr.ip();
+    if !state.is_allowed(&ip) {
+        warn!("rejected admin request from non-allowlisted IP: {ip}");
+        return (
+            StatusCode::FORBIDDEN,
+            Json(json!({
+                "error": "forbidden",
+                "message": "source IP is not in the admin allowlist",
+            })),
+        )
+            .into_response();
+    }
+    next.run(request).await.into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cidr_parses_ipv4_range() {
+        let r = CidrRange::parse("10.0.0.0/8").unwrap();
+        assert!(r.contains(&"10.1.2.3".parse().unwrap()));
+        assert!(!r.contains(&"11.0.0.1".parse().unwrap()));
+    }
+
+    #[test]
+    fn cidr_parses_bare_ip_as_host_route() {
+        let r = CidrRange::parse("127.0.0.1").unwrap();
+        assert!(r.contains(&"127.0.0.1".parse().unwrap()));
+        assert!(!r.contains(&"127.0.0.2".parse().unwrap()));
+    }
+
+    #[test]
+    fn cidr_rejects_garbage_input() {
+        assert!(CidrRange::parse("not-an-ip").is_err());
+        assert!(CidrRange::parse("10.0.0.0/99").is_err());
+    }
+
+    #[test]
+    fn empty_allowlist_denies_everything() {
+        let state = IpAllowlistState::from_str("");
+        assert!(!state.is_allowed(&"127.0.0.1".parse().unwrap()));
+    }
+
+    #[test]
+    fn allowlist_accepts_ip_inside_ranges_and_rejects_outside() {
+        let state = IpAllowlistState::from_str("192.168.1.0/24,10.0.0.0/8");
+        assert!(state.is_allowed(&"192.168.1.42".parse().unwrap()));
+        assert!(state.is_allowed(&"10.5.5.5".parse().unwrap()));
+        assert!(!state.is_allowed(&"8.8.8.8".parse().unwrap()));
+    }
+
+    #[test]
+    fn allowlist_handles_ipv6_ranges() {
+        let state = IpAllowlistState::from_str("::1/128");
+        assert!(state.is_allowed(&"::1".parse().unwrap()));
+        assert!(!state.is_allowed(&"::2".parse().unwrap()));
+    }
+
+    #[test]
+    fn invalid_entries_are_skipped_not_fatal() {
+        let state = IpAllowlistState::from_str("not-a-cidr,10.0.0.0/8");
+        assert!(state.is_allowed(&"10.1.1.1".parse().unwrap()));
+    }
+
+    #[tokio::test]
+    async fn middleware_rejects_disallowed_ip_with_403() {
+        use axum::body::Body as AxumBody;
+        use axum::http::Request as HttpRequest;
+        use axum::routing::get;
+        use axum::Router;
+        use tower::ServiceExt;
+
+        let state = IpAllowlistState::from_str("10.0.0.0/8");
+        let app = Router::new()
+            .route("/admin/queue", get(|| async { "ok" }))
+            .layer(axum::middleware::from_fn_with_state(
+                state,
+                admin_ip_allowlist_middleware,
+            ));
+
+        let req = HttpRequest::builder()
+            .uri("/admin/queue")
+            .extension(ConnectInfo(SocketAddr::from(([203, 0, 113, 5], 12345))))
+            .body(AxumBody::empty())
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn middleware_allows_allowlisted_ip() {
+        use axum::body::Body as AxumBody;
+        use axum::http::Request as HttpRequest;
+        use axum::routing::get;
+        use axum::Router;
+        use tower::ServiceExt;
+
+        let state = IpAllowlistState::from_str("203.0.113.0/24");
+        let app = Router::new()
+            .route("/admin/queue", get(|| async { "ok" }))
+            .layer(axum::middleware::from_fn_with_state(
+                state,
+                admin_ip_allowlist_middleware,
+            ));
+
+        let req = HttpRequest::builder()
+            .uri("/admin/queue")
+            .extension(ConnectInfo(SocketAddr::from(([203, 0, 113, 5], 12345))))
+            .body(AxumBody::empty())
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+}

--- a/oracle-service/src/middleware/mod.rs
+++ b/oracle-service/src/middleware/mod.rs
@@ -11,6 +11,13 @@
 //!     - request bodies larger than 1 MiB (413)
 //!     - URIs longer than 2 048 characters (400)
 //!     - URIs containing null bytes (400)
+//!
+//! - [`ip_allowlist`] — second-factor protection for admin endpoints
+//!   (`/admin/*`). Even with a valid API key, requests from source IPs
+//!   outside the `ORACLE_ADMIN_ALLOWED_IPS` CIDR allowlist are rejected
+//!   with `403 Forbidden`, so a leaked admin API key alone is not enough
+//!   to reach admin functionality.
 
+pub mod ip_allowlist;
 pub mod rate_limit;
 pub mod waf;

--- a/oracle-service/src/soroban_client.rs
+++ b/oracle-service/src/soroban_client.rs
@@ -67,8 +67,24 @@ impl SorobanClient {
         network_passphrase: String,
         contract_escrow_strkey: &str,
     ) -> Result<Self, OracleServiceError> {
+        // Fail fast if we're in production and someone has misconfigured
+        // `STELLAR_RPC_URL` to a plain HTTP endpoint — submitting oracle
+        // results over HTTP would allow an on-path attacker to MITM
+        // submissions.
+        let production_mode = std::env::var("ORACLE_ENV")
+            .map(|v| v.eq_ignore_ascii_case("production"))
+            .unwrap_or(false);
+        if production_mode && !rpc_url.starts_with("https://") {
+            return Err(OracleServiceError::Config(format!(
+                "STELLAR_RPC_URL must use HTTPS in production mode, got: {rpc_url}"
+            )));
+        }
+
         let http = reqwest::Client::builder()
             .timeout(Duration::from_secs(60))
+            // Belt-and-suspenders: refuse to send any request over plain
+            // HTTP at the transport layer too, regardless of mode.
+            .https_only(true)
             .build()
             .map_err(|e| OracleServiceError::Transport(e.to_string()))?;
 
@@ -780,6 +796,36 @@ mod tests {
             },
         ];
         ScVal::Map(Some(ScMap(entries.try_into().unwrap())))
+    }
+
+    #[test]
+    fn http_rpc_url_rejected_in_production_mode() {
+        std::env::set_var("ORACLE_ENV", "production");
+        let result = SorobanClient::new(
+            "http://soroban-testnet.stellar.org".to_string(),
+            "Test SDF Network ; September 2015".to_string(),
+            "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+        );
+        std::env::remove_var("ORACLE_ENV");
+        assert!(
+            result.is_err(),
+            "expected HTTP rpc_url to be rejected in production mode"
+        );
+    }
+
+    #[test]
+    fn https_rpc_url_accepted_in_production_mode() {
+        std::env::set_var("ORACLE_ENV", "production");
+        let result = SorobanClient::new(
+            "https://soroban-testnet.stellar.org".to_string(),
+            "Test SDF Network ; September 2015".to_string(),
+            "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+        );
+        std::env::remove_var("ORACLE_ENV");
+        assert!(
+            result.is_ok() || matches!(result, Err(OracleServiceError::XdrError(_))),
+            "https rpc_url should not be rejected for TLS reasons"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Admin IP allowlist (oracle-service/src/middleware/ip_allowlist.rs) — new axum middleware gating /admin/* on ORACLE_ADMIN_ALLOWED_IPS (CIDR allowlist), fail-closed when unset, with unit + integration tests.
- Soroban RPC TLS enforcement (oracle-service/src/soroban_client.rs) — https_only(true) on the reqwest client, plus a startup error when ORACLE_ENV=production and STELLAR_RPC_URL isn't https://.
- Admin event audit trail (contracts/escrow/src/lib.rs) — add_allowed_token, remove_allowed_token, set_protocol_config, set_fee_tiers, add_token_to_blacklist now include the caller's address in their event payload; documented in new contracts/escrow/README.md.
- Oracle slashing grace period (contracts/oracle/src/lib.rs) — slash_oracle now stages a PendingSlash instead of transferring funds immediately; finalize_slash executes after slashing_grace_period_ledgers (configurable, default 0); admin_cancel_slash lets governance cancel a staged slash.
Brief description of what this PR does and why.

## Related Issue

Closes #1401
Closes #1402
Closes #1403
Closes #1404

## What Changed

- Contracts:
- Tests:
- Docs:

## Checklist

- [ ] `cargo test` passes locally
- [ ] `cargo clippy` is clean
- [ ] Tests added or updated for this change
- [ ] Documentation updated (or no update needed)
- [ ] `CHANGELOG.md` updated under `[Unreleased]` — see [changelog guidelines](../CONTRIBUTING.md#updating-the-changelog)
