### PR TITLE
Feature/frontend docs enhancements 1

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -165,6 +165,52 @@ The contract enforces state validation at every entry point. Invalid transitions
 
 All invalid attempts return `InvalidState` error.
 
+## API Versioning
+
+The Event Indexer (and other off-chain HTTP services, e.g. the Oracle service) expose a
+versioned REST API so that clients can rely on stable contracts while the backend evolves.
+
+### Versioning Scheme
+
+- All indexer HTTP endpoints are served under a URI version prefix: `/v1/...`
+  (e.g. `/v1/indexer/events`, `/v1/indexer/matches`, `/v1/indexer/match/{match_id}`).
+- The version segment refers to the **API contract**, not the service's internal release
+  version. Internal releases (bug fixes, performance work, new optional fields) do not bump
+  the version.
+- Unversioned infrastructure endpoints (`/health`, `/indexer/health`) are excluded from
+  versioning since they are liveness/readiness probes, not data contracts.
+- A new major version (`/v2/`, `/v3/`, ...) is introduced only when a **breaking change**
+  is required. Non-breaking changes (new optional fields, new endpoints, new optional query
+  parameters) are shipped within the current version.
+
+### Breaking Change Policy
+
+A change is considered breaking if it does any of the following to an existing `/vN/` endpoint:
+
+- Removes or renames a field, endpoint, or query parameter
+- Changes the type or semantics of an existing field
+- Changes existing default behavior in a way that changes response shape or values
+- Tightens validation such that previously-valid requests are rejected
+
+Additive, backward-compatible changes (new optional fields, new endpoints, new enum
+variants clients are expected to treat as opaque strings) are **not** breaking and are
+released within the current version without a deprecation cycle.
+
+### Deprecation Notice Period
+
+When a breaking change requires a new major version:
+
+1. The new version (`/vN+1/`) is released alongside the existing version.
+2. The previous version is marked `Deprecated` in `docs/openapi.yaml` and in the
+   `Deprecation` / `Sunset` HTTP response headers returned by deprecated endpoints.
+3. The deprecated version remains fully supported for a minimum of **90 days** from the
+   date the replacement version ships.
+4. After the notice period, the deprecated version may be removed in a subsequent release;
+   removal is announced in `CHANGELOG.md` at least 2 weeks in advance of the removal date.
+
+Security fixes are backported to all supported versions for the duration of their
+deprecation window, regardless of this policy.
+
 ## Stable Public API
 
 The following types and contract functions are considered stable. External integrations and tooling should rely only on these.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -21,6 +21,12 @@ info:
     > interactively. Use the provided `curl` / JS / Python / Rust examples to see how to invoke them
     > with the Stellar CLI or SDKs.
 
+    ## API Versioning
+
+    Event Indexer HTTP endpoints are versioned via a URI prefix (`/v1/...`). See
+    "API Versioning" in `docs/architecture.md` for the deprecation notice period and
+    breaking-change policy. `/health` and `/indexer/health` are unversioned liveness probes.
+
     ## Match Lifecycle
 
     ```
@@ -2435,7 +2441,7 @@ paths:
                   detail:
                     type: string
 
-  /indexer/events:
+  /v1/indexer/events:
     get:
       tags: [Event Indexer]
       summary: Query indexed events with optional filters
@@ -2504,7 +2510,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ApiError'
 
-  /indexer/events/{match_id}:
+  /v1/indexer/events/{match_id}:
     get:
       tags: [Event Indexer]
       summary: Get all events for a specific match
@@ -2554,7 +2560,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ApiError'
 
-  /indexer/matches:
+  /v1/indexer/matches:
     get:
       tags: [Event Indexer]
       summary: List matches, optionally filtered by status
@@ -2589,7 +2595,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ApiError'
 
-  /indexer/match/{match_id}:
+  /v1/indexer/match/{match_id}:
     get:
       tags: [Event Indexer]
       summary: Get full match summary with all events
@@ -2626,7 +2632,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ApiError'
 
-  /indexer/stats:
+  /v1/indexer/stats:
     get:
       tags: [Event Indexer]
       summary: Get service-level statistics

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,15 +1,25 @@
 import { useWallet } from './hooks/useWallet'
 import { WalletConnector } from './components/wallet/WalletConnector'
 import { AdminPanel } from './pages/AdminPanel'
+import { MatchDetailPage } from './pages/MatchDetailPage'
 import './App.css'
+
+/** Matches deep-links of the form /match/1234 */
+const MATCH_ROUTE = /^\/match\/(\d+)$/
 
 function App() {
   const wallet = useWallet()
   const isAdmin = new URLSearchParams(window.location.search).get('admin') === '1'
     || window.location.pathname === '/admin'
 
+  const matchRouteMatch = window.location.pathname.match(MATCH_ROUTE)
+
   if (isAdmin) {
     return <AdminPanel wallet={wallet} />
+  }
+
+  if (matchRouteMatch) {
+    return <MatchDetailPage matchId={Number(matchRouteMatch[1])} />
   }
 
   return (

--- a/frontend/src/components/MatchList.tsx
+++ b/frontend/src/components/MatchList.tsx
@@ -8,6 +8,8 @@ interface Match {
   token: string;
   status: 'pending' | 'active' | 'completed' | 'cancelled';
   platform: 'lichess' | 'chessdotcom';
+  /** Decimal places for `token`; when set, stakeAmount is formatted from raw units. */
+  tokenDecimals?: number;
 }
 
 interface MatchListProps {

--- a/frontend/src/components/StakeAmountInput.tsx
+++ b/frontend/src/components/StakeAmountInput.tsx
@@ -1,4 +1,5 @@
 import React, { useId } from 'react';
+import { formatTokenAmount } from '../utils/tokenFormat';
 
 export type StakeAmountInputProps = {
   /** HTML id for the input element – needed for label association */
@@ -17,6 +18,12 @@ export type StakeAmountInputProps = {
   maximum_stake?: number;
   /** Alias max */
   max?: number;
+  /**
+   * Decimal places for `tokenSymbol` (e.g. 7 for most Stellar assets). When
+   * set, the input is treated as accepting a raw integer (stroops) amount
+   * and a human-readable preview is shown below the field.
+   */
+  tokenDecimals?: number;
 };
 
 /**
@@ -35,10 +42,13 @@ export const StakeAmountInput: React.FC<StakeAmountInputProps> = ({
   minimum_stake,
   maximum_stake,
   max,
+  tokenDecimals,
 }) => {
   const errorId = useId();
   const numericValue = Number(value);
   const isValidNumber = !isNaN(numericValue) && value.trim() !== '';
+  const humanReadablePreview =
+    tokenDecimals !== undefined && isValidNumber ? formatTokenAmount(value, tokenDecimals) : null;
 
   const effectiveMin = minimum_stake !== undefined ? minimum_stake : min;
   const effectiveMax = maximum_stake !== undefined ? maximum_stake : max;
@@ -95,6 +105,11 @@ export const StakeAmountInput: React.FC<StakeAmountInputProps> = ({
       {hasError && (
         <span id={errorId} role="alert" style={{ color: 'red', fontSize: '0.875rem' }}>
           {errorMessage}
+        </span>
+      )}
+      {humanReadablePreview !== null && !hasError && (
+        <span style={{ display: 'block', fontSize: '0.75rem', color: '#666' }}>
+          ≈ {humanReadablePreview} {tokenSymbol}
         </span>
       )}
     </div>

--- a/frontend/src/components/match/MatchCard.tsx
+++ b/frontend/src/components/match/MatchCard.tsx
@@ -1,4 +1,5 @@
 import { MatchStatusBadge } from './MatchStatusBadge';
+import { formatTokenAmount } from '../../utils/tokenFormat';
 
 interface MatchCardProps {
   matchId: number;
@@ -8,9 +9,19 @@ interface MatchCardProps {
   token: string;
   status: 'pending' | 'active' | 'completed' | 'cancelled';
   platform: 'lichess' | 'chessdotcom';
+  /**
+   * Decimal places for `token` (e.g. 7 for most Stellar assets). When
+   * provided, `stakeAmount` is treated as a raw integer (stroops) and
+   * formatted to a human-readable decimal string. When omitted,
+   * `stakeAmount` is rendered as-is for backward compatibility.
+   */
+  tokenDecimals?: number;
 }
 
-export function MatchCard({ matchId, player1, player2, stakeAmount, token, status, platform }: MatchCardProps) {
+export function MatchCard({ matchId, player1, player2, stakeAmount, token, status, platform, tokenDecimals }: MatchCardProps) {
+  const displayStake =
+    tokenDecimals !== undefined ? formatTokenAmount(stakeAmount, tokenDecimals) : stakeAmount;
+
   return (
     <div>
       <div>
@@ -20,7 +31,7 @@ export function MatchCard({ matchId, player1, player2, stakeAmount, token, statu
       <dl>
         <dt>Player 1</dt><dd>{player1}</dd>
         <dt>Player 2</dt><dd>{player2}</dd>
-        <dt>Stake</dt><dd>{stakeAmount} {token}</dd>
+        <dt>Stake</dt><dd>{displayStake} {token}</dd>
         <dt>Platform</dt><dd>{platform === 'lichess' ? 'Lichess' : 'Chess.com'}</dd>
       </dl>
     </div>

--- a/frontend/src/components/match/MatchDetail.test.tsx
+++ b/frontend/src/components/match/MatchDetail.test.tsx
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MatchDetail, buildMatchLink } from './MatchDetail';
+
+const baseProps = {
+  matchId: 1234,
+  player1: 'GAAA',
+  player2: 'GBBB',
+  stakeAmount: '50',
+  token: 'USDC',
+  status: 'active' as const,
+  platform: 'lichess' as const,
+};
+
+describe('MatchDetail - Copy Link', () => {
+  let writeText: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    writeText = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+  });
+
+  it('builds the correct deep-link URL', () => {
+    expect(buildMatchLink(1234, 'https://app.checkmate-escrow.xyz')).toBe(
+      'https://app.checkmate-escrow.xyz/match/1234',
+    );
+  });
+
+  it('copies the correct match URL to the clipboard when clicked', async () => {
+    render(<MatchDetail {...baseProps} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Copy Link' }));
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledTimes(1));
+    expect(writeText).toHaveBeenCalledWith(`${window.location.origin}/match/1234`);
+  });
+
+  it('shows confirmation text after copying', async () => {
+    render(<MatchDetail {...baseProps} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Copy Link' }));
+
+    await waitFor(() => expect(screen.getByRole('button').textContent).toBe('Link copied!'));
+  });
+});

--- a/frontend/src/components/match/MatchDetail.tsx
+++ b/frontend/src/components/match/MatchDetail.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { MatchStatusBadge } from './MatchStatusBadge';
+import { formatTokenAmount } from '../../utils/tokenFormat';
 
 export interface MatchDetailProps {
   matchId: number;
@@ -9,6 +10,8 @@ export interface MatchDetailProps {
   token: string;
   status: 'pending' | 'active' | 'completed' | 'cancelled';
   platform: 'lichess' | 'chessdotcom';
+  /** Decimal places for `token`; when set, stakeAmount is formatted from raw units. */
+  tokenDecimals?: number;
 }
 
 /**
@@ -27,8 +30,11 @@ export function MatchDetail({
   token,
   status,
   platform,
+  tokenDecimals,
 }: MatchDetailProps) {
   const [copied, setCopied] = useState(false);
+  const displayStake =
+    tokenDecimals !== undefined ? formatTokenAmount(stakeAmount, tokenDecimals) : stakeAmount;
 
   const handleCopyLink = async () => {
     const link = buildMatchLink(matchId);
@@ -51,7 +57,7 @@ export function MatchDetail({
       <dl>
         <dt>Player 1</dt><dd>{player1}</dd>
         <dt>Player 2</dt><dd>{player2}</dd>
-        <dt>Stake</dt><dd>{stakeAmount} {token}</dd>
+        <dt>Stake</dt><dd>{displayStake} {token}</dd>
         <dt>Platform</dt><dd>{platform === 'lichess' ? 'Lichess' : 'Chess.com'}</dd>
       </dl>
       <button type="button" onClick={handleCopyLink}>

--- a/frontend/src/components/match/MatchDetail.tsx
+++ b/frontend/src/components/match/MatchDetail.tsx
@@ -1,0 +1,62 @@
+import { useState } from 'react';
+import { MatchStatusBadge } from './MatchStatusBadge';
+
+export interface MatchDetailProps {
+  matchId: number;
+  player1: string;
+  player2: string;
+  stakeAmount: string;
+  token: string;
+  status: 'pending' | 'active' | 'completed' | 'cancelled';
+  platform: 'lichess' | 'chessdotcom';
+}
+
+/**
+ * Builds the shareable deep-link URL for a given match, e.g. `/match/1234`.
+ * Exported for reuse/testing outside of the component's click handler.
+ */
+export function buildMatchLink(matchId: number, origin: string = window.location.origin): string {
+  return `${origin}/match/${matchId}`;
+}
+
+export function MatchDetail({
+  matchId,
+  player1,
+  player2,
+  stakeAmount,
+  token,
+  status,
+  platform,
+}: MatchDetailProps) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopyLink = async () => {
+    const link = buildMatchLink(matchId);
+    try {
+      await navigator.clipboard.writeText(link);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Clipboard API unavailable (e.g. insecure context) - fail silently,
+      // the button remains usable for a retry.
+    }
+  };
+
+  return (
+    <section aria-label={`Match ${matchId} details`}>
+      <header>
+        <h2>Match #{matchId}</h2>
+        <MatchStatusBadge status={status} />
+      </header>
+      <dl>
+        <dt>Player 1</dt><dd>{player1}</dd>
+        <dt>Player 2</dt><dd>{player2}</dd>
+        <dt>Stake</dt><dd>{stakeAmount} {token}</dd>
+        <dt>Platform</dt><dd>{platform === 'lichess' ? 'Lichess' : 'Chess.com'}</dd>
+      </dl>
+      <button type="button" onClick={handleCopyLink}>
+        {copied ? 'Link copied!' : 'Copy Link'}
+      </button>
+    </section>
+  );
+}

--- a/frontend/src/hooks/useMatchWebSocket.test.ts
+++ b/frontend/src/hooks/useMatchWebSocket.test.ts
@@ -246,6 +246,44 @@ describe('useMatchWebSocket', () => {
         expect(allInstances.length).toBeGreaterThan(initialCount);
       });
     });
+
+    it('exposes reconnectAttempts and uses increasing delays across three attempts', async () => {
+      const { result } = renderHook(() => useMatchWebSocket({ url: 'ws://localhost:8090' }));
+      expect(result.current.reconnectAttempts).toBe(0);
+
+      const getInstances = () =>
+        (MockWebSocket as unknown as { instances: MockWebSocket[] }).instances;
+
+      // Attempt 1: close without ever connecting -> backoff = 1s (2^0 * 1000)
+      let ws = MockWebSocket.lastInstance();
+      act(() => ws.simulateClose());
+      await waitFor(() => expect(result.current.reconnectAttempts).toBe(1));
+
+      act(() => vi.advanceTimersByTime(999));
+      expect(getInstances().length).toBe(1); // not yet reconnected
+      act(() => vi.advanceTimersByTime(600)); // + jitter headroom
+      await waitFor(() => expect(getInstances().length).toBe(2));
+
+      // Attempt 2: backoff = 2s (2^1 * 1000)
+      ws = MockWebSocket.lastInstance();
+      act(() => ws.simulateClose());
+      await waitFor(() => expect(result.current.reconnectAttempts).toBe(2));
+
+      act(() => vi.advanceTimersByTime(1999));
+      expect(getInstances().length).toBe(2); // still waiting - longer delay than attempt 1
+      act(() => vi.advanceTimersByTime(600));
+      await waitFor(() => expect(getInstances().length).toBe(3));
+
+      // Attempt 3: backoff = 4s (2^2 * 1000)
+      ws = MockWebSocket.lastInstance();
+      act(() => ws.simulateClose());
+      await waitFor(() => expect(result.current.reconnectAttempts).toBe(3));
+
+      act(() => vi.advanceTimersByTime(3999));
+      expect(getInstances().length).toBe(3); // still waiting - longer delay than attempt 2
+      act(() => vi.advanceTimersByTime(600));
+      await waitFor(() => expect(getInstances().length).toBe(4));
+    });
   });
 
   describe('enabled flag', () => {

--- a/frontend/src/hooks/useMatchWebSocket.ts
+++ b/frontend/src/hooks/useMatchWebSocket.ts
@@ -82,6 +82,12 @@ export interface UseMatchWebSocketReturn {
   events: IndexedEvent[];
   /** Error message if status === 'error' */
   error: string | null;
+  /**
+   * Number of consecutive reconnection attempts made since the last
+   * successful connection. Resets to 0 on a successful 'welcome' handshake.
+   * Useful for showing "Reconnecting… (attempt N)" in the UI.
+   */
+  reconnectAttempts: number;
   /** Force a re-connection (e.g. after an error) */
   reconnect: () => void;
 }
@@ -133,6 +139,7 @@ export function useMatchWebSocket({
   const [latestEvent, setLatestEvent] = useState<IndexedEvent | null>(null);
   const [events, setEvents] = useState<IndexedEvent[]>([]);
   const [error, setError] = useState<string | null>(null);
+  const [reconnectAttempts, setReconnectAttempts] = useState(0);
 
   // Adjust status synchronously during render when `enabled` flips to false,
   // instead of from inside an effect (avoids a cascading extra render).
@@ -210,6 +217,7 @@ export function useMatchWebSocket({
       switch (msg.type) {
         case 'welcome': {
           retryCountRef.current = 0; // reset back-off on successful handshake
+          setReconnectAttempts(0);
           setStatus('subscribing');
           const ids = matchIdsRef.current;
           const addrs = playerAddressesRef.current;
@@ -266,9 +274,10 @@ export function useMatchWebSocket({
       const backoff = Math.min(BASE_BACKOFF_MS * 2 ** retryCountRef.current, MAX_BACKOFF_MS);
       const jitter = Math.random() * 500;
       retryCountRef.current += 1;
+      setReconnectAttempts(retryCountRef.current);
 
       setStatus('reconnecting');
-      setError(`Disconnected (${reason}). Reconnecting in ${Math.round(backoff)}ms…`);
+      setError(`Disconnected (${reason}). Reconnecting in ${Math.round(backoff)}ms… (attempt ${retryCountRef.current})`);
 
       retryTimerRef.current = setTimeout(() => {
         if (enabledRef.current || reconnectRequestedRef.current) {
@@ -338,10 +347,11 @@ export function useMatchWebSocket({
     clearRetryTimer();
     reconnectRequestedRef.current = true;
     retryCountRef.current = 0;
+    setReconnectAttempts(0);
     setStatus('connecting');
     setError(null);
     connect();
   }, [connect, clearRetryTimer]);
 
-  return { status, latestEvent, events, error, reconnect };
+  return { status, latestEvent, events, error, reconnectAttempts, reconnect };
 }

--- a/frontend/src/pages/MatchDetailPage.tsx
+++ b/frontend/src/pages/MatchDetailPage.tsx
@@ -1,0 +1,26 @@
+import { MatchDetail } from '../components/match/MatchDetail';
+
+/**
+ * Route target for `/match/:matchId`.
+ *
+ * This app does not depend on a routing library; App.tsx matches the path
+ * with a simple regex and renders this page directly with the parsed id.
+ * Real match data would be fetched by matchId here (e.g. via the indexer's
+ * `/v1/indexer/match/{match_id}` endpoint) - wired up separately from the
+ * deep-linking work this page exists for.
+ */
+export function MatchDetailPage({ matchId }: { matchId: number }) {
+  return (
+    <main id="match-detail-page">
+      <MatchDetail
+        matchId={matchId}
+        player1="—"
+        player2="—"
+        stakeAmount="—"
+        token=""
+        status="pending"
+        platform="lichess"
+      />
+    </main>
+  );
+}

--- a/frontend/src/utils/tokenFormat.test.ts
+++ b/frontend/src/utils/tokenFormat.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { formatTokenAmount } from './tokenFormat';
+
+describe('formatTokenAmount', () => {
+  it('formats 1_000_000 stroops of a 7-decimal token as "0.1"', () => {
+    expect(formatTokenAmount(1_000_000, 7)).toBe('0.1');
+  });
+
+  it('formats a whole-number amount with no remainder', () => {
+    expect(formatTokenAmount(2_500_000_000, 7)).toBe('250');
+  });
+
+  it('formats string input the same as numeric input', () => {
+    expect(formatTokenAmount('1000000', 7)).toBe('0.1');
+  });
+
+  it('handles 0 decimals by returning the raw integer', () => {
+    expect(formatTokenAmount(42, 0)).toBe('42');
+  });
+
+  it('handles negative amounts', () => {
+    expect(formatTokenAmount(-1_000_000, 7)).toBe('-0.1');
+  });
+
+  it('trims trailing zero fraction digits', () => {
+    expect(formatTokenAmount(1_500_000_0, 7)).toBe('1.5');
+  });
+});

--- a/frontend/src/utils/tokenFormat.ts
+++ b/frontend/src/utils/tokenFormat.ts
@@ -1,0 +1,75 @@
+import {
+  Account,
+  BASE_FEE,
+  Contract,
+  Keypair,
+  Networks,
+  SorobanRpc,
+  TransactionBuilder,
+  scValToNative,
+  xdr,
+} from '@stellar/stellar-sdk';
+
+const SOROBAN_RPC_URL = import.meta.env.VITE_SOROBAN_RPC_URL ?? 'https://soroban-testnet.stellar.org';
+const NETWORK_PASSPHRASE = import.meta.env.VITE_STELLAR_NETWORK_PASSPHRASE ?? Networks.TESTNET;
+
+const decimalsCache = new Map<string, number>();
+
+/**
+ * Formats a raw on-chain integer amount (stroops, or the smallest unit of
+ * any Stellar token) into a human-readable decimal string using the
+ * token's `decimals` value.
+ *
+ * @example formatTokenAmount(1_000_000, 7) === "0.1"
+ * @example formatTokenAmount("2500000000", 7) === "250"
+ */
+export function formatTokenAmount(rawAmount: string | number | bigint, decimals: number): string {
+  const raw = BigInt(rawAmount);
+  if (decimals <= 0) return raw.toString();
+
+  const negative = raw < 0n;
+  const abs = negative ? -raw : raw;
+  const divisor = 10n ** BigInt(decimals);
+  const whole = abs / divisor;
+  const fraction = (abs % divisor).toString().padStart(decimals, '0').replace(/0+$/, '');
+
+  const result = fraction.length > 0 ? `${whole}.${fraction}` : whole.toString();
+  return negative ? `-${result}` : result;
+}
+
+/**
+ * Reads the `decimals()` value from a Soroban token contract (SEP-41 /
+ * Stellar Asset Contract interface) via a read-only simulation, since
+ * `decimals` never changes for a given token. Results are cached per
+ * contract id for the lifetime of the page.
+ */
+export async function fetchTokenDecimals(
+  tokenContractId: string,
+  rpcUrl: string = SOROBAN_RPC_URL,
+): Promise<number> {
+  const cached = decimalsCache.get(tokenContractId);
+  if (cached !== undefined) return cached;
+
+  const server = new SorobanRpc.Server(rpcUrl);
+  const contract = new Contract(tokenContractId);
+  // Simulation-only source account: sequence number is irrelevant since the
+  // transaction is never submitted, only simulated to read `decimals()`.
+  const simulationAccount = new Account(Keypair.random().publicKey(), '0');
+
+  const tx = new TransactionBuilder(simulationAccount, {
+    fee: BASE_FEE,
+    networkPassphrase: NETWORK_PASSPHRASE,
+  })
+    .addOperation(contract.call('decimals'))
+    .setTimeout(30)
+    .build();
+
+  const sim = await server.simulateTransaction(tx);
+  if (!SorobanRpc.Api.isSimulationSuccess(sim) || !sim.result) {
+    throw new Error(`Failed to fetch decimals for token ${tokenContractId}`);
+  }
+
+  const decimals = scValToNative(sim.result.retval as xdr.ScVal) as number;
+  decimalsCache.set(tokenContractId, decimals);
+  return decimals;
+}


### PR DESCRIPTION
## Summary
1. 482ac08 – WS reconnect backoff visibility: exposed reconnectAttempts state from useMatchWebSocket (backoff logic already existed) + test for increasing delays across 3 attempts.
2. ccdef26 – Documented API versioning strategy in docs/architecture.md (URI scheme, 90-day deprecation window, breaking-change policy) and applied /v1/ prefix to indexer endpoints in docs/openapi.yaml.
3. 6e1520f – Added /match/:matchId routing (no new deps) + MatchDetail component with a "Copy Link" button and clipboard test.
4. 206eee8 – Added utils/tokenFormat.ts (formatTokenAmount, fetchTokenDecimals) and wired an optional tokenDecimals prop through MatchCard, MatchList, StakeAmountInput, MatchDetail for human-readable stroop display, with tests including the 1_000_000 @ 7 decimals → "0.1" case.

Brief description of what this PR does and why.

## Related Issue

Closes #1425
Closes #1426
Closes #1427
Closes #1428 


## What Changed

- Contracts:
- Tests:
- Docs:

## Checklist

- [ ] `cargo test` passes locally
- [ ] `cargo clippy` is clean
- [ ] Tests added or updated for this change
- [ ] Documentation updated (or no update needed)
- [ ] `CHANGELOG.md` updated under `[Unreleased]` — see [changelog guidelines](../CONTRIBUTING.md#updating-the-changelog)
