### PR TITLE
feat: resolve #1433, #1434, #1385, #1363 — monitoring, ratings, glossary, poller fix

### DIFF
--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -46,8 +46,8 @@ use soroban_sdk::{
 use types::{
     BalanceAtTimestamp, BalanceSnapshot, DataKey, Dispute, DisputeBondTier, DisputeState, FeeTier,
     Match, MatchState, OracleRotationState, PendingAdminProposal, PendingOracleRotation, Platform,
-    PlatformStats, PlayerBalanceSnapshot, PlayerFreezeKey, PlayerTier, ProtocolConfig,
-    SnapshotReason, TempOracleRotation, Winner,
+    PlatformStats, PlayerBalanceSnapshot, PlayerFreezeKey, PlayerRating, PlayerRatingKey,
+    PlayerTier, ProtocolConfig, SnapshotReason, TempOracleRotation, Winner,
 };
 
 /// ~30 days at 5s/ledger. Used as the default TTL and expiration threshold.
@@ -6502,5 +6502,88 @@ impl EscrowContract {
             fee
         };
         Ok(fee)
+    }
+
+    // ── FIDE / Platform ELO Rating Registry (issue #1434) ────────────────────
+
+    /// Register or update the oracle-verified ELO rating for a player on a
+    /// given chess platform.
+    ///
+    /// Requires oracle authorization — ratings cannot be self-reported, which
+    /// is the property that makes them safe to use for ELO-based matchmaking
+    /// (v4.0 roadmap).
+    ///
+    /// # Arguments
+    ///
+    /// * `player`   — Stellar address of the player whose rating is being recorded.
+    /// * `platform` — [`Platform::Lichess`] or [`Platform::ChessDotCom`].
+    /// * `username` — Platform username (e.g. `"Magnus"` on Lichess).
+    /// * `rating`   — Verified ELO / platform rating as a `u32`.
+    ///
+    /// # Events
+    ///
+    /// Emits `("rating", "registered")` with payload `(player, platform, rating)`.
+    pub fn register_player_rating(
+        env: Env,
+        caller: Address,
+        player: Address,
+        platform: Platform,
+        username: soroban_sdk::String,
+        rating: u32,
+    ) -> Result<(), Error> {
+        extend_instance_ttl(&env);
+
+        // Only the configured oracle may submit ratings.
+        let oracle: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Oracle)
+            .ok_or(Error::Unauthorized)?;
+        caller.require_auth();
+        if caller != oracle {
+            return Err(Error::Unauthorized);
+        }
+
+        let record = PlayerRating {
+            username,
+            rating,
+            recorded_ledger: env.ledger().sequence(),
+        };
+
+        let key = PlayerRatingKey::Rating(player.clone(), platform.clone());
+        env.storage().persistent().set(&key, &record);
+        env.storage().persistent().extend_ttl(
+            &key,
+            MATCH_TTL_LEDGERS,
+            MATCH_TTL_LEDGERS,
+        );
+
+        env.events().publish(
+            (Symbol::new(&env, "rating"), symbol_short!("registered")),
+            (player, platform, rating),
+        );
+
+        Ok(())
+    }
+
+    /// Return the oracle-verified rating for `player` on `platform`, or
+    /// `None` if no rating has been registered yet.
+    ///
+    /// This is a view function — no authentication required.
+    pub fn get_player_rating(
+        env: Env,
+        player: Address,
+        platform: Platform,
+    ) -> Option<PlayerRating> {
+        let key = PlayerRatingKey::Rating(player, platform);
+        let record: Option<PlayerRating> = env.storage().persistent().get(&key);
+        if record.is_some() {
+            env.storage().persistent().extend_ttl(
+                &key,
+                MATCH_TTL_LEDGERS,
+                MATCH_TTL_LEDGERS,
+            );
+        }
+        record
     }
 }

--- a/contracts/escrow/src/tests/mod.rs
+++ b/contracts/escrow/src/tests/mod.rs
@@ -207,3 +207,4 @@ mod issue_1342;
 mod issue_1343;
 mod issue_1344;
 mod issue_1345;
+mod player_rating;

--- a/contracts/escrow/src/tests/player_rating.rs
+++ b/contracts/escrow/src/tests/player_rating.rs
@@ -1,0 +1,140 @@
+//! Tests for the oracle-verified player rating registry (issue #1434).
+//!
+//! `register_player_rating` requires oracle authorization and stores a
+//! `PlayerRating` record in persistent storage keyed by `(player, platform)`.
+//! `get_player_rating` is a view that returns `None` until a rating is
+//! registered and the correct value afterward.
+
+use super::*;
+use crate::types::{Platform, PlayerRating};
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+/// Convenience wrapper around `register_player_rating`.
+fn register(
+    client: &EscrowContractClient,
+    env: &Env,
+    oracle: &Address,
+    player: &Address,
+    platform: Platform,
+    username: &str,
+    rating: u32,
+) -> Result<(), crate::errors::Error> {
+    client.try_register_player_rating(
+        oracle,
+        player,
+        &platform,
+        &soroban_sdk::String::from_str(env, username),
+        &rating,
+    )
+    .map_err(|e| e.unwrap())
+}
+
+// ── registration tests ────────────────────────────────────────────────────────
+
+#[test]
+fn register_and_retrieve_lichess_rating() {
+    let (env, contract_id, oracle, player1, _player2, _token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    register(&client, &env, &oracle, &player1, Platform::Lichess, "Magnus", 2850).unwrap();
+
+    let record: PlayerRating = client.get_player_rating(&player1, &Platform::Lichess).unwrap();
+    assert_eq!(record.username, soroban_sdk::String::from_str(&env, "Magnus"));
+    assert_eq!(record.rating, 2850);
+}
+
+#[test]
+fn register_and_retrieve_chess_com_rating() {
+    let (env, contract_id, oracle, player1, _player2, _token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    register(&client, &env, &oracle, &player1, Platform::ChessDotCom, "Hikaru", 3200).unwrap();
+
+    let record: PlayerRating = client.get_player_rating(&player1, &Platform::ChessDotCom).unwrap();
+    assert_eq!(record.username, soroban_sdk::String::from_str(&env, "Hikaru"));
+    assert_eq!(record.rating, 3200);
+}
+
+#[test]
+fn ratings_are_keyed_per_platform() {
+    // The same player can have independent ratings for Lichess and Chess.com.
+    let (env, contract_id, oracle, player1, _player2, _token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    register(&client, &env, &oracle, &player1, Platform::Lichess, "PlayerX", 1800).unwrap();
+    register(&client, &env, &oracle, &player1, Platform::ChessDotCom, "PlayerX_com", 1750).unwrap();
+
+    let lichess = client.get_player_rating(&player1, &Platform::Lichess).unwrap();
+    let chess_com = client.get_player_rating(&player1, &Platform::ChessDotCom).unwrap();
+
+    assert_eq!(lichess.rating, 1800);
+    assert_eq!(chess_com.rating, 1750);
+}
+
+#[test]
+fn oracle_can_update_existing_rating() {
+    let (env, contract_id, oracle, player1, _player2, _token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    register(&client, &env, &oracle, &player1, Platform::Lichess, "Magnus", 2800).unwrap();
+    // Oracle updates the rating after a new verified game.
+    register(&client, &env, &oracle, &player1, Platform::Lichess, "Magnus", 2855).unwrap();
+
+    let record = client.get_player_rating(&player1, &Platform::Lichess).unwrap();
+    assert_eq!(record.rating, 2855);
+}
+
+#[test]
+fn get_player_rating_returns_none_when_not_registered() {
+    let (env, contract_id, _oracle, player1, _player2, _token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let result = client.get_player_rating(&player1, &Platform::Lichess);
+    assert!(result.is_none(), "expected None for unregistered player");
+}
+
+// ── authorization tests ───────────────────────────────────────────────────────
+
+#[test]
+fn non_oracle_cannot_register_rating() {
+    let (env, contract_id, _oracle, player1, player2, _token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    // player2 pretends to be the oracle — must be rejected.
+    let result = client.try_register_player_rating(
+        &player2,
+        &player1,
+        &Platform::Lichess,
+        &soroban_sdk::String::from_str(&env, "Magnus"),
+        &2850u32,
+    );
+    assert!(result.is_err(), "non-oracle must not be able to register a rating");
+}
+
+#[test]
+fn admin_cannot_register_rating() {
+    let (env, contract_id, _oracle, player1, _player2, _token, admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let result = client.try_register_player_rating(
+        &admin,
+        &player1,
+        &Platform::Lichess,
+        &soroban_sdk::String::from_str(&env, "Magnus"),
+        &2850u32,
+    );
+    assert!(result.is_err(), "admin must not be able to register a rating (oracle only)");
+}
+
+#[test]
+fn rating_records_current_ledger() {
+    let (env, contract_id, oracle, player1, _player2, _token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let before = env.ledger().sequence();
+    register(&client, &env, &oracle, &player1, Platform::Lichess, "Magnus", 2850).unwrap();
+
+    let record = client.get_player_rating(&player1, &Platform::Lichess).unwrap();
+    assert!(record.recorded_ledger >= before, "recorded_ledger must be >= ledger at call time");
+}

--- a/contracts/escrow/src/types.rs
+++ b/contracts/escrow/src/types.rs
@@ -352,6 +352,35 @@ pub enum PlayerFreezeKey {
     FrozenPlayers,
 }
 
+/// Storage keys for oracle-verified FIDE / platform ELO ratings registered
+/// via `register_player_rating`.
+///
+/// Kept as a separate `#[contracttype]` enum rather than added to `DataKey`
+/// for the same reason as [`PlayerFreezeKey`]: `DataKey` is at its 50-variant
+/// XDR cap.
+#[contracttype]
+pub enum PlayerRatingKey {
+    /// Rating record keyed by (player address, platform).
+    /// Value: [`PlayerRating`].
+    Rating(Address, Platform),
+}
+
+/// An oracle-verified ELO / platform rating for a player.
+///
+/// Registered on-chain by the oracle via `register_player_rating` so that
+/// ELO-based matchmaking (v4.0 roadmap) can read it without trusting
+/// self-reported values.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PlayerRating {
+    /// The player's username on the given platform (e.g. `"Magnus"` on Lichess).
+    pub username: String,
+    /// The player's ELO / platform rating at the time of oracle verification.
+    pub rating: u32,
+    /// Ledger sequence number when this rating was last recorded by the oracle.
+    pub recorded_ledger: u32,
+}
+
 /// The lifecycle event that triggered a balance snapshot.
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -32,13 +32,19 @@ The act of a player transferring their `stake_amount` into the escrow contract (
 
 A match outcome (the `Draw` variant of the `Winner` enum) where neither player wins. Instead of paying the whole [pot](#pot) to one player, each player's [stake](#stake) is returned to them, and the match moves to [Completed](#completed).
 
-## Epoch
+## DisputeBond
+
+A collateral amount that a player must deposit when opening a dispute against a [PendingResult](#pendingresult). The bond is expressed as basis points of the match [stake](#stake) (default: 100 bp = 1 %). It is held in escrow while the dispute is under review and either refunded to the disputer (if the dispute is overturned, i.e. the oracle's result is overruled) or forfeited to the treasury (if the dispute is upheld, i.e. the oracle's result is confirmed). The bond mechanism deters frivolous disputes without blocking legitimate challenges. The global default is set via `DisputeBondBasisPoints` in contract storage; per-tier overrides are configured via `ProtocolConfig::dispute_bond_tier_schedule`. See `DisputeBondTier` in `contracts/escrow/src/types.rs` and `contracts/escrow/src/tests/dispute.rs`.
 
 A general blockchain term for a defined period or checkpoint used to group activity or coordinate state changes. Stellar itself does not expose a Checkmate-specific "epoch"; the network measures the passage of time in [ledgers](#ledger), and Checkmate-Escrow's time-based rules (such as match expiry and storage TTL) are expressed in ledger sequence numbers rather than epochs.
 
 ## Escrow
 
 The Soroban smart contract (and the funds it custodies) that holds both players' [stakes](#stake) from [deposit](#deposit) until the match reaches a terminal state. The escrow enforces the rules for creating matches, depositing, cancelling, expiring, and paying out, so that no party can withhold or redirect funds. This is the core contract of the project (`contracts/escrow`).
+
+## FeeTier
+
+A single entry in the admin-configured dynamic fee schedule. Each `FeeTier` specifies a `max_stake` (the upper bound of match stake this tier applies to) and `fee_basis_points` (the protocol fee charged as a fraction of the pot, where 100 basis points = 1 %). Tiers are stored in ascending `max_stake` order; the last tier acts as the open-ended catch-all for stakes that exceed all explicit thresholds. When no tier schedule is configured, the flat `protocol_fee_bps` from `ProtocolConfig` applies instead. Set the schedule via `set_fee_tiers`; inspect it via `get_protocol_config`. See the `FeeTier` struct in `contracts/escrow/src/types.rs` and `contracts/escrow/src/tests/fee_tiers.rs`.
 
 ## Freighter
 
@@ -76,11 +82,17 @@ The settlement transfer that happens when a match completes: the full [pot](#pot
 
 The initial [match](#match) state after `create_match`, while the contract awaits [deposits](#deposit). Zero, one, or both deposits may be present; the match stays Pending until both arrive (then [Active](#active)) or it is [Cancelled](#cancelled) via `cancel_match` or `expire_match`.
 
+## PendingResult
+
+A [match](#match) state introduced in v0.1.0 that sits between the oracle's result submission and the final [payout](#payout). When `submit_result` is called and the oracle's confidence in the result is below `DEFAULT_CONFIDENCE_THRESHOLD` (50 out of 100), the match transitions to `PendingResult` rather than immediately to [Completed](#completed). This opens a dispute window (`DisputePeriod` ledgers) during which a player may call `dispute_and_rollback_match` to contest the outcome. Once the dispute window elapses without a dispute (or a dispute is resolved), the match is finalized and payout executes. See `MatchState::PendingResult` in `contracts/escrow/src/types.rs` and the dispute flow in `contracts/escrow/src/tests/dispute.rs`.
+
 ## Pot
 
 The total amount held in escrow for an [Active](#active) match: `2 × stake`, i.e. both players' [stakes](#stake) combined. On a decisive result the entire pot is paid to the winner; on a [draw](#draw) it is split back to each player as their original stake.
 
-## Soroban
+## PlayerTier
+
+A progression tier assigned to a player based on their number of completed matches. There are four tiers — `Bronze`, `Silver`, `Gold`, and `Platinum` — each of which unlocks a higher allowed [stake](#stake) range. A new player starts at `Bronze` (1–100 token units) and advances to `Silver` after 3 completed matches, `Gold` after 6, and `Platinum` after 10, with `Platinum` having no upper stake bound. The tier system prevents new accounts from immediately wagering large amounts, reducing economic risk while the player's track record is established. Tier enforcement is applied in `create_match` and the tier thresholds are defined as constants in `contracts/escrow/src/lib.rs`. See `PlayerTier` in `contracts/escrow/src/types.rs` and `contracts/escrow/src/tests/tier.rs`.
 
 Stellar's smart contract platform. Contracts are written in Rust, compiled to WebAssembly (WASM), and deployed to the Stellar network. Checkmate-Escrow's escrow and oracle contracts are Soroban contracts (see `contracts/`).
 

--- a/docs/monitoring-setup.md
+++ b/docs/monitoring-setup.md
@@ -85,6 +85,15 @@ Example `operation` label values: `create_match`, `deposit`, `submit_result`, `c
 | `checkmate_oracle_api_duration_seconds` | Histogram | Latency of Lichess/Chess.com API calls |
 | `checkmate_stellar_rpc_health` | Gauge | `1` if Stellar RPC is reachable, `0` otherwise |
 
+### Event Indexer
+
+| Metric | Type | Description |
+|--------|------|-------------|
+| `indexer_matches_total` | Counter | Total contract events indexed since process start |
+| `indexer_rpc_lag_seconds` | Gauge | Estimated seconds between latest network ledger and last polled ledger |
+| `indexer_rpc_lag_ledgers` | Gauge | Ledger count between latest network ledger and last polled ledger; drives `IndexerLaggingAlert` when > 100 |
+| `indexer_cache_hit_ratio` | Gauge | API response cache hit rate (0.0–1.0) |
+
 ### Exporting Metrics from Contract Events
 
 The event indexer watches Soroban contract events and increments the counters above whenever it ingests an event. The mapping is:
@@ -229,6 +238,25 @@ All alerts are defined in [`monitoring/prometheus/alerts.yml`](../monitoring/pro
 | `OracleSubmissionErrorSpike` | Submission errors > 0.1/sec | Check oracle + Stellar RPC |
 | `LargeTVLDrop` | TVL drops > 50% in 5 min | Verify large batch of completions |
 | `StellarRPCDegraded` | RPC health != 1 for 3 min | Check RPC node; may delay payouts |
+| `IndexerLaggingAlert` | `indexer_rpc_lag_ledgers > 100` for 2 min | See [IndexerLaggingAlert](#indexerlaggingalert) |
+
+### IndexerLaggingAlert
+
+**Condition:** `indexer_rpc_lag_ledgers > 100` sustained for 2 minutes.
+
+**What it means:** The event-indexer is more than ~100 ledgers (≈ 8 minutes at 5 s/ledger) behind the chain tip. Players may see stale match states in the UI — a match that has been completed on-chain may still appear as `Active` until the indexer catches up.
+
+**Response steps:**
+
+1. Check the indexer process is running: `docker compose ps event-indexer` (or your orchestrator equivalent).
+2. Tail the indexer logs for errors: `docker compose logs --tail=100 event-indexer`.
+3. Verify the Soroban RPC endpoint is reachable from the indexer container:
+   ```bash
+   curl -s -o /dev/null -w "%{http_code}" $STELLAR_RPC_URL/health
+   ```
+4. Check disk I/O — a heavily loaded database can slow indexer throughput enough to cause lag.
+5. If the indexer recently restarted it will normally catch up automatically; monitor `indexer_rpc_lag_ledgers` in Grafana to confirm the value is decreasing.
+6. If lag persists or grows, consider scaling indexer replicas (see [event-indexer-scaling.md](event-indexer-scaling.md)).
 
 ### Connecting Alertmanager
 

--- a/monitoring/prometheus/alerts.yml
+++ b/monitoring/prometheus/alerts.yml
@@ -226,3 +226,28 @@ groups:
           description: >
             The oracle service reports Stellar RPC health is degraded.
             Result submissions and fund transfers may be delayed.
+
+  # ── Event-Indexer Health ──────────────────────────────────────────────────
+  - name: checkmate_event_indexer
+    interval: 30s
+    rules:
+
+      # Indexer has fallen more than 100 ledgers behind the chain tip.
+      # At ~5 s/ledger this means the UI could be showing match state that is
+      # over 8 minutes stale — players may see an incorrect Pending/Active
+      # status after a result has already been submitted on-chain.
+      - alert: IndexerLaggingAlert
+        expr: indexer_rpc_lag_ledgers > 100
+        for: 2m
+        labels:
+          severity: warning
+          component: event_indexer
+        annotations:
+          summary: "Event-indexer is lagging more than 100 ledgers behind chain tip"
+          description: >
+            The event-indexer instance is {{ printf "%.0f" $value }} ledgers
+            behind the latest network ledger (threshold: 100, ~8 minutes at
+            5 s/ledger). Players may see stale match state in the UI until the
+            indexer catches up. Check RPC connectivity, disk I/O, and whether
+            the indexer process is healthy.
+          runbook_url: "https://github.com/StellarCheckMate/Checkmate-Escrow/blob/main/docs/monitoring-setup.md#indexerlaggingalert"

--- a/oracle-service/src/poller.rs
+++ b/oracle-service/src/poller.rs
@@ -366,8 +366,27 @@ impl Poller {
                     .inner
                     .soroban
                     .has_result(&self.inner.contract_oracle, m.match_id, &self.inner.pubkey)
-                    .await?;
-                if has_result {
+                    .await;
+
+                // If the oracle contract or RPC returns an error (e.g. timeout,
+                // network partition), skip this match for the current cycle and
+                // log a warning.  Using `?` here would abort the whole
+                // reconciliation pass, which is worse — we'd lose all matches
+                // later in the page.  The match will be retried on the next
+                // reconciliation cycle.
+                let already_resolved = match has_result {
+                    Ok(b) => b,
+                    Err(e) => {
+                        warn!(
+                            match_id = m.match_id,
+                            "has_result RPC error during reconciliation (skipping match this cycle): {}",
+                            e
+                        );
+                        continue;
+                    }
+                };
+
+                if already_resolved {
                     continue;
                 }
 

--- a/oracle-service/tests/reconciliation_tests.rs
+++ b/oracle-service/tests/reconciliation_tests.rs
@@ -511,3 +511,129 @@ async fn cursor_cleared_after_complete_cycle() {
         "cursor file should be removed after a successful reconciliation cycle"
     );
 }
+
+/// When `has_result` returns an RPC error for one match, that match is skipped
+/// for the current reconciliation cycle rather than panicking or aborting the
+/// entire pass. Other matches on the same page are still processed normally.
+///
+/// Regression test for issue #1363: the old `?` propagation turned any RPC
+/// error into a full reconciliation abort; the fix logs a warning and
+/// `continue`s to the next match instead.
+#[tokio::test]
+async fn has_result_rpc_error_skips_match_and_continues_reconciliation() {
+    // ── Mock server that returns an RPC error for has_result on match 40
+    // but a valid (false) answer for match 41. ────────────────────────────
+    let rpc_server = MockServer::start().await;
+
+    let fixtures = vec![
+        FixtureMatch {
+            match_id: 40,
+            game_id: "zzzz0000", // will be skipped — has_result errors
+            platform: "Lichess",
+        },
+        FixtureMatch {
+            match_id: 41,
+            game_id: "abcd1234", // should be enqueued normally
+            platform: "Lichess",
+        },
+    ];
+
+    // We set up two separate mock patterns:
+    // 1. A mock that handles get_active_matches_paginated and has_result for
+    //    match 41 normally.
+    // 2. A second mock that returns a JSON-RPC error response for has_result
+    //    when the match_id arg is 40.
+    Mock::given(method("POST"))
+        .respond_with({
+            let active_xdr = active_matches_xdr(&fixtures);
+            move |req: &Request| {
+                let body: serde_json::Value =
+                    req.body_json().expect("valid JSON-RPC body");
+                let rpc_method = body["method"].as_str().unwrap_or("");
+                match rpc_method {
+                    "getAccount" => ResponseTemplate::new(200).set_body_json(
+                        serde_json::json!({
+                            "jsonrpc": "2.0", "id": 1,
+                            "result": { "sequence": "100" }
+                        }),
+                    ),
+                    "simulateTransaction" => {
+                        let tx_b64 = body["params"]["transaction"]
+                            .as_str()
+                            .expect("transaction field");
+                        let (function_name, args) = invoked_function(tx_b64);
+                        match function_name.as_str() {
+                            "get_active_matches_paginated" => {
+                                ResponseTemplate::new(200).set_body_json(
+                                    simulate_result_json(&active_xdr),
+                                )
+                            }
+                            "has_result" => {
+                                // Return an RPC error for match 40 only.
+                                let ScVal::U64(match_id) =
+                                    args.first().expect("match_id arg")
+                                else {
+                                    panic!("expected U64 match_id");
+                                };
+                                if *match_id == 40 {
+                                    // Simulate an RPC-level error (e.g. timeout
+                                    // or internal server error).
+                                    ResponseTemplate::new(500).set_body_json(
+                                        serde_json::json!({
+                                            "jsonrpc": "2.0", "id": 1,
+                                            "error": {
+                                                "code": -32000,
+                                                "message": "simulated RPC timeout"
+                                            }
+                                        }),
+                                    )
+                                } else {
+                                    // match 41 → not yet resolved
+                                    ResponseTemplate::new(200).set_body_json(
+                                        simulate_result_json(&bool_xdr(false)),
+                                    )
+                                }
+                            }
+                            other => {
+                                panic!("unexpected simulateTransaction target: {other}")
+                            }
+                        }
+                    }
+                    _ => ResponseTemplate::new(200).set_body_json(
+                        serde_json::json!({
+                            "jsonrpc": "2.0", "id": 1,
+                            "result": { "status": "SUCCESS" }
+                        }),
+                    ),
+                }
+            }
+        })
+        .mount(&rpc_server)
+        .await;
+
+    let dir = TempDir::new().unwrap();
+    let dir_str = dir.path().to_str().unwrap();
+    let cfg = make_config(&rpc_server.uri(), dir_str);
+    let queue = PendingQueue::new(dir_str);
+
+    let poller = Poller::new(&cfg).unwrap();
+
+    // reconcile() must succeed (not return an error) even though has_result
+    // for match 40 failed with an RPC error.
+    poller.reconcile().await.expect("reconcile must not propagate has_result RPC errors");
+
+    let entries = queue.load().await.unwrap();
+
+    // Match 41 — for which has_result returned false — should be queued.
+    assert!(
+        entries.iter().any(|e| e.match_id == 41),
+        "match 41 should be enqueued after reconciliation"
+    );
+    // Match 40 — for which has_result errored — should have been skipped; it
+    // must NOT be in the queue (we don't know its state, so we treat it
+    // conservatively: skip and retry on the next cycle).
+    assert!(
+        !entries.iter().any(|e| e.match_id == 40),
+        "match 40 should be skipped when has_result returns an RPC error"
+    );
+}

--- a/services/event-indexer/src/metrics.rs
+++ b/services/event-indexer/src/metrics.rs
@@ -2,11 +2,12 @@
 //!
 //! ## Exposed metrics
 //!
-//! | Metric name                  | Type    | Description                                                |
-//! |-------------------------------|---------|--------------------------------------------------------------|
-//! | `indexer_matches_total`      | Counter | Total number of contract events indexed since process start. |
-//! | `indexer_rpc_lag_seconds`    | Gauge   | Estimated seconds between the latest network ledger and the last ledger this instance has polled. |
-//! | `indexer_cache_hit_ratio`    | Gauge   | Hit rate (0.0-1.0) of the API response cache ([`crate::api_cache`]). |
+//! | Metric name                    | Type    | Description                                                |
+//! |--------------------------------|---------|--------------------------------------------------------------|
+//! | `indexer_matches_total`        | Counter | Total number of contract events indexed since process start. |
+//! | `indexer_rpc_lag_seconds`      | Gauge   | Estimated seconds between the latest network ledger and the last ledger this instance has polled. |
+//! | `indexer_rpc_lag_ledgers`      | Gauge   | Ledger count between the latest network ledger and the last ledger this instance has polled. Fires `IndexerLaggingAlert` when > 100. |
+//! | `indexer_cache_hit_ratio`      | Gauge   | Hit rate (0.0-1.0) of the API response cache ([`crate::api_cache`]). |
 //!
 //! All metrics are registered on the default Prometheus registry and served at
 //! `GET /metrics` in the text/plain exposition format understood by Prometheus
@@ -15,10 +16,12 @@
 //! ## Usage
 //!
 //! Call [`inc_matches_indexed`] once per event successfully written by the
-//! poller ([`crate::rpc::poll_events`]), [`set_rpc_lag_seconds`] once per poll
-//! iteration, and [`set_cache_hit_ratio`] whenever `/metrics` is scraped (it
-//! reads the live counters off [`crate::api_cache::ApiCache::stats`], so there
-//! is no need for a background updater).
+//! poller ([`crate::rpc::poll_events`]), [`set_rpc_lag_from_ledger_gap`] once
+//! per poll iteration (it updates both `indexer_rpc_lag_seconds` and
+//! `indexer_rpc_lag_ledgers`), and [`set_cache_hit_ratio`] whenever `/metrics`
+//! is scraped (it reads the live counters off
+//! [`crate::api_cache::ApiCache::stats`], so there is no need for a background
+//! updater).
 
 use once_cell::sync::Lazy;
 use prometheus::{register_gauge, register_int_counter, Gauge, IntCounter, TextEncoder};
@@ -45,6 +48,20 @@ pub static INDEXER_RPC_LAG_SECONDS: Lazy<Gauge> = Lazy::new(|| {
     .expect("failed to register indexer_rpc_lag_seconds gauge")
 });
 
+/// Gauge: raw ledger count between the latest network ledger and the last
+/// ledger this instance has finished polling.
+///
+/// Alerting rule `IndexerLaggingAlert` fires when this value exceeds 100,
+/// indicating that the indexer has fallen more than ~8 minutes behind the
+/// chain tip and the UI may be showing stale match state.
+pub static INDEXER_RPC_LAG_LEDGERS: Lazy<Gauge> = Lazy::new(|| {
+    register_gauge!(
+        "indexer_rpc_lag_ledgers",
+        "Ledger count between the latest network ledger and the last polled ledger"
+    )
+    .expect("failed to register indexer_rpc_lag_ledgers gauge")
+});
+
 /// Gauge: hit rate (0.0-1.0) of the shared API response cache.
 pub static INDEXER_CACHE_HIT_RATIO: Lazy<Gauge> = Lazy::new(|| {
     register_gauge!(
@@ -67,12 +84,14 @@ pub fn inc_matches_indexed() {
     INDEXER_MATCHES_TOTAL.inc();
 }
 
-/// Set [`INDEXER_RPC_LAG_SECONDS`] from the gap (in ledgers) between the
-/// latest network ledger and the last ledger this instance polled.
+/// Set [`INDEXER_RPC_LAG_SECONDS`] and [`INDEXER_RPC_LAG_LEDGERS`] from the
+/// gap (in ledgers) between the latest network ledger and the last ledger this
+/// instance polled.
 #[inline]
 pub fn set_rpc_lag_from_ledger_gap(latest_ledger: u32, last_polled_ledger: u32) {
     let ledger_gap = latest_ledger.saturating_sub(last_polled_ledger) as f64;
     INDEXER_RPC_LAG_SECONDS.set(ledger_gap * STELLAR_LEDGER_CLOSE_SECS);
+    INDEXER_RPC_LAG_LEDGERS.set(ledger_gap);
 }
 
 /// Set [`INDEXER_CACHE_HIT_RATIO`] directly (already computed as hits / total).
@@ -106,12 +125,14 @@ mod tests {
     fn rpc_lag_reflects_the_ledger_gap() {
         set_rpc_lag_from_ledger_gap(1000, 995);
         assert_eq!(INDEXER_RPC_LAG_SECONDS.get(), 5.0 * STELLAR_LEDGER_CLOSE_SECS);
+        assert_eq!(INDEXER_RPC_LAG_LEDGERS.get(), 5.0);
     }
 
     #[test]
     fn rpc_lag_is_zero_when_caught_up() {
         set_rpc_lag_from_ledger_gap(1000, 1000);
         assert_eq!(INDEXER_RPC_LAG_SECONDS.get(), 0.0);
+        assert_eq!(INDEXER_RPC_LAG_LEDGERS.get(), 0.0);
     }
 
     #[test]
@@ -120,6 +141,15 @@ mod tests {
         // must not produce a negative lag.
         set_rpc_lag_from_ledger_gap(500, 600);
         assert_eq!(INDEXER_RPC_LAG_SECONDS.get(), 0.0);
+        assert_eq!(INDEXER_RPC_LAG_LEDGERS.get(), 0.0);
+    }
+
+    #[test]
+    fn rpc_lag_ledgers_exceeds_alert_threshold() {
+        // Verify that a gap > 100 ledgers is faithfully reported (the
+        // Prometheus alert rule `IndexerLaggingAlert` fires at > 100).
+        set_rpc_lag_from_ledger_gap(1200, 1000);
+        assert!(INDEXER_RPC_LAG_LEDGERS.get() > 100.0);
     }
 
     #[test]
@@ -136,6 +166,7 @@ mod tests {
         let output = render();
         assert!(output.contains("indexer_matches_total"));
         assert!(output.contains("indexer_rpc_lag_seconds"));
+        assert!(output.contains("indexer_rpc_lag_ledgers"));
         assert!(output.contains("indexer_cache_hit_ratio"));
     }
 }


### PR DESCRIPTION
## Summary

Resolves four wave-ready issues in a single batch PR.

---

### #1433 — Monitoring: add alert rule for event-indexer falling behind chain by > 100 ledgers

**What changed:**
- Added `INDEXER_RPC_LAG_LEDGERS` Prometheus Gauge to `services/event-indexer/src/metrics.rs`. `set_rpc_lag_from_ledger_gap` now sets both the existing `indexer_rpc_lag_seconds` and the new `indexer_rpc_lag_ledgers` gauge in one call.
- Added `IndexerLaggingAlert` rule to `monitoring/prometheus/alerts.yml` — fires as `severity: warning` when `indexer_rpc_lag_ledgers > 100` is sustained for 2 minutes.
- Documented the new metric in the Metrics Exported table and added an `IndexerLaggingAlert` runbook section to `docs/monitoring-setup.md`.

---

### #1434 — Enhancement: oracle-verified FIDE / platform player rating registry

**What changed:**
- Added `PlayerRatingKey` enum and `PlayerRating` struct to `contracts/escrow/src/types.rs` (separate key enum to stay within the 50-variant XDR cap on `DataKey`).
- Added `register_player_rating(caller, player, platform, username, rating)` (oracle-auth only) and `get_player_rating(player, platform) -> Option<PlayerRating>` (view) to `contracts/escrow/src/lib.rs`.
- Added `contracts/escrow/src/tests/player_rating.rs` with 8 tests covering registration, retrieval, per-platform keying, oracle update, auth rejection (non-oracle and admin), and `recorded_ledger` tracking.

---

### #1385 — Docs: glossary entries for PendingResult, FeeTier, DisputeBond, PlayerTier

**What changed:**
- Added four entries to `docs/glossary.md` in alphabetical order, each 2–3 sentences with cross-references to the relevant source files and related docs:
  - **DisputeBond** — collateral required to open a dispute; refunded on overturn, forfeited on uphold
  - **FeeTier** — single entry in the dynamic fee schedule
  - **PendingResult** — intermediate match state between oracle submission and payout
  - **PlayerTier** — Bronze/Silver/Gold/Platinum stake-band progression

---

### #1363 — Fix: oracle poller does not handle has_result returning an error gracefully

**What changed:**
- Replaced bare `?` on the `has_result` call in `Poller::reconcile` (`oracle-service/src/poller.rs`) with a `match` that `warn!`-logs the error and `continue`s to the next match. This prevents a single transient RPC error from aborting the entire reconciliation pass.
- Added `has_result_rpc_error_skips_match_and_continues_reconciliation` to `oracle-service/tests/reconciliation_tests.rs`: a wiremock returns HTTP 500 for `has_result` on match 40 and a valid `false` for match 41; the test asserts `reconcile()` returns `Ok`, match 41 is enqueued, and match 40 is skipped.

---

## Testing

- `services/event-indexer/src/metrics.rs`: updated existing tests to cover `indexer_rpc_lag_ledgers`, added `rpc_lag_ledgers_exceeds_alert_threshold` test.
- `contracts/escrow/src/tests/player_rating.rs`: 8 new tests.
- `oracle-service/tests/reconciliation_tests.rs`: 1 new test.

## Checklist

- [x] Code changes match the issue descriptions
- [x] New Prometheus metric exposed on `/metrics`
- [x] Alert rule syntax follows existing `alerts.yml` conventions
- [x] Contract storage uses a separate key enum (XDR cap respected)
- [x] Oracle authorization enforced for `register_player_rating`
- [x] Poller reconcile no longer propagates RPC errors from `has_result`
- [x] All new code has associated tests
- [x] Docs updated (monitoring-setup.md, glossary.md)

closes #1433 
closes #1434 
closes #1385 
closes #1363 