### PR TITLE
fix: resolve #1429 #1430 #1431 #1432 (CI links, canary deploy, game_id filter, PDF receipt)

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -1,0 +1,29 @@
+name: Check Docs Links
+
+# Only run this workflow when documentation files change so it does not block
+# unrelated pull requests or incur CI minutes on pure code changes.
+on:
+  push:
+    branches: [main, master]
+    paths:
+      - 'docs/**'
+      - 'README.md'
+      - 'demo/**/*.md'
+  pull_request:
+    branches: [main, master]
+    paths:
+      - 'docs/**'
+      - 'README.md'
+      - 'demo/**/*.md'
+
+jobs:
+  check-links:
+    name: Check Markdown Links
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate local Markdown links
+        # scripts/check_links.sh scans docs/, demo/, and README.md for local
+        # Markdown links and exits non-zero if any target path is missing.
+        run: bash scripts/check_links.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,28 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # Detect whether any docs/ file changed so the heavy link-scan only
+      # runs on documentation PRs.  On push to main/master we always run it.
+      - name: Detect docs changes
+        id: docs-changed
+        run: |
+          if [[ "${{ github.event_name }}" == "push" ]]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            BASE="${{ github.event.pull_request.base.sha }}"
+            HEAD="${{ github.event.pull_request.head.sha }}"
+            if git diff --name-only "$BASE" "$HEAD" | grep -qE '^(docs/|README\.md|demo/.+\.md)'; then
+              echo "changed=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "changed=false" >> "$GITHUB_OUTPUT"
+            fi
+          fi
+
       - name: Validate local Markdown links
+        if: steps.docs-changed.outputs.changed == 'true'
         run: bash scripts/check_links.sh
 
   check-api-refs:

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -203,6 +203,53 @@ stellar contract invoke --id $ORACLE_CONTRACT_ID --network <network> \
 
 ---
 
+## Canary Deployment
+
+The `--canary` flag enables a validation gate between contract deployment and
+full production traffic cut-over. In canary mode the script:
+
+1. Deploys and initialises the contracts as normal.
+2. Runs `scripts/smoke_test.sh` against the freshly deployed contracts.
+3. If the smoke tests **pass**, deployment is considered successful and the
+   script prints the contract addresses for traffic promotion.
+4. If the smoke tests **fail**, the script exits non-zero and prints the
+   contract IDs so you can inspect or roll back before any traffic is routed to
+   the new deployment.
+
+### Usage
+
+```bash
+# Deploy to testnet with canary validation
+./scripts/deploy.sh testnet --canary
+
+# Upgrade existing contracts on mainnet with canary validation
+./scripts/deploy.sh mainnet --upgrade --canary
+```
+
+### What the smoke test covers
+
+`scripts/smoke_test.sh` exercises the full match lifecycle end-to-end: it
+creates a match, deposits funds for both players, submits a result, and verifies
+the payout was issued. If any step fails the test exits non-zero, triggering the
+canary abort path.
+
+### When to use canary mode
+
+| Scenario | Recommended? |
+|---|---|
+| First mainnet deployment | ✅ Yes — catch misconfigurations before routing users |
+| Mainnet contract upgrade | ✅ Yes — verify new WASM behaves identically under live conditions |
+| Testnet development iteration | Optional — slower but safer |
+| Hotfix to a non-contract service | Not needed |
+
+### Environment variables
+
+No extra variables are required. The canary step re-uses the `CONTRACT_ESCROW`
+and `CONTRACT_ORACLE` values the deploy step just produced, so both are always
+set correctly.
+
+---
+
 ## Smoke Testing: End-to-End Verification
 
 After deployment, use the smoke test script to verify the entire match lifecycle works correctly on testnet before moving to production.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@albedo-link/intent": "^0.13.0",
+        "@react-pdf/renderer": "^4.3.0",
         "@stellar/freighter-api": "^6.0.1",
         "@stellar/stellar-sdk": "^16.0.1",
         "react": "^19.2.6",
@@ -16,6 +17,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
+        "@testing-library/dom": "^10.4.0",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
@@ -295,7 +297,6 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
       "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -510,43 +511,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=20.19.0"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
-      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.2",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
-      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
-      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -830,6 +794,18 @@
         "@emnapi/runtime": "^1.7.1"
       }
     },
+    "node_modules/@noble/ciphers": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
+      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@noble/ed25519": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@noble/ed25519/-/ed25519-3.1.0.tgz",
@@ -859,6 +835,181 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@react-pdf/fns": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@react-pdf/fns/-/fns-3.1.3.tgz",
+      "integrity": "sha512-0I7pApDr1/RLAKbizuLy/IHTEa93LSPy/bEwYniboC3Xqnp6Od8xFJKbKEzGw2wh/5zKFFwl00g4t9RwgIMc3w==",
+      "license": "MIT"
+    },
+    "node_modules/@react-pdf/font": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@react-pdf/font/-/font-4.1.2.tgz",
+      "integrity": "sha512-RT/jiGWIRjIC9c4S9NiqhEyfuA6YL+DtWL3Rm+k+zQhfeHYvHwGzFxr7ZJzThIMrT8sIQy+mpvFvfYyitEei/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/types": "^2.14.0",
+        "fontkit": "^2.0.2",
+        "is-url": "^1.2.4",
+        "pdfkit": "0.20.1"
+      }
+    },
+    "node_modules/@react-pdf/hyphenate": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf/hyphenate/-/hyphenate-0.1.0.tgz",
+      "integrity": "sha512-CWulbuusHh2Lnos9ZffT3ZYfjCt332Yl8wjSyCKWbwhbTpe/VdFt53fM5elPp3HU3R6tzH6j3oYlLXDwC2WEHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "hyphen": "~1.6.4"
+      }
+    },
+    "node_modules/@react-pdf/image": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@react-pdf/image/-/image-3.1.2.tgz",
+      "integrity": "sha512-89vlvZCCv1hPunFtyeS2rJTRL8h2yYmTI97AM4ppibS79zGsPFbqz/YrAunndcHB9uwGdn5S3+5k18mj0L2vkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/svg": "^1.1.1",
+        "jay-peg": "^1.1.1",
+        "png-js": "^2.0.0"
+      }
+    },
+    "node_modules/@react-pdf/layout": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf/layout/-/layout-5.2.0.tgz",
+      "integrity": "sha512-Hzf9cShT1bKkr9tZ+A9qK/wHqUloOCgbNer72EquQS6QzqVGiDdtt6Wh9lQXwkd89U7yZolTLnFqP/dRdoRROw==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/fns": "3.1.3",
+        "@react-pdf/image": "^3.1.2",
+        "@react-pdf/paginate": "1.0.1",
+        "@react-pdf/primitives": "^4.4.0",
+        "@react-pdf/stylesheet": "^6.3.2",
+        "@react-pdf/textkit": "^7.0.1",
+        "@react-pdf/types": "^2.14.0",
+        "emoji-regex-xs": "^1.0.0",
+        "queue": "^6.0.1",
+        "yoga-layout": "^3.2.1"
+      }
+    },
+    "node_modules/@react-pdf/paginate": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@react-pdf/paginate/-/paginate-1.0.1.tgz",
+      "integrity": "sha512-JN6teDqkdpkcRhdGZqyrr7Y8flgTtyI8XS3yaBQLyiGjEBPbR9m/19cz2z3JkqYpApau5pEHZlLjwGqMurWysw==",
+      "license": "MIT"
+    },
+    "node_modules/@react-pdf/primitives": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf/primitives/-/primitives-4.4.0.tgz",
+      "integrity": "sha512-BFpuhNH6ffSFjTTMnpdUoZxWoXdhPmFDdrSVBl0i/zMR4yDTEfYOW3AcfjjmNIOpm9+LnIXbgELLklQJ+nD3oA==",
+      "license": "MIT"
+    },
+    "node_modules/@react-pdf/reconciler": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf/reconciler/-/reconciler-2.0.0.tgz",
+      "integrity": "sha512-7zaPRujpbHSmCpIrZ+b9HSTJHthcVZzX0Wx7RzvQGsGBUbHP4p6s5itXrAIOuQuPvDepoHGNOvf6xUuMVvdoyw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4.1.1",
+        "scheduler": "0.25.0-rc-603e6108-20241029"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@react-pdf/reconciler/node_modules/scheduler": {
+      "version": "0.25.0-rc-603e6108-20241029",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.25.0-rc-603e6108-20241029.tgz",
+      "integrity": "sha512-pFwF6H1XrSdYYNLfOcGlM28/j8CGLu8IvdrxqhjWULe2bPcKiKW4CV+OWqR/9fT52mywx65l7ysNkjLKBda7eA==",
+      "license": "MIT"
+    },
+    "node_modules/@react-pdf/render": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf/render/-/render-4.7.0.tgz",
+      "integrity": "sha512-UEMgR7gBmCJiKpuu9alY6QeZVNB+7b4DGHc7Hi8QIl+5PfHvyq+TV70N7+ngZ6wN7hF3XSiWz7GDuYxPIx5eRw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@react-pdf/fns": "3.1.3",
+        "@react-pdf/primitives": "^4.4.0",
+        "@react-pdf/textkit": "^7.0.1",
+        "@react-pdf/types": "^2.14.0",
+        "abs-svg-path": "^0.1.1",
+        "color-string": "^2.1.4",
+        "normalize-svg-path": "^1.1.0",
+        "parse-svg-path": "^0.1.2",
+        "svg-arc-to-cubic-bezier": "^3.2.0"
+      }
+    },
+    "node_modules/@react-pdf/renderer": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf/renderer/-/renderer-4.9.0.tgz",
+      "integrity": "sha512-RAbARMwjcSYEpqpaWoWXz0uOGF1HjAl5hdJr889r5mgkPhF9xhX4CXSvcEbLTgFVj+KWbcar31MzcXYoANk/Ag==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@react-pdf/fns": "3.1.3",
+        "@react-pdf/font": "^4.1.2",
+        "@react-pdf/layout": "^5.2.0",
+        "@react-pdf/primitives": "^4.4.0",
+        "@react-pdf/reconciler": "^2.0.0",
+        "@react-pdf/render": "^4.7.0",
+        "@react-pdf/types": "^2.14.0",
+        "events": "^3.3.0",
+        "object-assign": "^4.1.1",
+        "pdfkit": "0.20.1",
+        "prop-types": "^15.6.2",
+        "queue": "^6.0.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@react-pdf/stylesheet": {
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/@react-pdf/stylesheet/-/stylesheet-6.3.2.tgz",
+      "integrity": "sha512-UR247sNBx2k3RdL8JUCpUiyx39yQsUABagv3uAi91iMZCORE+fSCsOh7MOcEImmpms4GihydLGudbngI5g14PA==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/fns": "3.1.3",
+        "@react-pdf/types": "^2.14.0",
+        "color-string": "^2.1.4",
+        "hsl-to-hex": "^1.0.0",
+        "media-engine": "^2.0.0",
+        "postcss-value-parser": "^4.1.0"
+      }
+    },
+    "node_modules/@react-pdf/svg": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@react-pdf/svg/-/svg-1.1.1.tgz",
+      "integrity": "sha512-m1GmGxV2wg/3VpoQ0aCJ598fBedCCfN+HtxKx1lq5kdwUWEaTbfXI1DGFAUedprFDd/i24okKFaUhV/KVZIqIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/primitives": "^4.4.0"
+      }
+    },
+    "node_modules/@react-pdf/textkit": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@react-pdf/textkit/-/textkit-7.0.1.tgz",
+      "integrity": "sha512-ljY/YoEETIOR/+zxWdLLmKlupz8/nBsbmxglM3mDRco62UEzEPnIeMEzYVVVraovCAJC2t+50gKFNSV17FYxbw==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/fns": "3.1.3",
+        "@react-pdf/hyphenate": "^0.1.0",
+        "bidi-js": "^1.0.2",
+        "unicode-properties": "^1.4.1"
+      }
+    },
+    "node_modules/@react-pdf/types": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf/types/-/types-2.14.0.tgz",
+      "integrity": "sha512-TYHpThdf2sz/d1g+CP9nWjYCJ8BYBUN5ORL6+60A85Js9S/YouK8OXzi+hDpYUSZJTOdYXdRxUNeG2oW8//Ulg==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/font": "^4.1.2",
+        "@react-pdf/primitives": "^4.4.0",
+        "@react-pdf/stylesheet": "^6.3.2"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -1224,21 +1375,29 @@
         "node": ">=22.0.0"
       }
     },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.23",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.23.tgz",
+      "integrity": "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
     "node_modules/@testing-library/dom": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
-      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.0.tgz",
+      "integrity": "sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
         "@types/aria-query": "^5.0.1",
         "aria-query": "5.3.0",
+        "chalk": "^4.1.0",
         "dom-accessibility-api": "^0.5.9",
         "lz-string": "^1.5.0",
-        "picocolors": "1.1.1",
         "pretty-format": "^27.0.2"
       },
       "engines": {
@@ -1330,8 +1489,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -1815,6 +1973,12 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/abs-svg-path": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/abs-svg-path/-/abs-svg-path-0.1.1.tgz",
+      "integrity": "sha512-d8XPSGjfyzlXC3Xx891DJRyZfqk5JU0BJrDQcsWomFIV1/BIzPW5HDH5iDdWpqWaav0YVIEzT1RHTwWr0FFshA==",
+      "license": "MIT"
+    },
     "node_modules/acorn": {
       "version": "8.17.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
@@ -1873,20 +2037,21 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
       "engines": {
-        "node": ">=10"
+        "node": ">=8"
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
@@ -2005,7 +2170,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
       "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "require-from-string": "^2.0.2"
@@ -2028,6 +2192,15 @@
       },
       "engines": {
         "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/brotli": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/brotli/-/brotli-1.3.3.tgz",
+      "integrity": "sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.1.2"
       }
     },
     "node_modules/browserslist": {
@@ -2128,6 +2301,73 @@
       "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-convert/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/color-name": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.1.tgz",
+      "integrity": "sha512-p2FdgwVx1a9yWBHP2wI0VgShkDpgN4kZISkxdNipGBJWpa5G6b04OINlVWCyJj0JmfvcPrgqt95E9k8yvaOJFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
+    "node_modules/color-string": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-2.1.4.tgz",
+      "integrity": "sha512-Bb6Cq8oq0IjDOe8wJmi4JeNn763Xs9cfrBcaylK1tPypWzyoy2G3l90v9k64kjphl/ZJjPIShFztenRomi8WTg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
       "engines": {
         "node": ">=18"
       }
@@ -2277,13 +2517,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/dfa": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/dfa/-/dfa-1.2.0.tgz",
+      "integrity": "sha512-ED3jP8saaweFTjeGX8HQPjeC1YYyZs98jGNZx6IiBvxW7JG5v492kamAQB3m2wop07CvU/RQmzcKr6bgcC5D/Q==",
+      "license": "MIT"
+    },
     "node_modules/dom-accessibility-api": {
       "version": "0.5.16",
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -2305,6 +2550,12 @@
       "integrity": "sha512-cUVA7/RvbFTEuw/i3obUwDTRIXojaxkResf+ibByPFxjc6XK3VNtcQXV0NSbAlJ0FMjcJGgftVVB4Qo184EXvA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/emoji-regex-xs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex-xs/-/emoji-regex-xs-1.0.0.tgz",
+      "integrity": "sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==",
+      "license": "MIT"
     },
     "node_modules/entities": {
       "version": "8.0.0",
@@ -2589,6 +2840,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
     "node_modules/eventsource": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-4.1.0.tgz",
@@ -2624,7 +2884,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
@@ -2667,6 +2926,12 @@
       "dependencies": {
         "is-retry-allowed": "^3.0.0"
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "license": "MIT"
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
@@ -2737,6 +3002,23 @@
         "debug": {
           "optional": true
         }
+      }
+    },
+    "node_modules/fontkit": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/fontkit/-/fontkit-2.0.4.tgz",
+      "integrity": "sha512-syetQadaUEDNdxdugga9CpEYVaQIxOwk7GlwZWWZ19//qW4zE5bknOKeMBDYAASwnpaSHKJITRLMF9m1fp3s6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@swc/helpers": "^0.5.12",
+        "brotli": "^1.3.2",
+        "clone": "^2.1.2",
+        "dfa": "^1.2.0",
+        "fast-deep-equal": "^3.1.3",
+        "restructure": "^3.0.0",
+        "tiny-inflate": "^1.0.3",
+        "unicode-properties": "^1.4.0",
+        "unicode-trie": "^2.0.0"
       }
     },
     "node_modules/form-data": {
@@ -2930,6 +3212,21 @@
         "hermes-estree": "0.25.1"
       }
     },
+    "node_modules/hsl-to-hex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/hsl-to-hex/-/hsl-to-hex-1.0.0.tgz",
+      "integrity": "sha512-K6GVpucS5wFf44X0h2bLVRDsycgJmf9FF2elg+CrqD8GcFU8c6vYhgXn8NjUkFCwj+xDFb70qgLbTUm6sxwPmA==",
+      "license": "MIT",
+      "dependencies": {
+        "hsl-to-rgb-for-reals": "^1.1.0"
+      }
+    },
+    "node_modules/hsl-to-rgb-for-reals": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/hsl-to-rgb-for-reals/-/hsl-to-rgb-for-reals-1.1.1.tgz",
+      "integrity": "sha512-LgOWAkrN0rFaQpfdWBQlv/VhkOxb5AsBjk6NQVx4yEzWS923T07X0M1Y0VNko2H52HeSpZrZNNMJ0aFqsdVzQg==",
+      "license": "ISC"
+    },
     "node_modules/html-encoding-sniffer": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
@@ -2962,6 +3259,12 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/hyphen": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/hyphen/-/hyphen-1.6.6.tgz",
+      "integrity": "sha512-XtqmnT+b9n5MX+MsqluFAVTIenbtC25iskW0Z+jLd+awfhA+ZbWKWQMIvLJccGoa2bM1R6juWJ27cZxIFOmkWw==",
+      "license": "ISC"
     },
     "node_modules/ieee754": {
       "version": "1.2.1",
@@ -3013,6 +3316,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -3054,6 +3363,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/is-url": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
+      "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==",
+      "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -3101,11 +3416,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/jay-peg": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/jay-peg/-/jay-peg-1.1.1.tgz",
+      "integrity": "sha512-D62KEuBxz/ip2gQKOEhk/mx14o7eiFRaU+VNNSP4MOiIkwb/D6B3G1Mfas7C/Fit8EsSV2/IWjZElx/Gs6A4ww==",
+      "license": "MIT",
+      "dependencies": {
+        "restructure": "^3.0.0"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/jsdom": {
@@ -3491,6 +3814,25 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/linebreak": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/linebreak/-/linebreak-1.1.0.tgz",
+      "integrity": "sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/linebreak/node_modules/base64-js": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
+      "integrity": "sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -3505,6 +3847,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
       }
     },
     "node_modules/lru-cache": {
@@ -3523,7 +3877,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -3594,6 +3947,12 @@
       "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
       "dev": true,
       "license": "CC0-1.0"
+    },
+    "node_modules/media-engine": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/media-engine/-/media-engine-2.0.0.tgz",
+      "integrity": "sha512-FqNmlXKYrp5d3g7xEOMJb+6gXZE0fTssdyIQqYR4LbkifbNbS0hDylhNDOh8r6tCgLboHd8+mwgH2njgSYDpnQ==",
+      "license": "MIT"
     },
     "node_modules/mime-db": {
       "version": "1.52.0",
@@ -3684,6 +4043,24 @@
         "node": ">=18"
       }
     },
+    "node_modules/normalize-svg-path": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/normalize-svg-path/-/normalize-svg-path-1.1.0.tgz",
+      "integrity": "sha512-r9KHKG2UUeB5LoTouwDzBy2VxXlHsiM6fyLQvnJa0S5hrhzqElH/CH7TUGhT1fVvIYBIKf3OpY4YJ4CK+iaqHg==",
+      "license": "MIT",
+      "dependencies": {
+        "svg-arc-to-cubic-bezier": "^3.0.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/obug": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
@@ -3748,6 +4125,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/pako": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+      "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==",
+      "license": "MIT"
+    },
+    "node_modules/parse-svg-path": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/parse-svg-path/-/parse-svg-path-0.1.2.tgz",
+      "integrity": "sha512-JyPSBnkTJ0AI8GGJLfMXvKq42cj5c006fnLz6fXy6zfoVjJizi8BNTpu8on8ziI1cKy9d9DGNuY17Ce7wuejpQ==",
+      "license": "MIT"
+    },
     "node_modules/parse5": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
@@ -3788,6 +4177,32 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/pdfkit": {
+      "version": "0.20.1",
+      "resolved": "https://registry.npmjs.org/pdfkit/-/pdfkit-0.20.1.tgz",
+      "integrity": "sha512-1rRXK6x5o8I/3dBrBzXfxibpHpkfCnIA7EBAES7pEpGFc/65inMLlA8SalGWpJfal7BGekxeLf6A30IOpQpc5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/ciphers": "^1.3.0",
+        "@noble/hashes": "^1.8.0",
+        "fflate": "^0.8.3",
+        "fontkit": "^2.0.4",
+        "linebreak": "^1.1.0",
+        "png-js": "^2.0.0"
+      }
+    },
+    "node_modules/pdfkit/node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -3806,6 +4221,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/png-js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/png-js/-/png-js-2.0.0.tgz",
+      "integrity": "sha512-GdzJuUMc6ZSpxFJWVxtOH1bzYHym+TOnveqUjb+VJIbZWbZzyiRGFiKhbiielfpYbgMlhHVhsJ0FTazfuRFkMA==",
+      "dependencies": {
+        "fflate": "^0.8.2"
       }
     },
     "node_modules/postcss": {
@@ -3837,6 +4260,12 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "license": "MIT"
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -3853,7 +4282,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -3862,6 +4290,36 @@
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/prop-types/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
     },
     "node_modules/proxy-from-env": {
       "version": "2.1.0",
@@ -3880,6 +4338,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/queue": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/queue/-/queue-6.0.2.tgz",
+      "integrity": "sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "~2.0.3"
       }
     },
     "node_modules/react": {
@@ -3908,8 +4375,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/redent": {
       "version": "3.0.0",
@@ -3929,11 +4395,16 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/restructure": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/restructure/-/restructure-3.0.2.tgz",
+      "integrity": "sha512-gSfoiOEA0VPE6Tukkrr7I0RBdE0s7H1eFCDBk05l1KIQT1UIKNc5JZy6jdyW6eYH3aR3g5b3PuL77rq0hvwtAw==",
+      "license": "MIT"
     },
     "node_modules/rolldown": {
       "version": "1.0.3",
@@ -4090,11 +4561,23 @@
         "node": ">=8"
       }
     },
+    "node_modules/svg-arc-to-cubic-bezier": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/svg-arc-to-cubic-bezier/-/svg-arc-to-cubic-bezier-3.2.0.tgz",
+      "integrity": "sha512-djbJ/vZKZO+gPoSDThGNpKDO+o+bAeA4XQKovvkNCqnIS2t+S4qnLAGQhyyrulhCFRl1WWzAp0wUDV8PpTVU3g==",
+      "license": "ISC"
+    },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tiny-inflate": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
+      "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
       "license": "MIT"
     },
     "node_modules/tinybench": {
@@ -4204,9 +4687,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "license": "0BSD",
-      "optional": true
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -4287,6 +4768,26 @@
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/unicode-properties": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/unicode-properties/-/unicode-properties-1.4.1.tgz",
+      "integrity": "sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/unicode-trie": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
+      "integrity": "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^0.2.5",
+        "tiny-inflate": "^1.0.0"
+      }
     },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
@@ -4624,6 +5125,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/yoga-layout": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/yoga-layout/-/yoga-layout-3.2.1.tgz",
+      "integrity": "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==",
+      "license": "MIT"
     },
     "node_modules/zod": {
       "version": "4.4.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@albedo-link/intent": "^0.13.0",
+    "@react-pdf/renderer": "^4.3.0",
     "@stellar/freighter-api": "^6.0.1",
     "@stellar/stellar-sdk": "^16.0.1",
     "react": "^19.2.6",
@@ -21,6 +22,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
+    "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",

--- a/frontend/src/components/match/MatchDetail.tsx
+++ b/frontend/src/components/match/MatchDetail.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { MatchStatusBadge } from './MatchStatusBadge';
 import { formatTokenAmount } from '../../utils/tokenFormat';
+import type { MatchReceiptProps } from './MatchReceiptPDF';
 
 export interface MatchDetailProps {
   matchId: number;
@@ -12,6 +13,11 @@ export interface MatchDetailProps {
   platform: 'lichess' | 'chessdotcom';
   /** Decimal places for `token`; when set, stakeAmount is formatted from raw units. */
   tokenDecimals?: number;
+  /**
+   * Receipt data required to generate a PDF payout receipt.
+   * Only relevant (and shown) when `status === 'completed'`.
+   */
+  receipt?: Omit<MatchReceiptProps, 'matchId'>;
 }
 
 /**
@@ -31,8 +37,10 @@ export function MatchDetail({
   status,
   platform,
   tokenDecimals,
+  receipt,
 }: MatchDetailProps) {
   const [copied, setCopied] = useState(false);
+  const [downloading, setDownloading] = useState(false);
   const displayStake =
     tokenDecimals !== undefined ? formatTokenAmount(stakeAmount, tokenDecimals) : stakeAmount;
 
@@ -45,6 +53,18 @@ export function MatchDetail({
     } catch {
       // Clipboard API unavailable (e.g. insecure context) - fail silently,
       // the button remains usable for a retry.
+    }
+  };
+
+  const handleDownloadReceipt = async () => {
+    if (!receipt) return;
+    setDownloading(true);
+    try {
+      // Lazy-load the PDF module so it does not inflate the initial bundle.
+      const { downloadMatchReceipt } = await import('./MatchReceiptPDF');
+      await downloadMatchReceipt({ matchId, ...receipt });
+    } finally {
+      setDownloading(false);
     }
   };
 
@@ -63,6 +83,16 @@ export function MatchDetail({
       <button type="button" onClick={handleCopyLink}>
         {copied ? 'Link copied!' : 'Copy Link'}
       </button>
+      {status === 'completed' && receipt && (
+        <button
+          type="button"
+          onClick={handleDownloadReceipt}
+          disabled={downloading}
+          aria-label="Download payout receipt as PDF"
+        >
+          {downloading ? 'Generating…' : 'Download Receipt'}
+        </button>
+      )}
     </section>
   );
 }

--- a/frontend/src/components/match/MatchReceiptPDF.test.tsx
+++ b/frontend/src/components/match/MatchReceiptPDF.test.tsx
@@ -1,0 +1,156 @@
+/**
+ * Tests for the MatchReceiptPDF component and the MatchDetail integration
+ * (issue #1432 — PDF export for match payout receipts).
+ *
+ * @react-pdf/renderer renders to a non-DOM tree, so we test:
+ *  1. MatchReceiptDocument exposes the correct props for content assertions.
+ *  2. MatchDetail shows a "Download Receipt" button only for completed matches.
+ *  3. The download helper is triggered when the button is clicked.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MatchDetail } from './MatchDetail';
+import type { MatchReceiptProps } from './MatchReceiptPDF';
+
+// ── Mock @react-pdf/renderer ──────────────────────────────────────────────────
+// The renderer uses Canvas / Worker APIs unavailable in jsdom; mock it so the
+// structural tests run without needing a headless browser environment.
+vi.mock('@react-pdf/renderer', () => ({
+  Document: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  Page: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  Text: ({ children }: { children: React.ReactNode }) => <span>{children}</span>,
+  View: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  StyleSheet: { create: (s: unknown) => s },
+  pdf: vi.fn().mockReturnValue({ toBlob: vi.fn().mockResolvedValue(new Blob()) }),
+}));
+
+// ── Mock the lazy import inside MatchDetail ───────────────────────────────────
+// vi.mock hoists to the top of the module, so it intercepts the dynamic
+// import('./MatchReceiptPDF') inside the click handler too.
+const mockDownload = vi.fn().mockResolvedValue(undefined);
+vi.mock('./MatchReceiptPDF', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./MatchReceiptPDF')>();
+  return {
+    ...actual,
+    downloadMatchReceipt: mockDownload,
+  };
+});
+
+// ── Shared fixtures ───────────────────────────────────────────────────────────
+
+const receipt: Omit<MatchReceiptProps, 'matchId'> = {
+  completedAt: '2026-09-04T07:00:00.000Z',
+  player1: 'GAAA',
+  player2: 'GBBB',
+  stakeAmount: '50',
+  token: 'USDC',
+  payoutAmount: '100',
+  winner: 'GAAA',
+  txHash: 'abc123def456',
+};
+
+const completedProps = {
+  matchId: 7777,
+  player1: 'GAAA',
+  player2: 'GBBB',
+  stakeAmount: '50',
+  token: 'USDC',
+  status: 'completed' as const,
+  platform: 'lichess' as const,
+  receipt,
+};
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('MatchDetail — Download Receipt button', () => {
+  beforeEach(() => {
+    mockDownload.mockClear();
+  });
+
+  it('shows "Download Receipt" button for a completed match with receipt data', () => {
+    render(<MatchDetail {...completedProps} />);
+    // The button text is "Download Receipt"; aria-label is more descriptive.
+    // Query by the aria-label which is the accessible name.
+    expect(
+      screen.getByRole('button', { name: 'Download payout receipt as PDF' }),
+    ).toBeInTheDocument();
+  });
+
+  it('does NOT show "Download Receipt" button for a non-completed match', () => {
+    render(<MatchDetail {...completedProps} status="active" />);
+    expect(
+      screen.queryByRole('button', { name: 'Download payout receipt as PDF' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('does NOT show "Download Receipt" button when receipt prop is absent', () => {
+    const { receipt: _omit, ...propsNoReceipt } = completedProps;
+    render(<MatchDetail {...propsNoReceipt} />);
+    expect(
+      screen.queryByRole('button', { name: 'Download payout receipt as PDF' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('calls downloadMatchReceipt with matchId and receipt data when clicked', async () => {
+    render(<MatchDetail {...completedProps} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Download payout receipt as PDF' }));
+
+    await waitFor(() => expect(mockDownload).toHaveBeenCalledTimes(1));
+    expect(mockDownload).toHaveBeenCalledWith({
+      matchId: 7777,
+      ...receipt,
+    });
+  });
+
+  it('shows "Generating…" while the download is in progress', async () => {
+    // Make the mock stall so we can observe the interim label.
+    let resolve!: () => void;
+    mockDownload.mockReturnValueOnce(
+      new Promise<void>((res) => { resolve = res; }),
+    );
+
+    render(<MatchDetail {...completedProps} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Download payout receipt as PDF' }));
+
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'Download payout receipt as PDF' }).textContent).toBe('Generating…'),
+    );
+
+    // Unblock the mock and confirm the button label reverts.
+    resolve();
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'Download payout receipt as PDF' }).textContent).toBe('Download Receipt'),
+    );
+  });
+});
+
+describe('MatchReceiptDocument — content assertions', () => {
+  it('renders match_id and payout amount in the document', async () => {
+    // Import the un-mocked document component via the mocked module.
+    const { MatchReceiptDocument } = await import('./MatchReceiptPDF');
+
+    render(
+      <MatchReceiptDocument
+        matchId={7777}
+        completedAt="2026-09-04T07:00:00.000Z"
+        player1="GAAA"
+        player2="GBBB"
+        stakeAmount="50"
+        token="USDC"
+        payoutAmount="100"
+        winner="GAAA"
+        txHash="abc123def456"
+      />,
+    );
+
+    // Match ID appears in the document (multiple occurrences are fine).
+    const matchIdElements = screen.getAllByText(/7777/);
+    expect(matchIdElements.length).toBeGreaterThan(0);
+
+    // Payout amount appears in the document.
+    const payoutElements = screen.getAllByText(/100/);
+    expect(payoutElements.length).toBeGreaterThan(0);
+  });
+});

--- a/frontend/src/components/match/MatchReceiptPDF.tsx
+++ b/frontend/src/components/match/MatchReceiptPDF.tsx
@@ -1,0 +1,229 @@
+/**
+ * MatchReceiptPDF — printable payout receipt for completed matches.
+ *
+ * Renders a PDF document (via @react-pdf/renderer) containing:
+ *   - Match ID
+ *   - Date of completion
+ *   - Player addresses
+ *   - Stake amount and token
+ *   - Payout amount and recipient
+ *   - On-chain transaction hash
+ *
+ * Usage:
+ *   import { downloadMatchReceipt } from './MatchReceiptPDF';
+ *   downloadMatchReceipt(props);   // triggers browser download
+ */
+
+import {
+  Document,
+  Page,
+  Text,
+  View,
+  StyleSheet,
+  pdf,
+} from '@react-pdf/renderer';
+
+export interface MatchReceiptProps {
+  matchId: number;
+  /** ISO-8601 date string of when the match completed. */
+  completedAt: string;
+  player1: string;
+  player2: string;
+  stakeAmount: string;
+  token: string;
+  /** Amount paid to the winner (same as 2× stake for no-fee matches). */
+  payoutAmount: string;
+  /** Stellar address of the winner, or "draw" when the match was a draw. */
+  winner: string;
+  /** On-chain transaction hash of the payout transaction. */
+  txHash: string;
+}
+
+// ── Styles ────────────────────────────────────────────────────────────────────
+
+const styles = StyleSheet.create({
+  page: {
+    fontFamily: 'Helvetica',
+    fontSize: 11,
+    paddingTop: 40,
+    paddingBottom: 60,
+    paddingHorizontal: 50,
+    color: '#1a1a2e',
+  },
+  header: {
+    marginBottom: 24,
+    borderBottomWidth: 2,
+    borderBottomColor: '#7c3aed',
+    paddingBottom: 12,
+  },
+  title: {
+    fontSize: 20,
+    fontFamily: 'Helvetica-Bold',
+    color: '#7c3aed',
+    marginBottom: 4,
+  },
+  subtitle: {
+    fontSize: 11,
+    color: '#6b7280',
+  },
+  section: {
+    marginBottom: 16,
+  },
+  sectionTitle: {
+    fontSize: 13,
+    fontFamily: 'Helvetica-Bold',
+    marginBottom: 8,
+    color: '#374151',
+    borderBottomWidth: 1,
+    borderBottomColor: '#e5e7eb',
+    paddingBottom: 4,
+  },
+  row: {
+    flexDirection: 'row',
+    marginBottom: 4,
+  },
+  label: {
+    width: 160,
+    fontFamily: 'Helvetica-Bold',
+    color: '#4b5563',
+  },
+  value: {
+    flex: 1,
+    color: '#111827',
+    wordBreak: 'break-all',
+  },
+  footer: {
+    position: 'absolute',
+    bottom: 30,
+    left: 50,
+    right: 50,
+    fontSize: 9,
+    color: '#9ca3af',
+    textAlign: 'center',
+  },
+  badge: {
+    backgroundColor: '#7c3aed',
+    color: '#ffffff',
+    paddingHorizontal: 8,
+    paddingVertical: 2,
+    borderRadius: 4,
+    fontSize: 10,
+    alignSelf: 'flex-start',
+    marginTop: 2,
+  },
+});
+
+// ── Document component ────────────────────────────────────────────────────────
+
+/**
+ * The PDF document tree rendered by @react-pdf/renderer.
+ * Exported for unit-testing the content without triggering a download.
+ */
+export function MatchReceiptDocument(props: MatchReceiptProps) {
+  const {
+    matchId,
+    completedAt,
+    player1,
+    player2,
+    stakeAmount,
+    token,
+    payoutAmount,
+    winner,
+    txHash,
+  } = props;
+
+  const formattedDate = new Date(completedAt).toUTCString();
+
+  return (
+    <Document
+      title={`Match #${matchId} Payout Receipt`}
+      author="Checkmate-Escrow"
+      subject="Match payout receipt"
+    >
+      <Page size="A4" style={styles.page}>
+        {/* ── Header ──────────────────────────────────────────────────── */}
+        <View style={styles.header}>
+          <Text style={styles.title}>Checkmate-Escrow</Text>
+          <Text style={styles.subtitle}>Match Payout Receipt</Text>
+        </View>
+
+        {/* ── Match details ─────────────────────────────────────────── */}
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>Match Details</Text>
+          <View style={styles.row}>
+            <Text style={styles.label}>Match ID</Text>
+            <Text style={styles.value}>#{matchId}</Text>
+          </View>
+          <View style={styles.row}>
+            <Text style={styles.label}>Completed</Text>
+            <Text style={styles.value}>{formattedDate}</Text>
+          </View>
+          <View style={styles.row}>
+            <Text style={styles.label}>Player 1</Text>
+            <Text style={styles.value}>{player1}</Text>
+          </View>
+          <View style={styles.row}>
+            <Text style={styles.label}>Player 2</Text>
+            <Text style={styles.value}>{player2}</Text>
+          </View>
+        </View>
+
+        {/* ── Payout details ────────────────────────────────────────── */}
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>Payout Details</Text>
+          <View style={styles.row}>
+            <Text style={styles.label}>Stake Amount</Text>
+            <Text style={styles.value}>
+              {stakeAmount} {token}
+            </Text>
+          </View>
+          <View style={styles.row}>
+            <Text style={styles.label}>Payout Amount</Text>
+            <Text style={styles.value}>
+              {payoutAmount} {token}
+            </Text>
+          </View>
+          <View style={styles.row}>
+            <Text style={styles.label}>Winner</Text>
+            <Text style={styles.value}>{winner}</Text>
+          </View>
+        </View>
+
+        {/* ── Transaction ───────────────────────────────────────────── */}
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>On-Chain Transaction</Text>
+          <View style={styles.row}>
+            <Text style={styles.label}>Transaction Hash</Text>
+            <Text style={styles.value}>{txHash}</Text>
+          </View>
+        </View>
+
+        {/* ── Footer ────────────────────────────────────────────────── */}
+        <Text style={styles.footer}>
+          Generated by Checkmate-Escrow · trustless chess wagering on Stellar
+          Soroban · match #{matchId}
+        </Text>
+      </Page>
+    </Document>
+  );
+}
+
+// ── Download helper ───────────────────────────────────────────────────────────
+
+/**
+ * Generates the PDF in the browser and triggers a file download.
+ *
+ * @param props  Receipt data for the completed match.
+ */
+export async function downloadMatchReceipt(props: MatchReceiptProps): Promise<void> {
+  const blob = await pdf(<MatchReceiptDocument {...props} />).toBlob();
+  const url = URL.createObjectURL(blob);
+
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.download = `match-receipt-${props.matchId}.pdf`;
+  anchor.click();
+
+  // Release the object URL after a short delay to let the download start.
+  setTimeout(() => URL.revokeObjectURL(url), 5_000);
+}

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -11,6 +11,7 @@ usage() {
     echo "Options:"
     echo "  --skip-build  Skip contract compilation"
     echo "  --upgrade     Upgrade existing contracts (requires CONTRACT_ESCROW/CONTRACT_ORACLE)"
+    echo "  --canary      Canary deployment: deploy contract, run smoke tests, then proceed or abort"
     echo ""
     echo "Required env vars:"
     echo "  DEPLOYER_KEYPAIR   Stellar keypair name (default: deployer)"
@@ -29,10 +30,12 @@ NETWORK="${1:-}"
 
 SKIP_BUILD=false
 UPGRADE=false
+CANARY=false
 for arg in "${@:2}"; do
     case "$arg" in
         --skip-build) SKIP_BUILD=true ;;
         --upgrade)    UPGRADE=true ;;
+        --canary)     CANARY=true ;;
         *) echo "Unknown option: $arg"; usage ;;
     esac
 done
@@ -174,6 +177,31 @@ else
         --deployer "$DEPLOYER_ADDRESS"
 fi
 
+# ── Canary smoke tests ─────────────────────────────────────────────────────────
+if [[ "$CANARY" == true ]]; then
+    echo ""
+    echo "🐤 Canary mode: running smoke tests before proceeding..."
+    SMOKE_TEST_SCRIPT="scripts/smoke_test.sh"
+    if [[ ! -f "$SMOKE_TEST_SCRIPT" ]]; then
+        echo "❌ Smoke test script not found: $SMOKE_TEST_SCRIPT"; exit 1
+    fi
+
+    export CONTRACT_ESCROW="$ESCROW_CONTRACT_ID"
+    export CONTRACT_ORACLE="$ORACLE_CONTRACT_ID"
+
+    if bash "$SMOKE_TEST_SCRIPT" "$NETWORK"; then
+        echo "   ✅ Canary smoke tests passed — proceeding with full deployment"
+    else
+        echo ""
+        echo "❌ Canary smoke tests FAILED."
+        echo "   Contracts were deployed but smoke tests did not pass."
+        echo "   Oracle:  $ORACLE_CONTRACT_ID"
+        echo "   Escrow:  $ESCROW_CONTRACT_ID"
+        echo "   Fix the issue and re-run, or roll back by not pointing traffic at these contract IDs."
+        exit 1
+    fi
+fi
+
 # ── Post-deployment verification ───────────────────────────────────────────────
 echo ""
 echo "🔍 Verifying deployment..."
@@ -190,7 +218,7 @@ Checkmate-Escrow Deployment Report
 ===================================
 Timestamp:        $TIMESTAMP
 Network:          $NETWORK
-Mode:             $([ "$UPGRADE" == true ] && echo "upgrade" || echo "fresh")
+Mode:             $([ "$UPGRADE" == true ] && echo "upgrade" || echo "fresh")$([ "$CANARY" == true ] && echo " (canary-validated)" || echo "")
 Deployer address: $DEPLOYER_ADDRESS
 
 Contract Addresses

--- a/services/event-indexer/src/api.rs
+++ b/services/event-indexer/src/api.rs
@@ -155,6 +155,9 @@ pub struct EventQuery {
 pub struct MatchQuery {
     #[serde(default, deserialize_with = "empty_status_as_none")]
     pub status: Option<MatchStatus>,
+    /// Filter by Lichess or Chess.com game ID.  When set, only matches
+    /// associated with this `game_id` are returned (status filter is ignored).
+    pub game_id: Option<String>,
 }
 
 #[derive(Deserialize)]
@@ -528,16 +531,52 @@ async fn get_match_events(
     }
 }
 
-/// `GET /matches` – list matches, optionally filtered by status.
+/// `GET /matches` – list matches, optionally filtered by status or game_id.
 ///
-/// Cached for 10 seconds (`get_pending_matches` is the hot caller). Building the
-/// list fans out one `build_match_info` query per match, so this is the most
-/// expensive read the service serves and the one that benefits most from
-/// memoisation.
+/// - `?game_id=<id>` — returns the match(es) tied to the given Lichess or
+///   Chess.com game ID.  The `status` filter is ignored when `game_id` is set.
+/// - `?status=<status>` — returns all matches with the given status.
+/// - No params — returns all matches.
+///
+/// The match list is cached for 10 seconds when filtered by status.
+/// `game_id` lookups bypass the cache because they are precise and uncommon.
 async fn get_matches(
     State(state): State<AppState>,
     TypedQuery(query): TypedQuery<MatchQuery>,
 ) -> (StatusCode, Json<ApiResponse<Vec<MatchInfo>>>) {
+    // ── game_id path ──────────────────────────────────────────────────────
+    if let Some(ref gid) = query.game_id {
+        if gid.is_empty() {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(ApiResponse {
+                    success: false,
+                    data: None,
+                    error: Some("game_id must not be empty".to_string()),
+                }),
+            );
+        }
+        return match state.db.get_matches_by_game_id(gid).await {
+            Ok(matches) => (
+                StatusCode::OK,
+                Json(ApiResponse {
+                    success: true,
+                    data: Some(matches),
+                    error: None,
+                }),
+            ),
+            Err(e) => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ApiResponse {
+                    success: false,
+                    data: None,
+                    error: Some(format!("Database error: {}", e)),
+                }),
+            ),
+        };
+    }
+
+    // ── status path (existing behaviour, cached) ──────────────────────────
     let status = query.status;
     let cache_key = api_cache::matches_key(status.as_ref());
 

--- a/services/event-indexer/src/db.rs
+++ b/services/event-indexer/src/db.rs
@@ -112,6 +112,7 @@ impl Database {
             CREATE INDEX IF NOT EXISTS idx_events_timestamp     ON events(timestamp);
             CREATE INDEX IF NOT EXISTS idx_events_ledger        ON events(ledger_sequence);
             CREATE INDEX IF NOT EXISTS idx_events_status        ON events(status);
+            CREATE INDEX IF NOT EXISTS idx_events_game_id       ON events(game_id);
             CREATE INDEX IF NOT EXISTS idx_events_not_invalidated
                 ON events(ledger_sequence DESC)
                 WHERE reorg_invalidated_at IS NULL;
@@ -459,6 +460,41 @@ impl Database {
                 .map(|r| r.get::<_, i64>(0))
                 .collect()
         };
+
+        let mut matches = Vec::new();
+        for id in match_ids {
+            if let Some(info) = self.build_match_info(id as u64).await? {
+                matches.push(info);
+            }
+        }
+        Ok(matches)
+    }
+
+    /// Get matches associated with a specific `game_id`.
+    ///
+    /// A `game_id` uniquely identifies a Lichess or Chess.com game.  The index
+    /// `idx_events_game_id` makes this lookup efficient even on large tables.
+    /// In practice there should be at most one match per `game_id`, but the
+    /// method returns a `Vec` to be safe and future-proof.
+    pub async fn get_matches_by_game_id(&self, game_id: &str) -> Result<Vec<MatchInfo>> {
+        let conn = self
+            .read_pool
+            .get()
+            .await
+            .map_err(|e| anyhow!("Read pool error: {}", e))?;
+
+        let match_ids: Vec<i64> = conn
+            .query(
+                "SELECT DISTINCT match_id FROM events \
+                 WHERE game_id = $1 \
+                 ORDER BY match_id ASC",
+                &[&game_id],
+            )
+            .await
+            .map_err(|e| anyhow!("get_matches_by_game_id failed: {}", e))?
+            .iter()
+            .map(|r| r.get::<_, i64>(0))
+            .collect();
 
         let mut matches = Vec::new();
         for id in match_ids {

--- a/services/event-indexer/tests/get_matches_by_game_id_tests.rs
+++ b/services/event-indexer/tests/get_matches_by_game_id_tests.rs
@@ -1,0 +1,230 @@
+//! Tests for the `GET /matches?game_id=` endpoint filter (#1431).
+//!
+//! These tests verify:
+//! - Querying by game_id returns the correct match when it exists.
+//! - Querying by an unknown game_id returns an empty list (not a 404).
+//! - An empty game_id value returns a 400 Bad Request.
+//! - The response always has the correct `ApiResponse` envelope shape.
+//!
+//! Tests that require a live PostgreSQL instance are gated behind
+//! `DATABASE_URL` and skip gracefully when the env var is absent.
+
+use axum::body::to_bytes;
+use axum::http::{Request, StatusCode};
+use chrono::Utc;
+use event_indexer::{
+    api::{build_router, ApiResponse},
+    api_cache::ApiCache,
+    cache::EventCache,
+    db::Database,
+    models::{IndexedEvent, MatchInfo},
+    rpc::SorobanRpcClient,
+};
+use std::sync::Arc;
+use tokio::sync::RwLock;
+use tower::ServiceExt;
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+fn no_cache() -> Arc<ApiCache> {
+    Arc::new(ApiCache::disabled())
+}
+
+const UNREACHABLE_DSN: &str = "postgres://nobody:nobody@127.0.0.1:1/nowhere";
+
+fn unreachable_app() -> axum::Router {
+    let db = Arc::new(
+        Database::from_dsns(UNREACHABLE_DSN, UNREACHABLE_DSN, 1, 1)
+            .expect("DSN must parse without connecting"),
+    );
+    let cache = Arc::new(RwLock::new(EventCache::new(16)));
+    let rpc = Arc::new(SorobanRpcClient::new("http://127.0.0.1:1").unwrap());
+    build_router(db, cache, rpc, no_cache(), None)
+}
+
+fn make_event(game_id: &str, match_id: u64) -> IndexedEvent {
+    IndexedEvent {
+        id: format!("evt-{}-{}", match_id, game_id),
+        ledger_sequence: 100,
+        match_id,
+        event_type: "match:created".to_string(),
+        player1: Some("GAAA".to_string()),
+        player2: Some("GBBB".to_string()),
+        status: Some("pending".to_string()),
+        winner: None,
+        stake_amount: Some("1000".to_string()),
+        token: Some("XLM".to_string()),
+        game_id: Some(game_id.to_string()),
+        platform: Some("lichess".to_string()),
+        timestamp: Utc::now(),
+        txn_hash: Some("txhash-abc".to_string()),
+        event_index_in_txn: None,
+        reorg_invalidated_at: None,
+    }
+}
+
+// ── structural / routing tests (no DB needed) ─────────────────────────────────
+
+/// `GET /matches?game_id=` with an empty value returns 400 (not 500).
+#[tokio::test]
+async fn get_matches_empty_game_id_returns_400() {
+    let response = unreachable_app()
+        .oneshot(
+            Request::builder()
+                .uri("/matches?game_id=")
+                .body(axum::body::Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        response.status(),
+        StatusCode::BAD_REQUEST,
+        "Empty game_id must be rejected with 400"
+    );
+
+    let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let resp: ApiResponse<Vec<MatchInfo>> =
+        serde_json::from_slice(&body).expect("body must be valid ApiResponse JSON");
+    assert!(!resp.success);
+    assert!(resp.error.is_some());
+}
+
+/// `GET /matches?game_id=<value>` routes correctly (status ≠ 404 means the
+/// endpoint accepted the parameter even though the DB is unreachable).
+#[tokio::test]
+async fn get_matches_game_id_param_is_accepted_by_router() {
+    let response = unreachable_app()
+        .oneshot(
+            Request::builder()
+                .uri("/matches?game_id=lichess-abc123")
+                .body(axum::body::Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    // With an unreachable DB we expect 500, but definitely not 400 (bad param)
+    // or 404 (unknown route).
+    assert_ne!(
+        response.status(),
+        StatusCode::BAD_REQUEST,
+        "game_id param must be accepted by the router without a 400"
+    );
+    assert_ne!(
+        response.status(),
+        StatusCode::NOT_FOUND,
+        "route /matches must exist when game_id is provided"
+    );
+}
+
+// ── integration tests (require DATABASE_URL) ──────────────────────────────────
+
+/// Create a match event with a known `game_id`, then query `/matches?game_id=`
+/// and verify the match is returned.
+#[tokio::test]
+async fn get_matches_by_game_id_returns_match() {
+    let db_url = match std::env::var("DATABASE_URL") {
+        Ok(v) => v,
+        Err(_) => {
+            println!("Skipping get_matches_by_game_id_returns_match: DATABASE_URL not set");
+            return;
+        }
+    };
+
+    let db = Arc::new(
+        Database::from_dsns(&db_url, &db_url, 2, 2).expect("failed to create db"),
+    );
+    db.init_schema().await.expect("failed to init schema");
+
+    // Use a unique game_id to avoid interference from other tests.
+    let unique_game_id = format!("test-game-{}", Utc::now().timestamp_nanos_opt().unwrap_or(0));
+    let match_id: u64 = 88_001;
+
+    let event = make_event(&unique_game_id, match_id);
+    db.insert_event(&event).await.expect("insert_event failed");
+
+    let cache = Arc::new(RwLock::new(EventCache::new(16)));
+    let rpc = Arc::new(SorobanRpcClient::new("http://127.0.0.1:1").unwrap());
+    let app = build_router(
+        db,
+        cache,
+        rpc,
+        Arc::new(ApiCache::in_memory()),
+        None,
+    );
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri(format!("/matches?game_id={}", unique_game_id))
+                .body(axum::body::Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let resp: ApiResponse<Vec<MatchInfo>> =
+        serde_json::from_slice(&body).expect("body must be valid ApiResponse JSON");
+
+    assert!(resp.success, "success must be true");
+    let matches = resp.data.expect("data must be present");
+    assert!(
+        matches.iter().any(|m| m.match_id == match_id),
+        "expected match_id {} in response, got: {:?}",
+        match_id,
+        matches.iter().map(|m| m.match_id).collect::<Vec<_>>()
+    );
+}
+
+/// Querying a `game_id` that has no associated events returns an empty list
+/// (not a 404 or an error).
+#[tokio::test]
+async fn get_matches_by_unknown_game_id_returns_empty_list() {
+    let db_url = match std::env::var("DATABASE_URL") {
+        Ok(v) => v,
+        Err(_) => {
+            println!(
+                "Skipping get_matches_by_unknown_game_id_returns_empty_list: DATABASE_URL not set"
+            );
+            return;
+        }
+    };
+
+    let db = Arc::new(
+        Database::from_dsns(&db_url, &db_url, 2, 2).expect("failed to create db"),
+    );
+    db.init_schema().await.expect("failed to init schema");
+
+    let cache = Arc::new(RwLock::new(EventCache::new(16)));
+    let rpc = Arc::new(SorobanRpcClient::new("http://127.0.0.1:1").unwrap());
+    let app = build_router(db, cache, rpc, Arc::new(ApiCache::in_memory()), None);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/matches?game_id=no-such-game-id-xyz-99999")
+                .body(axum::body::Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let resp: ApiResponse<Vec<MatchInfo>> =
+        serde_json::from_slice(&body).expect("body must be valid ApiResponse JSON");
+
+    assert!(resp.success, "success must be true even for an empty result");
+    let matches = resp.data.expect("data field must be present");
+    assert!(
+        matches.is_empty(),
+        "unknown game_id must return an empty list, got {} match(es)",
+        matches.len()
+    );
+}


### PR DESCRIPTION
## Summary

Resolves four wave-ready issues in a single PR.

---

### #1429 — CI: add docs link-check with path filter

- Updated the `check-links` job in `.github/workflows/ci.yml` to detect whether any `docs/` file changed before running `scripts/check_links.sh`. On `push` to main/master it always runs; on pull requests it skips if no docs files were touched.
- Added a standalone `.github/workflows/check-links.yml` workflow with a `paths:` trigger (`docs/**`, `README.md`, `demo/**/*.md`) as the canonical docs-only filter.

---

### #1430 — Deployment: canary flag for deploy.sh

- Added `--canary` flag to `scripts/deploy.sh`.
- In canary mode: deploys contracts, runs `scripts/smoke_test.sh` against them, and **aborts** (non-zero exit) if tests fail — contract addresses are printed so operators can investigate or roll back.
- Deployment report updated to tag canary-validated runs.
- New `## Canary Deployment` section in `docs/deployment.md` covering usage, smoke-test scope, when to use it, and environment variables.

---

### #1431 — Event-indexer: GET /matches?game_id= filter

- Added `game_id: Option<String>` field to `MatchQuery` struct.
- Updated `get_matches` handler: when `game_id` is present it calls the new `db.get_matches_by_game_id()` method (bypassing the status cache); empty `game_id` returns 400.
- Added `get_matches_by_game_id` DB method querying the read pool.
- Added `CREATE INDEX IF NOT EXISTS idx_events_game_id ON events(game_id)` to `init_schema`.
- New test file `services/event-indexer/tests/get_matches_by_game_id_tests.rs`:
  - Structural tests (no DB needed): empty `game_id` → 400, valid param accepted by router.
  - Integration tests (gated on `DATABASE_URL`): create match, query by game_id, verify returned; unknown game_id returns empty list.

---

### #1432 — Frontend: PDF export for match payout receipts

- Added `@react-pdf/renderer@^4.3.0` dependency.
- New `MatchReceiptPDF.tsx`: `MatchReceiptDocument` component (match ID, date, players, stake, payout, tx hash) + `downloadMatchReceipt()` async helper (lazy-loaded via dynamic `import()` to keep initial bundle small).
- `MatchDetail` extended with optional `receipt` prop; shows a **Download Receipt** button on completed matches.
- `MatchReceiptPDF.test.tsx`: 6 tests all passing — button visibility for completed/non-completed/no-receipt, click handler invocation, loading state, and document content (match_id + payout amount).

## What was tested

- Frontend: `npm test` — 166/167 tests pass. The 1 pre-existing failure (`CreateMatchForm` stale snapshot) and 1 pre-existing suite failure (`AdminPanel` albedo UMD issue) are unrelated to this PR.
- Rust: Cargo not available in this environment; code reviewed for correctness against existing patterns in the file.

## Closes

Closes #1429,
Closes #1430, 
Closes #1431, 
Closes #1432