### PR TITLE
Feature/deploy health check dark mode lichess import skeleton loader

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,7 @@
 import { useWallet } from './hooks/useWallet'
 import { WalletConnector } from './components/wallet/WalletConnector'
 import { AdminPanel } from './pages/AdminPanel'
+import { ThemeToggle } from './components/ThemeToggle'
 import './App.css'
 
 function App() {
@@ -14,6 +15,7 @@ function App() {
 
   return (
     <main id="landing">
+      <ThemeToggle />
       <h1>Checkmate-Escrow</h1>
       <p className="tagline">Trustless chess wagering on Stellar — stake, play, get paid instantly.</p>
       <WalletConnector wallet={wallet} />

--- a/frontend/src/components/ThemeToggle.test.tsx
+++ b/frontend/src/components/ThemeToggle.test.tsx
@@ -1,0 +1,62 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { ThemeToggle } from './ThemeToggle';
+
+// WCAG AA requires a contrast ratio >= 4.5:1 for normal body text.
+function relativeLuminance(hex: string): number {
+  const c = hex.replace('#', '');
+  const r = parseInt(c.slice(0, 2), 16) / 255;
+  const g = parseInt(c.slice(2, 4), 16) / 255;
+  const b = parseInt(c.slice(4, 6), 16) / 255;
+  const [rl, gl, bl] = [r, g, b].map(v =>
+    v <= 0.03928 ? v / 12.92 : Math.pow((v + 0.055) / 1.055, 2.4),
+  );
+  return 0.2126 * rl + 0.7152 * gl + 0.0722 * bl;
+}
+
+function contrastRatio(hex1: string, hex2: string): number {
+  const l1 = relativeLuminance(hex1);
+  const l2 = relativeLuminance(hex2);
+  const [lighter, darker] = l1 > l2 ? [l1, l2] : [l2, l1];
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+describe('ThemeToggle', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    document.documentElement.removeAttribute('data-theme');
+  });
+
+  test('renders and toggles the theme attribute on <html>', () => {
+    render(<ThemeToggle />);
+    const button = screen.getByRole('button');
+
+    fireEvent.click(button);
+    const themeAfterFirstClick = document.documentElement.getAttribute('data-theme');
+    expect(['light', 'dark']).toContain(themeAfterFirstClick);
+
+    fireEvent.click(button);
+    const themeAfterSecondClick = document.documentElement.getAttribute('data-theme');
+    expect(themeAfterSecondClick).not.toBe(themeAfterFirstClick);
+  });
+
+  test('persists the chosen theme in localStorage', () => {
+    render(<ThemeToggle />);
+    fireEvent.click(screen.getByRole('button'));
+    expect(window.localStorage.getItem('checkmate-escrow-theme')).toMatch(/^(light|dark)$/);
+  });
+
+  test('dark theme body text meets WCAG AA contrast against background', () => {
+    // --text: #c3c8d1 on --bg: #16171d
+    expect(contrastRatio('#c3c8d1', '#16171d')).toBeGreaterThanOrEqual(4.5);
+  });
+
+  test('dark theme heading text meets WCAG AA contrast against background', () => {
+    // --text-h: #f3f4f6 on --bg: #16171d
+    expect(contrastRatio('#f3f4f6', '#16171d')).toBeGreaterThanOrEqual(4.5);
+  });
+
+  test('light theme body text meets WCAG AA contrast against background', () => {
+    // --text: #514a5b on --bg: #fff
+    expect(contrastRatio('#514a5b', '#ffffff')).toBeGreaterThanOrEqual(4.5);
+  });
+});

--- a/frontend/src/components/ThemeToggle.tsx
+++ b/frontend/src/components/ThemeToggle.tsx
@@ -1,0 +1,18 @@
+import { useTheme } from '../hooks/useTheme';
+
+export function ThemeToggle() {
+  const { theme, toggleTheme } = useTheme();
+  const isDark = theme === 'dark';
+
+  return (
+    <button
+      type="button"
+      className="theme-toggle"
+      onClick={toggleTheme}
+      aria-pressed={isDark}
+      aria-label={isDark ? 'Switch to light mode' : 'Switch to dark mode'}
+    >
+      {isDark ? '☀️ Light' : '🌙 Dark'}
+    </button>
+  );
+}

--- a/frontend/src/components/match/CreateMatchForm.tsx
+++ b/frontend/src/components/match/CreateMatchForm.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { StakeAmountInput } from '../StakeAmountInput';
+import { LichessGamePicker } from './LichessGamePicker';
 
 export interface CreateMatchData {
   player2: string;
@@ -88,6 +89,9 @@ export function CreateMatchForm({ onSubmit }: CreateMatchFormProps) {
         <input id="gameId" value={form.gameId} onChange={set('gameId')} />
         {errors.gameId && <span role="alert">{errors.gameId}</span>}
       </div>
+      {form.platform === 'lichess' && (
+        <LichessGamePicker onSelect={gameId => setForm(f => ({ ...f, gameId }))} />
+      )}
       <div>
         <label htmlFor="platform">Platform</label>
         <select id="platform" value={form.platform} onChange={set('platform')}>

--- a/frontend/src/components/match/LichessGamePicker.tsx
+++ b/frontend/src/components/match/LichessGamePicker.tsx
@@ -1,0 +1,85 @@
+import { useEffect, useMemo, useState } from 'react';
+import { fetchRecentLichessGames, formatGameLabel, type LichessGame } from '../../services/lichessService';
+
+interface LichessGamePickerProps {
+  onSelect: (gameId: string) => void;
+}
+
+export function LichessGamePicker({ onSelect }: LichessGamePickerProps) {
+  const [username, setUsername] = useState('');
+  const [games, setGames] = useState<LichessGame[]>([]);
+  const [query, setQuery] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!username.trim()) {
+      setGames([]);
+      return;
+    }
+
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+
+    fetchRecentLichessGames(username)
+      .then(result => {
+        if (!cancelled) setGames(result);
+      })
+      .catch(err => {
+        if (!cancelled) setError((err as Error).message);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [username]);
+
+  const filteredGames = useMemo(() => {
+    if (!query.trim()) return games;
+    const q = query.toLowerCase();
+    return games.filter(
+      g => g.id.toLowerCase().includes(q) || g.opponent.toLowerCase().includes(q),
+    );
+  }, [games, query]);
+
+  return (
+    <div className="lichess-game-picker">
+      <label htmlFor="lichess-username">Lichess Username</label>
+      <input
+        id="lichess-username"
+        value={username}
+        onChange={ev => setUsername(ev.target.value)}
+        placeholder="e.g. DrNykterstein"
+      />
+
+      {loading && <p role="status">Loading recent games…</p>}
+      {error && <p role="alert">{error}</p>}
+
+      {!loading && !error && games.length > 0 && (
+        <>
+          <label htmlFor="lichess-game-search">Search Games</label>
+          <input
+            id="lichess-game-search"
+            value={query}
+            onChange={ev => setQuery(ev.target.value)}
+            placeholder="Search by game ID or opponent"
+          />
+          <ul aria-label="Recent Lichess games" role="listbox">
+            {filteredGames.map(game => (
+              <li key={game.id}>
+                <button type="button" onClick={() => onSelect(game.id)}>
+                  {formatGameLabel(game)}
+                </button>
+              </li>
+            ))}
+          </ul>
+          {filteredGames.length === 0 && <p>No games match your search.</p>}
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/match/MatchDetail.tsx
+++ b/frontend/src/components/match/MatchDetail.tsx
@@ -1,0 +1,37 @@
+import { useMatch } from '../../hooks/useMatch';
+import { MatchDetailSkeleton } from './MatchDetailSkeleton';
+import { MatchStatusBadge } from './MatchStatusBadge';
+
+interface MatchDetailProps {
+  matchId: number | null;
+}
+
+export function MatchDetail({ matchId }: MatchDetailProps) {
+  const { match, loading, error } = useMatch(matchId);
+
+  if (loading) {
+    return <MatchDetailSkeleton />;
+  }
+
+  if (error) {
+    return <p role="alert">{error}</p>;
+  }
+
+  if (!match) {
+    return <p>No match selected.</p>;
+  }
+
+  return (
+    <div className="match-detail">
+      <h2>Match #{match.match_id}</h2>
+      <div className="match-detail-players">
+        <span>{match.player1}</span>
+        <span> vs </span>
+        <span>{match.player2}</span>
+      </div>
+      <MatchStatusBadge status={match.status as 'pending' | 'active' | 'completed' | 'cancelled'} />
+      {match.stake_amount && <p>Stake: {match.stake_amount} {match.token}</p>}
+      {match.winner && <p>Winner: {match.winner}</p>}
+    </div>
+  );
+}

--- a/frontend/src/components/match/MatchDetailSkeleton.test.tsx
+++ b/frontend/src/components/match/MatchDetailSkeleton.test.tsx
@@ -1,0 +1,14 @@
+import { render } from '@testing-library/react';
+import { MatchDetailSkeleton } from './MatchDetailSkeleton';
+
+describe('MatchDetailSkeleton', () => {
+  test('matches snapshot', () => {
+    const { container } = render(<MatchDetailSkeleton />);
+    expect(container).toMatchSnapshot();
+  });
+
+  test('exposes an accessible loading status', () => {
+    const { getByRole } = render(<MatchDetailSkeleton />);
+    expect(getByRole('status')).toHaveAttribute('aria-label', 'Loading match details');
+  });
+});

--- a/frontend/src/components/match/MatchDetailSkeleton.tsx
+++ b/frontend/src/components/match/MatchDetailSkeleton.tsx
@@ -1,0 +1,18 @@
+export function MatchDetailSkeleton() {
+  return (
+    <div className="match-detail-skeleton" role="status" aria-live="polite" aria-label="Loading match details">
+      <div className="skeleton-line skeleton-title" />
+      <div className="skeleton-row">
+        <div className="skeleton-avatar" />
+        <div className="skeleton-line skeleton-short" />
+        <span className="skeleton-vs">vs</span>
+        <div className="skeleton-avatar" />
+        <div className="skeleton-line skeleton-short" />
+      </div>
+      <div className="skeleton-line skeleton-medium" />
+      <div className="skeleton-line skeleton-medium" />
+      <div className="skeleton-line skeleton-short" />
+      <span className="sr-only">Loading match details…</span>
+    </div>
+  );
+}

--- a/frontend/src/hooks/useTheme.ts
+++ b/frontend/src/hooks/useTheme.ts
@@ -1,0 +1,31 @@
+import { useEffect, useState } from 'react';
+
+export type Theme = 'light' | 'dark';
+
+const STORAGE_KEY = 'checkmate-escrow-theme';
+
+function getSystemPreference(): Theme {
+  if (typeof window === 'undefined' || !window.matchMedia) return 'light';
+  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+}
+
+function getStoredTheme(): Theme | null {
+  if (typeof window === 'undefined') return null;
+  const stored = window.localStorage.getItem(STORAGE_KEY);
+  return stored === 'dark' || stored === 'light' ? stored : null;
+}
+
+export function useTheme() {
+  const [theme, setTheme] = useState<Theme>(() => getStoredTheme() ?? getSystemPreference());
+
+  useEffect(() => {
+    document.documentElement.setAttribute('data-theme', theme);
+    window.localStorage.setItem(STORAGE_KEY, theme);
+  }, [theme]);
+
+  function toggleTheme() {
+    setTheme(t => (t === 'dark' ? 'light' : 'dark'));
+  }
+
+  return { theme, setTheme, toggleTheme };
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -50,6 +50,55 @@
   }
 }
 
+/* Explicit theme overrides — take priority over prefers-color-scheme
+   when the user has picked a preference via the ThemeToggle. WCAG AA
+   contrast (>= 4.5:1) is maintained for body text against --bg. */
+:root[data-theme='dark'] {
+  --text: #c3c8d1;
+  --text-h: #f3f4f6;
+  --bg: #16171d;
+  --border: #2e303a;
+  --code-bg: #1f2028;
+  --accent: #c084fc;
+  --accent-bg: rgba(192, 132, 252, 0.15);
+  --accent-border: rgba(192, 132, 252, 0.5);
+  --social-bg: rgba(47, 48, 58, 0.5);
+  --shadow:
+    rgba(0, 0, 0, 0.4) 0 10px 15px -3px, rgba(0, 0, 0, 0.25) 0 4px 6px -2px;
+}
+
+:root[data-theme='dark'] #social .button-icon {
+  filter: invert(1) brightness(2);
+}
+
+:root[data-theme='light'] {
+  --text: #514a5b;
+  --text-h: #08060d;
+  --bg: #fff;
+  --border: #e5e4e7;
+  --code-bg: #f4f3ec;
+  --accent: #aa3bff;
+  --accent-bg: rgba(170, 59, 255, 0.1);
+  --accent-border: rgba(170, 59, 255, 0.5);
+  --social-bg: rgba(244, 243, 236, 0.5);
+  --shadow:
+    rgba(0, 0, 0, 0.1) 0 10px 15px -3px, rgba(0, 0, 0, 0.05) 0 4px 6px -2px;
+}
+
+.theme-toggle {
+  font: inherit;
+  cursor: pointer;
+  color: var(--text-h);
+  background: var(--code-bg);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 6px 12px;
+}
+
+.theme-toggle:hover {
+  border-color: var(--accent-border);
+}
+
 #root {
   width: 1126px;
   max-width: 100%;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -109,3 +109,78 @@ code {
   padding: 4px 8px;
   background: var(--code-bg);
 }
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.match-detail-skeleton {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 16px;
+  text-align: left;
+}
+
+.match-detail-skeleton .skeleton-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.skeleton-line,
+.skeleton-avatar {
+  background: linear-gradient(
+    90deg,
+    var(--code-bg) 25%,
+    var(--border) 37%,
+    var(--code-bg) 63%
+  );
+  background-size: 400% 100%;
+  animation: skeleton-shimmer 1.4s ease infinite;
+  border-radius: 6px;
+}
+
+.skeleton-title {
+  height: 28px;
+  width: 40%;
+}
+
+.skeleton-short {
+  height: 16px;
+  width: 20%;
+}
+
+.skeleton-medium {
+  height: 16px;
+  width: 60%;
+}
+
+.skeleton-avatar {
+  height: 32px;
+  width: 32px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.skeleton-vs {
+  color: var(--text);
+  font-size: 0.85rem;
+}
+
+@keyframes skeleton-shimmer {
+  0% {
+    background-position: 100% 50%;
+  }
+  100% {
+    background-position: 0 50%;
+  }
+}

--- a/frontend/src/services/lichessService.test.ts
+++ b/frontend/src/services/lichessService.test.ts
@@ -1,0 +1,76 @@
+import { vi } from 'vitest';
+import { fetchRecentLichessGames, formatGameLabel } from './lichessService';
+
+const NDJSON_RESPONSE = [
+  JSON.stringify({
+    id: 'abcd1234',
+    createdAt: 1700000000000,
+    speed: 'blitz',
+    variant: { key: 'standard' },
+    winner: 'white',
+    players: {
+      white: { user: { name: 'TestPlayer' } },
+      black: { user: { name: 'Opponent1' } },
+    },
+  }),
+  JSON.stringify({
+    id: 'efgh5678',
+    createdAt: 1700003600000,
+    speed: 'rapid',
+    variant: { key: 'standard' },
+    players: {
+      white: { user: { name: 'Opponent2' } },
+      black: { user: { name: 'TestPlayer' } },
+    },
+  }),
+].join('\n');
+
+describe('lichessService', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test('fetches and normalizes recent games for a username', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      statusText: 'OK',
+      text: () => Promise.resolve(NDJSON_RESPONSE),
+    }) as unknown as typeof fetch;
+
+    const games = await fetchRecentLichessGames('TestPlayer');
+
+    expect(games).toHaveLength(2);
+    expect(games[0]).toMatchObject({ id: 'abcd1234', opponent: 'Opponent1', result: 'win' });
+    expect(games[1]).toMatchObject({ id: 'efgh5678', opponent: 'Opponent2', result: 'draw' });
+  });
+
+  test('returns an empty array for a blank username', async () => {
+    global.fetch = vi.fn();
+    const games = await fetchRecentLichessGames('   ');
+    expect(games).toEqual([]);
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  test('throws when the Lichess API responds with an error', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      statusText: 'Not Found',
+    }) as unknown as typeof fetch;
+
+    await expect(fetchRecentLichessGames('missinguser')).rejects.toThrow('Not Found');
+  });
+
+  test('formatGameLabel includes id, opponent, and result', () => {
+    const label = formatGameLabel({
+      id: 'abcd1234',
+      opponent: 'Opponent1',
+      result: 'win',
+      createdAt: 1700000000000,
+      speed: 'blitz',
+      variant: 'standard',
+    });
+    expect(label).toContain('abcd1234');
+    expect(label).toContain('Opponent1');
+    expect(label).toContain('win');
+  });
+});

--- a/frontend/src/services/lichessService.ts
+++ b/frontend/src/services/lichessService.ts
@@ -1,0 +1,85 @@
+const LICHESS_API_BASE = import.meta.env.VITE_LICHESS_API_URL ?? 'https://lichess.org';
+
+export interface LichessGame {
+  id: string;
+  opponent: string;
+  result: string;
+  createdAt: number;
+  speed: string;
+  variant: string;
+}
+
+interface LichessApiPlayer {
+  user?: { name?: string };
+}
+
+interface LichessApiGame {
+  id: string;
+  createdAt: number;
+  speed?: string;
+  variant?: { key?: string };
+  winner?: string;
+  players: {
+    white: LichessApiPlayer;
+    black: LichessApiPlayer;
+  };
+}
+
+/**
+ * Fetch a player's recent games from the Lichess API.
+ * Lichess returns newline-delimited JSON (ndjson) for this endpoint.
+ */
+export async function fetchRecentLichessGames(
+  username: string,
+  max = 20,
+): Promise<LichessGame[]> {
+  const trimmed = username.trim();
+  if (!trimmed) return [];
+
+  const url = `${LICHESS_API_BASE}/api/games/user/${encodeURIComponent(trimmed)}?max=${max}&pgnInJson=false`;
+
+  const response = await fetch(url, {
+    headers: { Accept: 'application/x-ndjson' },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch Lichess games: ${response.statusText}`);
+  }
+
+  const text = await response.text();
+  if (!text.trim()) return [];
+
+  return text
+    .trim()
+    .split('\n')
+    .filter(Boolean)
+    .map(line => JSON.parse(line) as LichessApiGame)
+    .map(game => toLichessGame(game, trimmed));
+}
+
+function toLichessGame(game: LichessApiGame, username: string): LichessGame {
+  const isWhite = game.players.white.user?.name?.toLowerCase() === username.toLowerCase();
+  const opponent = isWhite
+    ? game.players.black.user?.name ?? 'Unknown'
+    : game.players.white.user?.name ?? 'Unknown';
+
+  let result = 'draw';
+  if (game.winner) {
+    const won = (game.winner === 'white' && isWhite) || (game.winner === 'black' && !isWhite);
+    result = won ? 'win' : 'loss';
+  }
+
+  return {
+    id: game.id,
+    opponent,
+    result,
+    createdAt: game.createdAt,
+    speed: game.speed ?? 'unknown',
+    variant: game.variant?.key ?? 'standard',
+  };
+}
+
+export function formatGameLabel(game: LichessGame): string {
+  const date = new Date(game.createdAt).toLocaleDateString();
+  return `${game.id} · vs ${game.opponent} · ${game.result} · ${date}`;
+}

--- a/scripts/deploy_testnet.sh
+++ b/scripts/deploy_testnet.sh
@@ -74,11 +74,53 @@ stellar contract invoke \
     --deployer "$DEPLOYER_ADDRESS"
 
 echo ""
-echo "✅ Deployment complete!"
+echo "🩺 Verifying deployment health..."
+
+RPC_URL=${SOROBAN_RPC_URL:-"https://soroban-testnet.stellar.org"}
+
+check_initialized() {
+    local name="$1"
+    local contract_id="$2"
+    local result
+
+    if ! result=$(stellar contract invoke \
+        --id "$contract_id" \
+        --source "$DEPLOYER_KEYPAIR" \
+        --network "$NETWORK" \
+        -- \
+        is_initialized 2>&1); then
+        echo "❌ Health check failed for $name contract ($contract_id):"
+        echo "   $result"
+        return 1
+    fi
+
+    if [[ "$result" != *"true"* ]]; then
+        echo "❌ $name contract ($contract_id) reports not initialized: $result"
+        return 1
+    fi
+
+    echo "   ✅ $name contract is initialized"
+    return 0
+}
+
+HEALTH_OK=1
+check_initialized "Oracle" "$ORACLE_CONTRACT_ID" || HEALTH_OK=0
+check_initialized "Escrow" "$ESCROW_CONTRACT_ID" || HEALTH_OK=0
+
+if [[ "$HEALTH_OK" -ne 1 ]]; then
+    echo ""
+    echo "❌ Deployment health check failed. One or more contracts are not initialized."
+    exit 1
+fi
+
+echo ""
+echo "✅ Deployment complete and verified healthy!"
 echo ""
 echo "📋 Contract Addresses:"
 echo "   Oracle Contract:  $ORACLE_CONTRACT_ID"
 echo "   Escrow Contract:  $ESCROW_CONTRACT_ID"
+echo ""
+echo "🌐 RPC URL: $RPC_URL"
 echo ""
 echo "🔧 Update your .env file with:"
 echo "   CONTRACT_ESCROW=$ESCROW_CONTRACT_ID"


### PR DESCRIPTION
## Summary
1. Deploy health check — scripts/deploy_testnet.sh now calls is_initialized on both contracts post-deploy, exits 1 on failure, prints contract addresses + RPC URL on success.
2. Match detail skeleton loader — new MatchDetailSkeleton + MatchDetail components (wired to useMatch's loading state) with shimmer CSS and a snapshot test.
3. Lichess game import — new services/lichessService.ts (fetches/normalizes recent games via Lichess API) + LichessGamePicker searchable dropdown, wired into CreateMatchForm, with a test using a mocked ndjson API response.
4. Dark mode — useTheme hook + ThemeToggle component, persisted via localStorage, explicit data-theme CSS overrides in index.css, wired into App.tsx, plus a WCAG AA contrast-ratio test for both themes.

Brief description of what this PR does and why.

## Related Issue

Closes #1412
Closes #1413
Closes #1414
Closes #1416

## What Changed

- Contracts:
- Tests:
- Docs:

## Checklist

- [ ] `cargo test` passes locally
- [ ] `cargo clippy` is clean
- [ ] Tests added or updated for this change
- [ ] Documentation updated (or no update needed)
- [ ] `CHANGELOG.md` updated under `[Unreleased]` — see [changelog guidelines](../CONTRIBUTING.md#updating-the-changelog)
